### PR TITLE
Smart Routing: add flag for evm speed, keep track of latest and earliest block number

### DIFF
--- a/modules/consts.go
+++ b/modules/consts.go
@@ -20,6 +20,7 @@ const (
 
 	// Health check constants
 	DefaultHCMethod                = "eth_blockNumber"
+	DefaultGetBlockNumberMethod    = "eth_getBlockByNumber"
 	DefaultHCThreshold             = 2
 	DefaultHCInterval              = 5
 	DefaultBlockLagLimit           = int64(5)
@@ -40,6 +41,9 @@ const (
 
 	// Upstream/Selector Constants
 	MaxPriority = 9
+
+	// EVM Speed Constants
+	DefaultEVMSpeedEnabled = false
 )
 
 // String method to convert MyEnum to string

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -554,6 +554,13 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 							return fmt.Errorf("invalid request attempt count: %v", err)
 						}
 						d.Networks[networkName].RequestAttemptCount = requestAttemptCount
+					case "evm_speed_enabled":
+						dispenser.Next()
+						evmSpeedEnabled, err := strconv.ParseBool(dispenser.Val())
+						if err != nil {
+							return fmt.Errorf("invalid evm speed enabled: %v", err)
+						}
+						d.Networks[networkName].EVMSpeedEnabled = evmSpeedEnabled
 					default:
 						return dispenser.Errf("unrecognized option: %s", dispenser.Val())
 					}

