### PR TITLE
Change types on JSONRPCRequest struct

### DIFF
--- a/lib/http/types.go
+++ b/lib/http/types.go
@@ -1,8 +1,12 @@
 package http
 
+import (
+	"encoding/json"
+)
+
 type JSONRPCRequest struct {
-	Method  string        `json:"method"`
-	Params  []interface{} `json:"params"`
-	ID      int           `json:"id"`
-	JSONRPC string        `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage   `json:"params"`
+	ID      json.RawMessage `json:"id"`
+	JSONRPC string          `json:"jsonrpc"`
 }


### PR DESCRIPTION
Per the [JSON RPC Specification](https://www.jsonrpc.org/specification#request_object) the type of ID can be strings or numbers. We have a lot of messages in our logs about decoding failures because we assumed them to be integers. I changed this to json.RawMessage, which is more permissive than the spec, but this is consistent with Geth's implementation, so we would accept what the more permissive clients allow.

I also set Params to be a json.RawMessage, which also aligns with Geth's implementation. This is cheaper (and more correct) than []interface{} when parsing requests from users, and if we ever end up trying to do more detailed parsing of parameters, it will make it easier to massage it into the data structures we want to work with than the types Go's JSON library uses.

As far as I can tell, all we do with ID is ignore it completely (in which case maybe we don't need it in our struct at all?), and all we do with Params is log it, which json.RawMessage might be better for.