### PR TITLE
fix: decouple network provider checks from each other to prevent inter-impact

### DIFF
--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -15,8 +15,6 @@ import (
 	"sync"
 	"time"
 
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
-	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 	"github.com/DIN-center/din-sc/apps/din-go/lib/din"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -25,6 +23,9 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 )
@@ -629,9 +630,12 @@ func (d *DinMiddleware) ParseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.Middle
 // StartHealthchecks starts a background goroutine to monitor all of the networks' overall health and the health of its providers
 func (d *DinMiddleware) startHealthChecks() error {
 	d.logger.Info("Starting healthchecks", zap.String("machine_id", d.machineID))
-	for _, network := range d.Networks {
-		d.logger.Info("Starting healthcheck for network", zap.String("network", network.Name), zap.String("machine_id", d.machineID))
-		network.startHealthcheck()
+	for _, net := range d.Networks {
+		d.logger.Info("Starting healthcheck for network", zap.String("network", net.Name),
+			zap.String("machine_id", d.machineID))
+		for netProviderName, netProvider := range net.Providers {
+			go net.startHealthcheck(netProviderName, netProvider)
+		}
 	}
 	return nil
 }

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-sc/apps/din-go/lib/din"
 	dinreg "github.com/DIN-center/din-sc/apps/din-go/pkg/dinregistry"
 	"go.uber.org/zap"
+
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 )
 
 // syncRegistryWithLatestBlock checks the latest block number from the linea network and updates the middleware object with the latest registry data if the block number difference is greater than or equal to the epoch
@@ -137,7 +138,9 @@ func (d *DinMiddleware) addNetworkWithRegistryData(regNetwork *din.Network) erro
 
 	// Start the healthcheck for the network if the middleware is not in test mode
 	if !d.testMode {
-		network.startHealthcheck()
+		for provName, prov := range network.Providers {
+			go network.startHealthcheck(provName, prov)
+		}
 		d.logger.Info("Starting healthcheck for network", zap.String("network", network.Name), zap.String("machine_id", d.machineID))
 	}
 	return nil

--- a/modules/network.go
+++ b/modules/network.go
@@ -9,11 +9,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 type network struct {
@@ -61,24 +62,22 @@ func NewNetwork(name string) *network {
 	}
 }
 
