### PR TITLE
Add single default signer instead of provider-specific signers

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -24,6 +24,9 @@
 	route /* {
 		# middleware declaration
 		din {
+			siwe-signer {
+				secret_file /run/secrets/din-secret-key
+			}
 			# middleware configurtion data, read by DinMiddleware.UnmarshalCaddyfile()
 			networks {
 				eth {
@@ -33,9 +36,6 @@
 							auth {
 								type siwe
 								url https://din.rivet.cloud/auth
-								signer {
-									secret_file /run/secrets/din-secret-key
-								}
 							}
 						}
 					}

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -68,8 +68,8 @@ func (d *DinMiddleware) Provision(context caddy.Context) error {
 
 	// Initialize the HTTP client for each network and provider
 	httpClient := din_http.NewHTTPClient()
-	for networkname, network := range d.Networks {
-		d.logger.Debug("Registered network", zap.String("name", networkname))
+	for networkName, network := range d.Networks {
+		d.logger.Debug("Registered network", zap.String("name", networkName))
 		network.HTTPClient = httpClient
 		network.logger = d.logger
 		network.PrometheusClient = promClient


### PR DESCRIPTION
This lets us configure a single signer and use that anywhere the siwe auth option is used, without having to configure it on a per provider basis. It still lets us define it on a per-provider basis, but if nothing is specified on a provider, the default signer will be used.

The signer is dinMiddleware.DefaultSigner, so it should be available for providers generated from the on-chain registry.