### PR TITLE
Extend providers to support custom headers

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,11 @@
                     methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof eth_getBalanceValues
                     providers {
                         https://lb.nodies.app:443/v1/key
+                        https://blast.laconic.com:443/v1/eth/ {
+                            headers {
+                                x-api-key key
+                            }
+                        }
                     }
                 }
                 blast-testnet {


### PR DESCRIPTION
We have a provider that requires custom headers for authentication rather than path details, so I've extended the plugin to support parsing that out of the Caddyfile and providing the headers in the outgoing request after the provider is selected.

This also sets a framework for additional provider-specific details. When we need to have provider weights, providers that only implement specific methods, etc. this will be a good place to put it.