--- a/modules/network.go
+++ b/modules/network.go
@@ -109,16 +109,20 @@ func (n *network) healthCheck() {
 			}
 
 			if n.EVMSpeedEnabled {
-				earliestBlockNumber, statusCode, err := provider.getEarliestBlockNumber(n.HCMethod, n.RequestAttemptCount)
-				if err != nil {
-					n.handleBlockNumberError(providerName, provider, statusCode, providerBlockNumber, err)
-					return
-				}
+				// Only check and set earliest block number if it hasn't been set yet.
+				// earliest block to check will be block 1.
+				if provider.earliestBlockNumber != 0 {
+					earliestBlockNumber, statusCode, err := provider.getEarliestBlockNumber(n.HCMethod, n.RequestAttemptCount)
+					if err != nil {
+						n.handleBlockNumberError(providerName, provider, statusCode, providerBlockNumber, err)
+						return
+					}
 
-				err = provider.saveEarliestBlockNumber(earliestBlockNumber)
-				if err != nil {
-					n.logger.Error("Error saving earliest block number", zap.String("provider", providerName), zap.String("network", n.Name), zap.Error(err), zap.String("machine_id", n.machineID))
-					return
+					err = provider.saveEarliestBlockNumber(earliestBlockNumber)
+					if err != nil {
+						n.logger.Error("Error saving earliest block number", zap.String("provider", providerName), zap.String("network", n.Name), zap.Error(err), zap.String("machine_id", n.machineID))
+						return
+					}
 				}
 			}
 

--- a/modules/network.go
+++ b/modules/network.go
@@ -111,8 +111,8 @@ func (n *network) healthCheck() {
 			if n.EVMSpeedEnabled {
 				// Only check and set earliest block number if it hasn't been set yet.
 				// earliest block to check will be block 1.
-				if provider.earliestBlockNumber != 0 {
-					earliestBlockNumber, statusCode, err := provider.getEarliestBlockNumber(n.HCMethod, n.RequestAttemptCount)
+				if provider.earliestBlockNumber == 0 {
+					earliestBlockNumber, statusCode, err := provider.getEarliestBlockNumber(DefaultGetBlockNumberMethod, n.RequestAttemptCount)
 					if err != nil {
 						n.handleBlockNumberError(providerName, provider, statusCode, providerBlockNumber, err)
 						return

--- a/modules/network.go
+++ b/modules/network.go
@@ -1,18 +1,12 @@
 package modules
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -39,6 +33,9 @@ type network struct {
 	BlockNumberDelta        int64                `json:"block_number_delta"`
 	MaxRequestPayloadSizeKB int64                `json:"max_request_payload_size_kb"`
 	RequestAttemptCount     int                  `json:"request_attempt_count"`
+
+	// EVMSpeedEnabled is a flag to enable EVM Speed service provided by Infura
+	EVMSpeedEnabled bool `json:"evm_speed_enabled"`
 }
 
 // NewNetwork creates a new network with the given name
@@ -55,6 +52,7 @@ func NewNetwork(name string) *network {
 		BlockNumberDelta:        DefaultBlockNumberDelta,
 		MaxRequestPayloadSizeKB: DefaultMaxRequestPayloadSizeKB,
 		RequestAttemptCount:     DefaultRequestAttemptCount,
+		EVMSpeedEnabled:         DefaultEVMSpeedEnabled,
 
 		CheckedProviders: make(map[string][]healthCheckEntry),
 		Providers:        make(map[string]*provider),
@@ -96,13 +94,33 @@ func (n *network) healthCheck() {
 		wg.Add(1) // Increment the WaitGroup counter
 		go func(providerName string, provider *provider) {
 			defer wg.Done() // Decrement the counter when the goroutine completes
-			// get the latest block number from the current provider
-			providerBlockNumber, statusCode, err := n.getLatestBlockNumber(provider.HttpUrl, provider.Headers, provider.AuthClient())
+			// Use provider's method instead
+			providerBlockNumber, statusCode, err := provider.getLatestBlockNumber(n.HCMethod)
 			if err != nil {
 				n.handleBlockNumberError(providerName, provider, statusCode, providerBlockNumber, err)
 				return
 			}
 			blockTime = time.Now()
+
+			err = provider.saveLatestBlockNumber(providerBlockNumber)
+			if err != nil {
+				n.logger.Error("Error saving block number", zap.String("provider", providerName), zap.String("network", n.Name), zap.Error(err), zap.String("machine_id", n.machineID))
+				return
+			}
+
+			if n.EVMSpeedEnabled {
+				earliestBlockNumber, statusCode, err := provider.getEarliestBlockNumber(n.HCMethod, n.RequestAttemptCount)
+				if err != nil {
+					n.handleBlockNumberError(providerName, provider, statusCode, providerBlockNumber, err)
+					return
+				}
+
+				err = provider.saveEarliestBlockNumber(earliestBlockNumber)
+				if err != nil {
+					n.logger.Error("Error saving earliest block number", zap.String("provider", providerName), zap.String("network", n.Name), zap.Error(err), zap.String("machine_id", n.machineID))
+					return
+				}
+			}
 
 			if n.pingHealthCheck(providerName, provider, statusCode, providerBlockNumber) {
 				return
@@ -203,7 +221,7 @@ func (n *network) consistencyHealthCheck(providerName string, provider *provider
 	if providerBlockNumber > n.latestBlockNumber {
 		n.latestBlockNumber = providerBlockNumber
 	}
-	
+
 	// Also update latest block number with reference block if it's higher
 	if referenceBlock > n.latestBlockNumber {
 		n.latestBlockNumber = referenceBlock
@@ -281,53 +299,6 @@ func (n *network) addHealthCheckToCheckedProviderList(providerName string, healt
 		currentHealthCheckList = append(newHealthCheckList, currentHealthCheckList...)
 		n.setCheckedProviderHCList(providerName, currentHealthCheckList)
 	}
-}
-
-func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string, ac auth.IAuthClient) (int64, int, error) {
-	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":[],"id":1}`, n.HCMethod))
-
-	// Send the POST request
-	resBytes, statusCode, err := n.HttpClient.Post(httpUrl, headers, []byte(payload), ac)
-	if err != nil {
-		return 0, 0, errors.Wrap(err, "Error sending POST request")
-	}
-
-	if *statusCode == http.StatusServiceUnavailable || *statusCode == StatusOriginUnreachable {
-		return 0, *statusCode, errors.New("Network Unavailable")
-	}
-
-	// response struct
-	var respObject map[string]interface{}
-
-	// Unmarshal the response
-	err = json.Unmarshal(resBytes, &respObject)
-	if err != nil {
-		return 0, 0, errors.Wrap(err, "Error unmarshalling response")
-	}
-
-	if _, ok := respObject["result"]; !ok {
-		return 0, 0, errors.New("Error getting block number from response")
-	}
-
-	var blockNumber int64
-
-	switch result := respObject["result"].(type) {
-	case string:
-		if result == "" || result[:2] != "0x" {
-			return 0, 0, errors.New("Invalid block number")
-		}
-
-		// Convert the hexadecimal string to an int64
-		blockNumber, err = strconv.ParseInt(result[2:], 16, 64)
-		if err != nil {
-			return 0, 0, errors.Wrap(err, "Error converting block number")
-		}
-	case float64:
-		blockNumber = int64(result)
-	default:
-		return 0, 0, errors.New("unsupported block number type")
-	}
-	return blockNumber, *statusCode, nil
 }
 
 func (n *network) close() {

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -30,33 +30,33 @@ func TestHealthCheck(t *testing.T) {
 		wantLatestBlock    int64
 		wantEarliestBlock  int64
 	}{
-		// {
-		// 	name: "single provider, successful response",
-		// 	network: &network{
-		// 		PrometheusClient: mockPrometheusClient,
-		// 		BlockNumberDelta: 10,
-		// 		HCThreshold:      3,
-		// 		Name:             "test-network",
-		// 		logger:           logger,
-		// 		EVMSpeedEnabled:  false,
-		// 		Providers: map[string]*provider{
-		// 			"provider1": {
-		// 				healthStatus: Healthy,
-		// 				host:         "provider1",
-		// 				httpClient:   mockHttpClient,
-		// 			},
-		// 		},
-		// 		latestBlockNumber: 5000000,
-		// 		CheckedProviders:  map[string][]healthCheckEntry{},
-		// 	},
-		// 	latestBlockResp: []byte(`{"jsonrpc": "2.0", "id": 1,"result": "0x4c4b43"}`),
-		// 	statusCode:      200,
-		// 	err:             nil,
-		// 	wantProviderStatus: map[string]HealthStatus{
-		// 		"provider1": Healthy,
-		// 	},
-		// 	wantLatestBlock: 5000003,
-		// },
+		{
+			name: "single provider, successful response",
+			network: &network{
+				PrometheusClient: mockPrometheusClient,
+				BlockNumberDelta: 10,
+				HCThreshold:      3,
+				Name:             "test-network",
+				logger:           logger,
+				EVMSpeedEnabled:  false,
+				Providers: map[string]*provider{
+					"provider1": {
+						healthStatus: Healthy,
+						host:         "provider1",
+						httpClient:   mockHttpClient,
+					},
+				},
+				latestBlockNumber: 5000000,
+				CheckedProviders:  map[string][]healthCheckEntry{},
+			},
+			latestBlockResp: []byte(`{"jsonrpc": "2.0", "id": 1,"result": "0x4c4b43"}`),
+			statusCode:      200,
+			err:             nil,
+			wantProviderStatus: map[string]HealthStatus{
+				"provider1": Healthy,
+			},
+			wantLatestBlock: 5000003,
+		},
 		{
 			name: "single provider with EVMSpeed enabled",
 			network: &network{

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -18,128 +18,90 @@ func TestHealthCheck(t *testing.T) {
 	logger := zap.NewNop()
 
 	tests := []struct {
-		name                string
-		network             *network
-		latestBlockResponse struct {
-			responseBytes []byte
-			statusCode    int
-			err           error
-		}
+		name               string
+		network            *network
+		evmSpeedEnabled    bool
+		latestBlockResp    []byte
+		earliestBlockResp  []byte
+		statusCode         int
+		err                error
 		wantProviderStatus map[string]HealthStatus
+		wantLatestBlock    int64
+		wantEarliestBlock  int64
 	}{
 		{
 			name: "single provider, successful response",
 			network: &network{
-				HttpClient:       mockHttpClient,
 				PrometheusClient: mockPrometheusClient,
 				BlockNumberDelta: 10,
 				HCThreshold:      3,
 				Name:             "test-network",
 				logger:           logger,
+				EVMSpeedEnabled:  false,
 				Providers: map[string]*provider{
 					"provider1": {
 						healthStatus: Healthy,
 						host:         "provider1",
-						HttpUrl:      "http://provider1",
+						httpClient:   mockHttpClient,
 					},
 				},
 				latestBlockNumber: 5000000,
 				CheckedProviders:  map[string][]healthCheckEntry{},
 			},
-			latestBlockResponse: struct {
-				responseBytes []byte
-				statusCode    int
-				err           error
-			}{
-				responseBytes: []byte(`{"jsonrpc": "2.0", "id": 1,"result": "0x4c4b43"}`),
-				statusCode:    200,
-				err:           nil,
-			},
+			latestBlockResp: []byte(`{"jsonrpc": "2.0", "id": 1,"result": "0x4c4b43"}`),
+			statusCode:      200,
+			err:             nil,
 			wantProviderStatus: map[string]HealthStatus{
 				"provider1": Healthy,
 			},
+			wantLatestBlock: 5000003,
 		},
 		{
-			name: "single provider, error response",
+			name: "single provider with EVMSpeed enabled",
 			network: &network{
-				HttpClient:       mockHttpClient,
 				PrometheusClient: mockPrometheusClient,
 				BlockNumberDelta: 10,
 				HCThreshold:      3,
 				Name:             "test-network",
 				logger:           logger,
+				EVMSpeedEnabled:  true,
 				Providers: map[string]*provider{
 					"provider1": {
 						healthStatus: Healthy,
 						host:         "provider1",
-						HttpUrl:      "http://provider1",
-						failures:     3, // Set initial failures to trigger unhealthy state
+						httpClient:   mockHttpClient,
 					},
 				},
 				latestBlockNumber: 5000000,
 				CheckedProviders:  map[string][]healthCheckEntry{},
 			},
-			latestBlockResponse: struct {
-				responseBytes []byte
-				statusCode    int
-				err           error
-			}{
-				responseBytes: nil,
-				statusCode:    400,
-				err:           nil,
-			},
-			wantProviderStatus: map[string]HealthStatus{
-				"provider1": Unhealthy,
-			},
-		},
-		{
-			name: "multiple providers, mixed responses",
-			network: &network{
-				HttpClient:       mockHttpClient,
-				PrometheusClient: mockPrometheusClient,
-				BlockNumberDelta: 10,
-				HCThreshold:      3,
-				Name:             "test-network",
-				logger:           logger,
-				Providers: map[string]*provider{
-					"provider1": {
-						healthStatus: Healthy,
-						host:         "provider1",
-						HttpUrl:      "http://provider1",
-					},
-					"provider2": {
-						healthStatus: Healthy,
-						host:         "provider2",
-						HttpUrl:      "http://provider2",
-						failures:     3,
-					},
-				},
-				latestBlockNumber: 5000000,
-				CheckedProviders:  map[string][]healthCheckEntry{},
-			},
-			latestBlockResponse: struct {
-				responseBytes []byte
-				statusCode    int
-				err           error
-			}{
-				responseBytes: []byte(`{"jsonrpc": "2.0", "id": 1,"result": "0x4c4b43"}`),
-				statusCode:    200,
-				err:           nil,
-			},
+			latestBlockResp:   []byte(`{"jsonrpc": "2.0", "id": 1,"result": "0x4c4b43"}`),
+			earliestBlockResp: []byte(`{"jsonrpc": "2.0", "id": 1,"result": {"number": "0x0"}}`),
+			statusCode:        200,
+			err:               nil,
 			wantProviderStatus: map[string]HealthStatus{
 				"provider1": Healthy,
-				"provider2": Healthy,
 			},
+			wantLatestBlock:   5000003,
+			wantEarliestBlock: 0,
 		},
+		// Add more test cases...
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up mock expectations
-			for range tt.network.Providers {
+			for _, provider := range tt.network.Providers {
+				// Mock getLatestBlockNumber call
 				mockHttpClient.EXPECT().
-					Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(tt.latestBlockResponse.responseBytes, &tt.latestBlockResponse.statusCode, tt.latestBlockResponse.err)
+					Post(provider.HttpUrl, provider.Headers, gomock.Any(), provider.AuthClient()).
+					Return(tt.latestBlockResp, &tt.statusCode, tt.err)
+
+				if tt.network.EVMSpeedEnabled {
+					// Mock getEarliestBlockNumber call
+					mockHttpClient.EXPECT().
+						Post(provider.HttpUrl, provider.Headers, gomock.Any(), provider.AuthClient()).
+						Return(tt.earliestBlockResp, &tt.statusCode, tt.err)
+				}
 
 				mockPrometheusClient.EXPECT().
 					HandleLatestBlockMetric(gomock.Any()).
@@ -149,12 +111,24 @@ func TestHealthCheck(t *testing.T) {
 			// Run health check
 			tt.network.healthCheck()
 
-			// Verify results
+			// Verify provider status
 			for providerName, provider := range tt.network.Providers {
 				wantStatus := tt.wantProviderStatus[providerName]
 				if provider.healthStatus != wantStatus {
 					t.Errorf("healthCheck() for provider %s got status = %v, want %v",
 						providerName, provider.healthStatus, wantStatus)
+				}
+
+				// Verify latest block number
+				if provider.latestBlockNumber != uint64(tt.wantLatestBlock) {
+					t.Errorf("healthCheck() for provider %s got latest block = %v, want %v",
+						providerName, provider.latestBlockNumber, tt.wantLatestBlock)
+				}
+
+				// Verify earliest block number if EVMSpeed is enabled
+				if tt.network.EVMSpeedEnabled && provider.earliestBlockNumber != uint64(tt.wantEarliestBlock) {
+					t.Errorf("healthCheck() for provider %s got earliest block = %v, want %v",
+						providerName, provider.earliestBlockNumber, tt.wantEarliestBlock)
 				}
 			}
 		})
@@ -271,20 +245,20 @@ func TestPingHealthCheck(t *testing.T) {
 func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 	timeNow := time.Now()
 	tests := []struct {
-		name             string
-		providerName     string
-		provider         *provider
-		blockNumber      int64
-		network          *network
-		expectUnhealthy  bool
-		expectedStatus   HealthStatus
+		name            string
+		providerName    string
+		provider        *provider
+		blockNumber     int64
+		network         *network
+		expectUnhealthy bool
+		expectedStatus  HealthStatus
 	}{
 		{
 			name:         "single provider - always healthy",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000030,
 			network: &network{
@@ -304,7 +278,7 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000030,
 			network: &network{
@@ -328,7 +302,7 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 4999970,
 			network: &network{
@@ -352,7 +326,7 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000010,
 			network: &network{
@@ -392,20 +366,20 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 func TestConsistencyHealthCheck(t *testing.T) {
 	timeNow := time.Now()
 	tests := []struct {
-		name                  string
-		providerName         string
-		provider             *provider
-		blockNumber          int64
-		network              *network
-		want                 HealthStatus
-		expectedLatestBlock  int64
+		name                string
+		providerName        string
+		provider            *provider
+		blockNumber         int64
+		network             *network
+		want                HealthStatus
+		expectedLatestBlock int64
 	}{
 		{
 			name:         "single provider - always healthy",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000000,
 			network: &network{
@@ -413,7 +387,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider1": {host: "provider1"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 			},
 			want:                Healthy,
 			expectedLatestBlock: 5000000,
@@ -423,7 +397,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 4999800,
 			network: &network{
@@ -433,7 +407,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider3": {host: "provider3"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 				CheckedProviders: map[string][]healthCheckEntry{
 					"provider1": {{blockNumber: 4999800, timestamp: &timeNow}},
 					"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
@@ -448,7 +422,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000000,
 			network: &network{
@@ -457,7 +431,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider2": {host: "provider2"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 				CheckedProviders: map[string][]healthCheckEntry{
 					"provider1": {{blockNumber: 5000000, timestamp: &timeNow}},
 					"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
@@ -782,7 +756,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				CheckedProviders: make(map[string][]healthCheckEntry),
 			},
 			percentile: 0.75,
-			want:      0,
+			want:       0,
 		},
 		{
 			name: "single provider",
@@ -795,7 +769,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				},
 			},
 			percentile: 0.75,
-			want:      1000,
+			want:       1000,
 		},
 		{
 			name: "multiple providers - 75th percentile",
@@ -814,7 +788,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				},
 			},
 			percentile: 0.75,
-			want:      1200,
+			want:       1200,
 		},
 		{
 			name: "providers with no health checks",
@@ -826,7 +800,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				CheckedProviders: make(map[string][]healthCheckEntry),
 			},
 			percentile: 0.75,
-			want:      0,
+			want:       0,
 		},
 	}
 

--- a/modules/provider.go
+++ b/modules/provider.go
@@ -1,28 +1,36 @@
 package modules
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
 type provider struct {
-	HttpUrl      string
-	path         string
-	host         string
-	Headers      map[string]string
-	upstream     *reverseproxy.Upstream
-	httpClient   *din_http.HTTPClient
-	logger       *zap.Logger
-	failures     int
-	successes    int
-	healthStatus HealthStatus // 0 = Healthy, 1 = Warning, 2 = Unhealthy
-	Priority     int
-	quit         chan struct{}
+	HttpUrl             string
+	path                string
+	host                string
+	Headers             map[string]string
+	upstream            *reverseproxy.Upstream
+	httpClient          din_http.IHTTPClient
+	logger              *zap.Logger
+	failures            int
+	successes           int
+	healthStatus        HealthStatus // 0 = Healthy, 1 = Warning, 2 = Unhealthy
+	latestBlockNumber   uint64
+	earliestBlockNumber uint64
+	Priority            int
+	quit                chan struct{}
 
 	// Registry Configuration Values
 	Methods []*string            `json:"methods"`
@@ -127,4 +135,206 @@ func (p *provider) Warning() bool {
 	} else {
 		return false
 	}
+}
+
+// intToHex converts an int64 to a "0x" prefixed hex string
+func intToHex(n int64) string {
+	return fmt.Sprintf("0x%x", n)
+}
+
+func hexToInt(hex string) (int64, error) {
+	// Check for empty string
+	if len(hex) == 0 {
+		return 0, fmt.Errorf("empty hex string")
+	}
+
+	// Check for minimum length (0x + at least one digit)
+	if len(hex) < 3 {
+		return 0, fmt.Errorf("invalid hex format: too short")
+	}
+
+	// Verify 0x prefix
+	if hex[:2] != "0x" {
+		return 0, fmt.Errorf("invalid hex format: missing 0x prefix")
+	}
+
+	hexNum := hex[2:]
+	return strconv.ParseInt(hexNum, 16, 64)
+}
+
+func parseBlockNumber(result interface{}) (int64, error) {
+	switch result := result.(type) {
+	case string:
+		if result == "" || result[:2] != "0x" {
+			return 0, errors.New("Invalid block number")
+		}
+		// Convert the hexadecimal string to an int64
+		blockNumber, err := hexToInt(result)
+		if err != nil {
+			return 0, errors.Wrap(err, "Error converting block number")
+		}
+		return blockNumber, nil
+	case float64:
+		return int64(result), nil
+	default:
+		return 0, errors.New("unsupported block number type")
+	}
+}
+
+func (p *provider) getLatestBlockNumber(hcMethod string) (int64, int, error) {
+	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":[],"id":1}`, hcMethod))
+
+	// Send the POST request
+	resBytes, statusCode, err := p.httpClient.Post(p.HttpUrl, p.Headers, []byte(payload), p.AuthClient())
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "Error sending POST request")
+	}
+
+	if *statusCode == http.StatusServiceUnavailable || *statusCode == StatusOriginUnreachable {
+		return 0, *statusCode, errors.New("Network Unavailable")
+	}
+
+	// response struct
+	var respObject map[string]interface{}
+
+	// Unmarshal the response
+	err = json.Unmarshal(resBytes, &respObject)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "Error unmarshalling response")
+	}
+
+	if _, ok := respObject["result"]; !ok {
+		return 0, 0, errors.New("Error getting block number from response")
+	}
+
+	blockNumber, err := parseBlockNumber(respObject["result"])
+	if err != nil {
+		return 0, 0, err
+	}
+	return blockNumber, *statusCode, nil
+}
+
+// getEarliestBlockNumber gets the earliest block number from the provider
+// If the blocknumber at 0 isn't available, then binary search is used to find the earliest block number
+// This is only enabled for EVM based networks
+func (p *provider) getEarliestBlockNumber(getBlockNumberMethod string, retryCount int) (int64, int, error) {
+	// First attempt to get block 0 since it's commonly the earliest block
+	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":["0x0", false],"id":1}`, getBlockNumberMethod))
+
+	// Make HTTP request to the node
+	resBytes, statusCode, err := p.httpClient.Post(p.HttpUrl, p.Headers, []byte(payload), p.AuthClient())
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "Error sending POST request")
+	}
+
+	// Check if node is available
+	if *statusCode == http.StatusServiceUnavailable || *statusCode == StatusOriginUnreachable {
+		return 0, *statusCode, errors.New("Network Unavailable")
+	}
+
+	var respObject map[string]interface{}
+
+	// Parse JSON response
+	err = json.Unmarshal(resBytes, &respObject)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "Error unmarshalling response")
+	}
+
+	// If block 0 exists, parse and return its number
+	if result, ok := respObject["result"]; ok && result != nil {
+		// Result should be a map containing block details
+		blockInfo, ok := result.(map[string]interface{})
+		if !ok {
+			return 0, 0, errors.New("invalid block info format")
+		}
+
+		if blockInfo["number"] == nil {
+			return 0, 0, errors.New("block number is nil")
+		}
+
+		blockNumber, err := parseBlockNumber(blockInfo["number"])
+		if err != nil {
+			return 0, 0, err
+		}
+		return blockNumber, *statusCode, nil
+	}
+
+	// If block 0 doesn't exist, use binary search to find earliest block
+	return p.binarySearchEarliestBlock(getBlockNumberMethod)
+}
+
+// binarySearchEarliestBlock performs a binary search to find the earliest available block
+func (p *provider) binarySearchEarliestBlock(getBlockNumberMethod string) (int64, int, error) {
+	if p.latestBlockNumber == 0 {
+		return 0, 0, errors.New("latest block number not set")
+	}
+
+	left := int64(1)
+	right := int64(p.latestBlockNumber)
+	var earliestBlock int64
+
+	maxIterations := 100
+	iterations := 0
+
+	for left <= right {
+		iterations++
+		if iterations > maxIterations {
+			return 0, 0, errors.New("binary search exceeded maximum iterations")
+		}
+
+		mid := left + (right-left)/2
+		hexBlock := intToHex(mid)
+
+		// Query the midpoint block
+		payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":["%s", false],"id":1}`, getBlockNumberMethod, hexBlock))
+		resBytes, statusCode, err := p.httpClient.Post(p.HttpUrl, p.Headers, []byte(payload), p.AuthClient())
+		if err != nil {
+			return 0, 0, errors.Wrap(err, "Error sending POST request during binary search")
+		}
+
+		// Check node availability
+		if *statusCode == http.StatusServiceUnavailable || *statusCode == StatusOriginUnreachable {
+			return 0, *statusCode, errors.New("Network Unavailable during binary search")
+		}
+
+		var respObject map[string]interface{}
+		err = json.Unmarshal(resBytes, &respObject)
+		if err != nil {
+			return 0, 0, errors.Wrap(err, "Error unmarshalling response during binary search")
+		}
+
+		// Check for RPC error
+		if errObj, hasError := respObject["error"]; hasError {
+			return 0, 0, errors.Errorf("RPC error during binary search: %v", errObj)
+		}
+
+		// If block exists, look for earlier blocks
+		// If block doesn't exist, look for later blocks
+		if result, ok := respObject["result"]; ok && result != nil {
+			earliestBlock = mid
+			right = mid - 1
+		} else {
+			left = mid + 1
+		}
+
+		// Rate limiting protection
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	// Return error if no valid block was found
+	if earliestBlock == 0 {
+		return 0, 0, errors.New("Could not find earliest block")
+	}
+
+	return earliestBlock, http.StatusOK, nil
+}
+
+func (p *provider) saveLatestBlockNumber(blockNumber int64) error {
+	p.latestBlockNumber = uint64(blockNumber)
+	return nil
+}
+
+func (p *provider) saveEarliestBlockNumber(blockNumber int64) error {
+	p.earliestBlockNumber = uint64(blockNumber)
+	return nil
 }

--- a/modules/provider_test.go
+++ b/modules/provider_test.go
@@ -707,16 +707,16 @@ func TestGetEarliestBlockNumber(t *testing.T) {
 		wantErr         bool
 	}{
 		{
-			name:     "successful response for block 0",
+			name:     "successful response for block 1",
 			hcMethod: "eth_getBlockByNumber",
 			provider: &provider{
 				HttpUrl:    "http://localhost:8545",
 				httpClient: mockHttpClient,
 			},
-			mockResponses:   [][]byte{[]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x0"}}`)},
+			mockResponses:   [][]byte{[]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x1"}}`)},
 			mockStatusCodes: []int{200},
 			mockErrors:      []error{nil},
-			want:            0,
+			want:            1,
 			wantStatus:      200,
 			wantErr:         false,
 		},
@@ -834,8 +834,8 @@ func TestGetEarliestBlockNumber(t *testing.T) {
 
 				var expectedPayload []byte
 				if i == 0 {
-					// First call is always for block 0
-					expectedPayload = []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":["0x0", false],"id":1}`, tt.hcMethod))
+					// First call is always for block 1
+					expectedPayload = []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":["0x1", false],"id":1}`, tt.hcMethod))
 				} else {
 					// Skip checking exact payload for binary search calls as they're dynamic
 					mockHttpClient.EXPECT().

--- a/modules/provider_test.go
+++ b/modules/provider_test.go
@@ -1,9 +1,14 @@
 package modules
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -334,6 +339,526 @@ func TestMarkUnhealthy(t *testing.T) {
 			}
 			if tt.provider.consecutiveHealthyChecks != tt.expectedConsecutiveHC {
 				t.Errorf("consecutiveHealthyChecks = %v, want %v", tt.provider.consecutiveHealthyChecks, tt.expectedConsecutiveHC)
+			}
+		})
+	}
+}
+
+func TestIntToHex(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int64
+		want string
+	}{
+		{
+			name: "convert 0",
+			n:    0,
+			want: "0x0",
+		},
+		{
+			name: "convert positive number",
+			n:    255,
+			want: "0xff",
+		},
+		{
+			name: "convert large number",
+			n:    1000000,
+			want: "0xf4240",
+		},
+		{
+			name: "convert negative number",
+			n:    -255,
+			want: "0x-ff",
+		},
+		{
+			name: "convert max int64",
+			n:    9223372036854775807,
+			want: "0x7fffffffffffffff",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := intToHex(tt.n)
+			if got != tt.want {
+				t.Errorf("intToHex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHexToInt(t *testing.T) {
+	tests := []struct {
+		name    string
+		hex     string
+		want    int64
+		wantErr bool
+	}{
+		{
+			name:    "convert 0x0",
+			hex:     "0x0",
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "convert 0xff",
+			hex:     "0xff",
+			want:    255,
+			wantErr: false,
+		},
+		{
+			name:    "convert large hex",
+			hex:     "0xf4240",
+			want:    1000000,
+			wantErr: false,
+		},
+		{
+			name:    "convert max value",
+			hex:     "0x7fffffffffffffff",
+			want:    9223372036854775807,
+			wantErr: false,
+		},
+		{
+			name:    "invalid hex prefix",
+			hex:     "ff",
+			wantErr: true,
+		},
+		{
+			name:    "invalid hex characters",
+			hex:     "0xgg",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			hex:     "",
+			wantErr: true,
+		},
+		{
+			name:    "only prefix",
+			hex:     "0x",
+			wantErr: true,
+		},
+		{
+			name:    "overflow value",
+			hex:     "0x8000000000000000",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hexToInt(tt.hex)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hexToInt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("hexToInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSaveLatestBlockNumber(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    *provider
+		blockNumber int64
+		want        uint64
+	}{
+		{
+			name:        "save zero block number",
+			provider:    &provider{},
+			blockNumber: 0,
+			want:        0,
+		},
+		{
+			name:        "save positive block number",
+			provider:    &provider{},
+			blockNumber: 1000000,
+			want:        1000000,
+		},
+		{
+			name:        "overwrite existing block number",
+			provider:    &provider{latestBlockNumber: 500000},
+			blockNumber: 1000000,
+			want:        1000000,
+		},
+		{
+			name:        "save max int64 block number",
+			provider:    &provider{},
+			blockNumber: 9223372036854775807,
+			want:        9223372036854775807,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.provider.saveLatestBlockNumber(tt.blockNumber)
+			if err != nil {
+				t.Errorf("saveLatestBlockNumber() error = %v", err)
+			}
+			if tt.provider.latestBlockNumber != tt.want {
+				t.Errorf("saveLatestBlockNumber() got = %v, want %v", tt.provider.latestBlockNumber, tt.want)
+			}
+		})
+	}
+}
+
+func TestSaveEarliestBlockNumber(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    *provider
+		blockNumber int64
+		want        uint64
+	}{
+		{
+			name:        "save zero block number",
+			provider:    &provider{},
+			blockNumber: 0,
+			want:        0,
+		},
+		{
+			name:        "save positive block number",
+			provider:    &provider{},
+			blockNumber: 1000,
+			want:        1000,
+		},
+		{
+			name:        "overwrite existing block number",
+			provider:    &provider{earliestBlockNumber: 500},
+			blockNumber: 1000,
+			want:        1000,
+		},
+		{
+			name:        "save max int64 block number",
+			provider:    &provider{},
+			blockNumber: 9223372036854775807,
+			want:        9223372036854775807,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.provider.saveEarliestBlockNumber(tt.blockNumber)
+			if err != nil {
+				t.Errorf("saveEarliestBlockNumber() error = %v", err)
+			}
+			if tt.provider.earliestBlockNumber != tt.want {
+				t.Errorf("saveEarliestBlockNumber() got = %v, want %v", tt.provider.earliestBlockNumber, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLatestBlockNumber(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockHttpClient := din_http.NewMockIHTTPClient(mockCtrl)
+
+	tests := []struct {
+		name           string
+		hcMethod       string
+		provider       *provider
+		mockResponse   []byte
+		mockStatusCode int
+		mockError      error
+		want           int64
+		wantStatus     int
+		wantErr        bool
+	}{
+		{
+			name:     "successful hex response",
+			hcMethod: "eth_blockNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponse:   []byte(`{"jsonrpc":"2.0","id":1,"result":"0xff"}`),
+			mockStatusCode: 200,
+			mockError:      nil,
+			want:           255,
+			wantStatus:     200,
+			wantErr:        false,
+		},
+		{
+			name:     "successful decimal response",
+			hcMethod: "eth_blockNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponse:   []byte(`{"jsonrpc":"2.0","id":1,"result":255}`),
+			mockStatusCode: 200,
+			mockError:      nil,
+			want:           255,
+			wantStatus:     200,
+			wantErr:        false,
+		},
+		{
+			name:     "service unavailable",
+			hcMethod: "eth_blockNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponse:   []byte{},
+			mockStatusCode: http.StatusServiceUnavailable,
+			mockError:      nil,
+			want:           0,
+			wantStatus:     http.StatusServiceUnavailable,
+			wantErr:        true,
+		},
+		{
+			name:     "invalid json response",
+			hcMethod: "eth_blockNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponse:   []byte(`invalid json`),
+			mockStatusCode: 200,
+			mockError:      nil,
+			want:           0,
+			wantStatus:     0,
+			wantErr:        true,
+		},
+		{
+			name:     "missing result field",
+			hcMethod: "eth_blockNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponse:   []byte(`{"jsonrpc":"2.0","id":1}`),
+			mockStatusCode: 200,
+			mockError:      nil,
+			want:           0,
+			wantStatus:     0,
+			wantErr:        true,
+		},
+		{
+			name:     "invalid block number format",
+			hcMethod: "eth_blockNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponse:   []byte(`{"jsonrpc":"2.0","id":1,"result":"invalid"}`),
+			mockStatusCode: 200,
+			mockError:      nil,
+			want:           0,
+			wantStatus:     0,
+			wantErr:        true,
+		},
+		{
+			name:     "http client error",
+			hcMethod: "eth_blockNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponse:   nil,
+			mockStatusCode: 0,
+			mockError:      errors.New("connection error"),
+			want:           0,
+			wantStatus:     0,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup expected HTTP client call
+			expectedPayload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":[],"id":1}`, tt.hcMethod))
+			mockHttpClient.EXPECT().
+				Post(tt.provider.HttpUrl, tt.provider.Headers, expectedPayload, tt.provider.AuthClient()).
+				Return(tt.mockResponse, &tt.mockStatusCode, tt.mockError)
+
+			got, gotStatus, err := tt.provider.getLatestBlockNumber(tt.hcMethod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getLatestBlockNumber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getLatestBlockNumber() got = %v, want %v", got, tt.want)
+			}
+			if gotStatus != tt.wantStatus {
+				t.Errorf("getLatestBlockNumber() gotStatus = %v, want %v", gotStatus, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestGetEarliestBlockNumber(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockHttpClient := din_http.NewMockIHTTPClient(mockCtrl)
+
+	tests := []struct {
+		name            string
+		hcMethod        string
+		provider        *provider
+		mockResponses   [][]byte
+		mockStatusCodes []int
+		mockErrors      []error
+		want            int64
+		wantStatus      int
+		wantErr         bool
+	}{
+		{
+			name:     "successful response for block 0",
+			hcMethod: "eth_getBlockByNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponses:   [][]byte{[]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x0"}}`)},
+			mockStatusCodes: []int{200},
+			mockErrors:      []error{nil},
+			want:            0,
+			wantStatus:      200,
+			wantErr:         false,
+		},
+		{
+			name:     "block 0 not found, binary search finds block 1",
+			hcMethod: "eth_getBlockByNumber",
+			provider: &provider{
+				HttpUrl:           "http://localhost:8545",
+				httpClient:        mockHttpClient,
+				latestBlockNumber: 10, // Set a small range for testing
+			},
+			mockResponses: [][]byte{
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":null}`),             // Block 0 not found
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x5"}}`), // Mid point (5)
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x2"}}`), // Mid point (2)
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":{"number":"0x1"}}`), // Found block 1
+			},
+			mockStatusCodes: []int{200, 200, 200, 200},
+			mockErrors:      []error{nil, nil, nil, nil},
+			want:            1,
+			wantStatus:      200,
+			wantErr:         false,
+		},
+		{
+			name:     "service unavailable during initial check",
+			hcMethod: "eth_getBlockByNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponses:   [][]byte{[]byte{}},
+			mockStatusCodes: []int{http.StatusServiceUnavailable},
+			mockErrors:      []error{nil},
+			want:            0,
+			wantStatus:      http.StatusServiceUnavailable,
+			wantErr:         true,
+		},
+		{
+			name:     "service unavailable during binary search",
+			hcMethod: "eth_getBlockByNumber",
+			provider: &provider{
+				HttpUrl:           "http://localhost:8545",
+				httpClient:        mockHttpClient,
+				latestBlockNumber: 10,
+			},
+			mockResponses: [][]byte{
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":null}`), // Block 0 not found
+				[]byte{}, // Service unavailable during binary search
+			},
+			mockStatusCodes: []int{200, http.StatusServiceUnavailable},
+			mockErrors:      []error{nil, nil},
+			want:            0,
+			wantStatus:      http.StatusServiceUnavailable,
+			wantErr:         true,
+		},
+		{
+			name:     "invalid json response during binary search",
+			hcMethod: "eth_getBlockByNumber",
+			provider: &provider{
+				HttpUrl:           "http://localhost:8545",
+				httpClient:        mockHttpClient,
+				latestBlockNumber: 10,
+			},
+			mockResponses: [][]byte{
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":null}`), // Block 0 not found
+				[]byte(`invalid json`),                           // Invalid JSON during binary search
+			},
+			mockStatusCodes: []int{200, 200},
+			mockErrors:      []error{nil, nil},
+			want:            0,
+			wantStatus:      0,
+			wantErr:         true,
+		},
+		{
+			name:     "no blocks found during binary search",
+			hcMethod: "eth_getBlockByNumber",
+			provider: &provider{
+				HttpUrl:           "http://localhost:8545",
+				httpClient:        mockHttpClient,
+				latestBlockNumber: 2,
+			},
+			mockResponses: [][]byte{
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":null}`), // Block 0 not found
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":null}`), // Block 1 not found
+				[]byte(`{"jsonrpc":"2.0","id":1,"result":null}`), // Block 2 not found
+			},
+			mockStatusCodes: []int{200, 200, 200},
+			mockErrors:      []error{nil, nil, nil},
+			want:            0,
+			wantStatus:      0,
+			wantErr:         true,
+		},
+		{
+			name:     "http client error during initial check",
+			hcMethod: "eth_getBlockByNumber",
+			provider: &provider{
+				HttpUrl:    "http://localhost:8545",
+				httpClient: mockHttpClient,
+			},
+			mockResponses:   [][]byte{nil},
+			mockStatusCodes: []int{0},
+			mockErrors:      []error{errors.New("connection error")},
+			want:            0,
+			wantStatus:      0,
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup expected HTTP client calls
+			for i, response := range tt.mockResponses {
+				statusCode := tt.mockStatusCodes[i]
+				err := tt.mockErrors[i]
+
+				var expectedPayload []byte
+				if i == 0 {
+					// First call is always for block 0
+					expectedPayload = []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method": "%s","params":["0x0", false],"id":1}`, tt.hcMethod))
+				} else {
+					// Skip checking exact payload for binary search calls as they're dynamic
+					mockHttpClient.EXPECT().
+						Post(tt.provider.HttpUrl, tt.provider.Headers, gomock.Any(), tt.provider.AuthClient()).
+						Return(response, &statusCode, err)
+					continue
+				}
+
+				mockHttpClient.EXPECT().
+					Post(tt.provider.HttpUrl, tt.provider.Headers, expectedPayload, tt.provider.AuthClient()).
+					Return(response, &statusCode, err)
+			}
+
+			got, gotStatus, err := tt.provider.getEarliestBlockNumber(tt.hcMethod, 1)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getEarliestBlockNumber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getEarliestBlockNumber() got = %v, want %v", got, tt.want)
+			}
+			if gotStatus != tt.wantStatus {
+				t.Errorf("getEarliestBlockNumber() gotStatus = %v, want %v", gotStatus, tt.wantStatus)
 			}
 		})
 	}


### PR DESCRIPTION
This commit improves the monitoring capabilities of EVM endpoints while maintaining 
backward compatibility with existing functionality.

Key Changes:
1. Added EVMSpeed Feature flag Support
   - Introduced EVMSpeedEnabled flag for providers
   - Added DefaultEVMSpeedEnabled constant (default: false)
   - Added DefaultGetBlockNumberMethod constant

2. Enhanced Block Number Tracking
   - Added capability to track both earliest and latest block numbers
   - Implemented binary search algorithm to find earliest block
   - only check earliest blockNumber on initialization; binary search doesn't need to be ran on each health check.
   - earliestBlockNumber check starts at 1 so as to not confuse the genesis block number value of `0` with the default `0`value of the `provider.earliestBlockNumber` struct.
   - Added block number storage functionality for providers

3. Provider Enhancements
   - Moved block number fetching logic from network to provider
   - Added methods for saving earliest and latest block numbers
   - Enhanced error handling for block number queries

4. Testing Improvements
   - Added comprehensive tests for hex/int conversions
   - Added tests for block number tracking
   - Added tests for EVMSpeed functionality
   - Enhanced provider and network test coverage

5. Configuration Updates
   - Added evm_speed_enabled option to Caddyfile parser
   - Updated provider struct with new fields