-func (n *network) startHealthcheck() {
-	n.healthCheck()
+func (n *network) startHealthcheck(netProviderName string, netProvider *provider) {
+	n.healthCheck(netProviderName, netProvider)
 	ticker := time.NewTicker(time.Second * time.Duration(n.HCInterval))
-	go func() {
-		// Keep an index for RPC request IDs
-		for i := 0; ; i++ {
-			select {
-			// Cleanup if the quit channel gets closed. Right now nothing closes this channel, but
-			// once we integrate the authentication work there's code that should.
-			case <-n.quit:
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				// Set up the healthcheck request with authentication for this provider.
-				n.healthCheck()
-			}
+	// Keep an index for RPC request IDs
+	for i := 0; ; i++ {
+		select {
+		// Cleanup if the quit channel gets closed. Right now nothing closes this channel, but
+		// once we integrate the authentication work there's code that should.
+		case <-n.quit:
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			// Set up the healthcheck request with authentication for this provider.
+			n.healthCheck(netProviderName, netProvider)
 		}
-	}()
+	}
 }
 
 type healthCheckEntry struct {
@@ -86,42 +85,29 @@ type healthCheckEntry struct {
 	timestamp   *time.Time
 }
 
-func (n *network) healthCheck() {
-	// wait group to wait for all the providers to finish their health checks
-	var wg sync.WaitGroup
-	var blockTime time.Time
-
-	for name, currentProvider := range n.Providers {
-		// check all of the providers simultaneously using async job management for more accurate blocknumber results.
-		wg.Add(1) // Increment the WaitGroup counter
-		go func(providerName string, provider *provider) {
-			defer wg.Done() // Decrement the counter when the goroutine completes
-			// get the latest block number from the current provider
-			providerBlockNumber, statusCode, err := n.getLatestBlockNumber(provider.HttpUrl, provider.Headers, provider.AuthClient())
-			if err != nil {
-				n.handleBlockNumberError(providerName, provider, statusCode, providerBlockNumber, err)
-				return
-			}
-			blockTime = time.Now()
-
-			if n.pingHealthCheck(providerName, provider, statusCode, providerBlockNumber) {
-				return
-			}
-
-			if n.blockNumberDeltaHealthCheck(providerName, provider, providerBlockNumber) {
-				return
-			}
-
-			n.consistencyHealthCheck(providerName, provider, providerBlockNumber)
-
-			n.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
-
-			// add the current provider to the checked providers map
-			n.addHealthCheckToCheckedProviderList(provider.host, healthCheckEntry{blockNumber: providerBlockNumber, timestamp: &blockTime})
-		}(name, currentProvider) // Pass the loop variable to the goroutine
+func (n *network) healthCheck(netProviderName string, netProvider *provider) {
+	// get the latest block number from the current provider
+	providerBlockNumber, statusCode, err := n.getLatestBlockNumber(netProvider.HttpUrl, netProvider.Headers, netProvider.AuthClient())
+	if err != nil {
+		n.handleBlockNumberError(netProviderName, netProvider, statusCode, providerBlockNumber, err)
+		return
 	}
-	// Wait for all goroutines to complete
-	wg.Wait()
+
+	if n.pingHealthCheck(netProviderName, netProvider, statusCode, providerBlockNumber) {
+		return
+	}
+
+	if n.blockNumberDeltaHealthCheck(netProviderName, netProvider, providerBlockNumber) {
+		return
+	}
+
+	n.consistencyHealthCheck(netProviderName, netProvider, providerBlockNumber)
+
+	n.sendLatestBlockMetric(netProvider.host, statusCode, netProvider.healthStatus.String(), providerBlockNumber)
+
+	// add the current provider to the checked providers map
+	blockTime := time.Now()
+	n.addHealthCheckToCheckedProviderList(netProvider.host, healthCheckEntry{blockNumber: providerBlockNumber, timestamp: &blockTime})
 }
 
 func (n *network) handleBlockNumberError(providerName string, provider *provider, statusCode int, providerBlockNumber int64, err error) {
@@ -203,7 +189,7 @@ func (n *network) consistencyHealthCheck(providerName string, provider *provider
 	if providerBlockNumber > n.latestBlockNumber {
 		n.latestBlockNumber = providerBlockNumber
 	}
-	
+
 	// Also update latest block number with reference block if it's higher
 	if referenceBlock > n.latestBlockNumber {
 		n.latestBlockNumber = referenceBlock

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
-	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	"github.com/golang/mock/gomock"
 	"go.uber.org/zap"
+
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -147,7 +148,9 @@ func TestHealthCheck(t *testing.T) {
 			}
 
 			// Run health check
-			tt.network.healthCheck()
+			for provName, prov := range tt.network.Providers {
+				tt.network.healthCheck(provName, prov)
+			}
 
 			// Verify results
 			for providerName, provider := range tt.network.Providers {
@@ -271,20 +274,20 @@ func TestPingHealthCheck(t *testing.T) {
 func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 	timeNow := time.Now()
 	tests := []struct {
-		name             string
-		providerName     string
-		provider         *provider
-		blockNumber      int64
-		network          *network
-		expectUnhealthy  bool
-		expectedStatus   HealthStatus
+		name            string
+		providerName    string
+		provider        *provider
+		blockNumber     int64
+		network         *network
+		expectUnhealthy bool
+		expectedStatus  HealthStatus
 	}{
 		{
 			name:         "single provider - always healthy",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000030,
 			network: &network{
@@ -304,7 +307,7 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000030,
 			network: &network{
@@ -328,7 +331,7 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 4999970,
 			network: &network{
@@ -352,7 +355,7 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000010,
 			network: &network{
@@ -392,20 +395,20 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 func TestConsistencyHealthCheck(t *testing.T) {
 	timeNow := time.Now()
 	tests := []struct {
-		name                  string
-		providerName         string
-		provider             *provider
-		blockNumber          int64
-		network              *network
-		want                 HealthStatus
-		expectedLatestBlock  int64
+		name                string
+		providerName        string
+		provider            *provider
+		blockNumber         int64
+		network             *network
+		want                HealthStatus
+		expectedLatestBlock int64
 	}{
 		{
 			name:         "single provider - always healthy",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000000,
 			network: &network{
@@ -413,7 +416,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider1": {host: "provider1"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 			},
 			want:                Healthy,
 			expectedLatestBlock: 5000000,
@@ -423,7 +426,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 4999800,
 			network: &network{
@@ -433,7 +436,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider3": {host: "provider3"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 				CheckedProviders: map[string][]healthCheckEntry{
 					"provider1": {{blockNumber: 4999800, timestamp: &timeNow}},
 					"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
@@ -448,7 +451,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000000,
 			network: &network{
@@ -457,7 +460,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider2": {host: "provider2"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 				CheckedProviders: map[string][]healthCheckEntry{
 					"provider1": {{blockNumber: 5000000, timestamp: &timeNow}},
 					"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
@@ -782,7 +785,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				CheckedProviders: make(map[string][]healthCheckEntry),
 			},
 			percentile: 0.75,
-			want:      0,
+			want:       0,
 		},
 		{
 			name: "single provider",
@@ -795,7 +798,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				},
 			},
 			percentile: 0.75,
-			want:      1000,
+			want:       1000,
 		},
 		{
 			name: "multiple providers - 75th percentile",
@@ -814,7 +817,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				},
 			},
 			percentile: 0.75,
-			want:      1200,
+			want:       1200,
 		},
 		{
 			name: "providers with no health checks",
@@ -826,7 +829,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				CheckedProviders: make(map[string][]healthCheckEntry),
 			},
 			percentile: 0.75,
-			want:      0,
+			want:       0,
 		},
 	}
 


### PR DESCRIPTION
## Context
Network health checks run sequentially for all available providers, causing interdependency among them. For instance, if one of the available providers becomes slow replying, the remaining providers health checks will carry on the calculated latency of the slowest "sibling" provider for the same network

## Changes
Create independent health check routines per network and provider

## Test cases
Updated unit tests to validate the updates