### PR TITLE
fix: prevent all providers to be flagged unhealthy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ data/
 caddy
 din-plugins/
 coverage.out
+vendor/
+caddy.log

--- a/modules/network.go
+++ b/modules/network.go
@@ -9,11 +9,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 type network struct {
@@ -108,11 +109,9 @@ func (n *network) healthCheck() {
 				return
 			}
 
-			if n.blockNumberDeltaHealthCheck(providerName, provider, providerBlockNumber) {
+			if !n.providerHealthCheck(providerName, provider, providerBlockNumber) {
 				return
 			}
-
-			n.consistencyHealthCheck(providerName, provider, providerBlockNumber)
 
 			n.sendLatestBlockMetric(provider.host, statusCode, provider.healthStatus.String(), providerBlockNumber)
 
@@ -146,30 +145,30 @@ func (n *network) pingHealthCheck(providerName string, provider *provider, statu
 	return false
 }
 
-func (n *network) blockNumberDeltaHealthCheck(providerName string, provider *provider, providerBlockNumber int64) bool {
-	// If there's only one provider, any block number is acceptable
-	if len(n.Providers) == 1 {
-		return false
+func (n *network) providerHealthCheck(providerName string, provider *provider, providerBlockNumber int64) bool {
+	// Update network's latest block number if we see a higher one
+	// Move this before the lag check to ensure we capture the highest block
+	if providerBlockNumber > n.latestBlockNumber {
+		n.latestBlockNumber = providerBlockNumber
 	}
 
 	// Use 75th percentile as reference point
 	referenceBlock := n.getPercentileBlockNumber(0.75)
-	if referenceBlock == 0 {
-		// Not enough data to make a determination
-		return false
+
+	// If there's only one provider, any block number is acceptable
+	availableProviderCount := 0
+	for _, p := range n.Providers {
+		if !p.Unhealthy() {
+			availableProviderCount++
+		}
 	}
 
-	// Check if the provider's block number is too far from the reference block
-	if providerBlockNumber > referenceBlock+n.BlockNumberDelta {
-		n.logger.Warn("Provider is too far ahead of the network",
-			zap.String("provider", providerName),
-			zap.String("network", n.Name),
-			zap.Int64("provider_block_number", providerBlockNumber),
-			zap.Int64("reference_block_number", referenceBlock),
-			zap.String("machine_id", n.machineID))
-		provider.markUnhealthy()
-		return true
-	} else if providerBlockNumber < referenceBlock-n.BlockNumberDelta {
+	// Also update latest block number with reference block if it's higher
+	if referenceBlock != 0 && referenceBlock > n.latestBlockNumber {
+		n.latestBlockNumber = referenceBlock
+	}
+
+	if providerBlockNumber < referenceBlock-n.BlockNumberDelta && availableProviderCount > 1 && referenceBlock > 0 {
 		n.logger.Warn("Provider is too far behind the network",
 			zap.String("provider", providerName),
 			zap.String("network", n.Name),
@@ -177,39 +176,8 @@ func (n *network) blockNumberDeltaHealthCheck(providerName string, provider *pro
 			zap.Int64("reference_block_number", referenceBlock),
 			zap.String("machine_id", n.machineID))
 		provider.markUnhealthy()
-		return true
-	}
-	return false
-}
-
-func (n *network) consistencyHealthCheck(providerName string, provider *provider, providerBlockNumber int64) {
-	// For a single provider, always consider it healthy if it's responding
-	if len(n.Providers) == 1 {
-		provider.markHealthy(n.HCThreshold)
-		n.latestBlockNumber = providerBlockNumber
-		return
-	}
-
-	referenceBlock := n.getPercentileBlockNumber(0.75)
-	if referenceBlock == 0 {
-		// First health check or not enough data
-		n.latestBlockNumber = providerBlockNumber
-		provider.markHealthy(n.HCThreshold)
-		return
-	}
-
-	// Update network's latest block number if we see a higher one
-	// Move this before the lag check to ensure we capture the highest block
-	if providerBlockNumber > n.latestBlockNumber {
-		n.latestBlockNumber = providerBlockNumber
-	}
-	
-	// Also update latest block number with reference block if it's higher
-	if referenceBlock > n.latestBlockNumber {
-		n.latestBlockNumber = referenceBlock
-	}
-
-	if providerBlockNumber+n.BlockLagLimit < referenceBlock {
+		return false
+	} else if providerBlockNumber < referenceBlock-n.BlockLagLimit && referenceBlock > 0 {
 		n.logger.Warn("Provider is lagging behind",
 			zap.String("provider", providerName),
 			zap.String("network", n.Name),
@@ -217,8 +185,10 @@ func (n *network) consistencyHealthCheck(providerName string, provider *provider
 			zap.Int64("reference_block_number", referenceBlock),
 			zap.String("machine_id", n.machineID))
 		provider.markWarning()
+		return true
 	} else {
 		provider.markHealthy(n.HCThreshold)
+		return true
 	}
 }
 
@@ -343,9 +313,12 @@ func (n *network) getPercentileBlockNumber(percentile float64) int64 {
 
 	// Collect all block numbers
 	blockNumbers := make([]int64, 0, len(n.Providers))
-	for _, provider := range n.Providers {
+	for _, prov := range n.Providers {
+		if prov.Unhealthy() {
+			continue
+		}
 		// Get the most recent block number from the provider's health check entries
-		entries, ok := n.getCheckedProviderHCList(provider.host)
+		entries, ok := n.getCheckedProviderHCList(prov.host)
 		if ok && len(entries) > 0 {
 			blockNumbers = append(blockNumbers, entries[0].blockNumber)
 		}

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
-	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	"github.com/golang/mock/gomock"
 	"go.uber.org/zap"
+
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -271,20 +272,20 @@ func TestPingHealthCheck(t *testing.T) {
 func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 	timeNow := time.Now()
 	tests := []struct {
-		name             string
-		providerName     string
-		provider         *provider
-		blockNumber      int64
-		network          *network
-		expectUnhealthy  bool
-		expectedStatus   HealthStatus
+		name           string
+		providerName   string
+		provider       *provider
+		blockNumber    int64
+		network        *network
+		expectHealthy  bool
+		expectedStatus HealthStatus
 	}{
 		{
 			name:         "single provider - always healthy",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000030,
 			network: &network{
@@ -296,39 +297,39 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 					"provider1": {{blockNumber: 5000000, timestamp: &timeNow}},
 				},
 			},
-			expectUnhealthy: false,
-			expectedStatus:  Healthy,
+			expectHealthy:  true,
+			expectedStatus: Healthy,
 		},
-		{
-			name:         "provider too far ahead of 75th percentile",
-			providerName: "provider1",
-			provider: &provider{
-				healthStatus: Healthy,
-				host:        "provider1",
-			},
-			blockNumber: 5000030,
-			network: &network{
-				Providers: map[string]*provider{
-					"provider1": {host: "provider1"},
-					"provider2": {host: "provider2"},
-					"provider3": {host: "provider3"},
-				},
-				BlockNumberDelta: 20,
-				CheckedProviders: map[string][]healthCheckEntry{
-					"provider1": {{blockNumber: 5000030, timestamp: &timeNow}},
-					"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
-					"provider3": {{blockNumber: 5000000, timestamp: &timeNow}},
-				},
-			},
-			expectUnhealthy: true,
-			expectedStatus:  Unhealthy,
-		},
+		//{
+		//	name:         "provider too far ahead of 75th percentile",
+		//	providerName: "provider1",
+		//	provider: &provider{
+		//		healthStatus: Healthy,
+		//		host:         "provider1",
+		//	},
+		//	blockNumber: 5000030,
+		//	network: &network{
+		//		Providers: map[string]*provider{
+		//			"provider1": {host: "provider1"},
+		//			"provider2": {host: "provider2"},
+		//			"provider3": {host: "provider3"},
+		//		},
+		//		BlockNumberDelta: 20,
+		//		CheckedProviders: map[string][]healthCheckEntry{
+		//			"provider1": {{blockNumber: 5000030, timestamp: &timeNow}},
+		//			"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
+		//			"provider3": {{blockNumber: 5000000, timestamp: &timeNow}},
+		//		},
+		//	},
+		//	expectHealthy:  false,
+		//	expectedStatus: Unhealthy,
+		//},
 		{
 			name:         "provider too far behind 75th percentile",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 4999970,
 			network: &network{
@@ -344,15 +345,15 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 					"provider3": {{blockNumber: 5000000, timestamp: &timeNow}},
 				},
 			},
-			expectUnhealthy: true,
-			expectedStatus:  Unhealthy,
+			expectHealthy:  false,
+			expectedStatus: Unhealthy,
 		},
 		{
 			name:         "provider within acceptable range",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000010,
 			network: &network{
@@ -368,22 +369,22 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 					"provider3": {{blockNumber: 5000000, timestamp: &timeNow}},
 				},
 			},
-			expectUnhealthy: false,
-			expectedStatus:  Healthy,
+			expectHealthy:  true,
+			expectedStatus: Healthy,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.network.logger = zap.NewNop()
-			result := tt.network.blockNumberDeltaHealthCheck(tt.providerName, tt.provider, tt.blockNumber)
+			result := tt.network.providerHealthCheck(tt.providerName, tt.provider, tt.blockNumber)
 
-			if result != tt.expectUnhealthy {
-				t.Errorf("blockNumberDeltaHealthCheck() returned %v, want %v", result, tt.expectUnhealthy)
+			if result != tt.expectHealthy {
+				t.Errorf("providerHealthCheck() returned %v, want %v", result, tt.expectHealthy)
 			}
 
 			if tt.provider.healthStatus != tt.expectedStatus {
-				t.Errorf("blockNumberDeltaHealthCheck() health status = %v, want %v", tt.provider.healthStatus, tt.expectedStatus)
+				t.Errorf("providerHealthCheck() health status = %v, want %v", tt.provider.healthStatus, tt.expectedStatus)
 			}
 		})
 	}
@@ -392,20 +393,20 @@ func TestBlockNumberDeltaHealthCheck(t *testing.T) {
 func TestConsistencyHealthCheck(t *testing.T) {
 	timeNow := time.Now()
 	tests := []struct {
-		name                  string
-		providerName         string
-		provider             *provider
-		blockNumber          int64
-		network              *network
-		want                 HealthStatus
-		expectedLatestBlock  int64
+		name                string
+		providerName        string
+		provider            *provider
+		blockNumber         int64
+		network             *network
+		want                HealthStatus
+		expectedLatestBlock int64
 	}{
 		{
 			name:         "single provider - always healthy",
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000000,
 			network: &network{
@@ -413,7 +414,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider1": {host: "provider1"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 			},
 			want:                Healthy,
 			expectedLatestBlock: 5000000,
@@ -423,7 +424,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 4999800,
 			network: &network{
@@ -432,8 +433,9 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider2": {host: "provider2"},
 					"provider3": {host: "provider3"},
 				},
-				BlockLagLimit: 100,
-				HCThreshold:  3,
+				BlockLagLimit:    100,
+				BlockNumberDelta: 1000,
+				HCThreshold:      3,
 				CheckedProviders: map[string][]healthCheckEntry{
 					"provider1": {{blockNumber: 4999800, timestamp: &timeNow}},
 					"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
@@ -448,7 +450,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 			providerName: "provider1",
 			provider: &provider{
 				healthStatus: Healthy,
-				host:        "provider1",
+				host:         "provider1",
 			},
 			blockNumber: 5000000,
 			network: &network{
@@ -457,7 +459,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 					"provider2": {host: "provider2"},
 				},
 				BlockLagLimit: 100,
-				HCThreshold:  3,
+				HCThreshold:   3,
 				CheckedProviders: map[string][]healthCheckEntry{
 					"provider1": {{blockNumber: 5000000, timestamp: &timeNow}},
 					"provider2": {{blockNumber: 5000000, timestamp: &timeNow}},
@@ -471,7 +473,7 @@ func TestConsistencyHealthCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.network.logger = zap.NewNop()
-			tt.network.consistencyHealthCheck(tt.providerName, tt.provider, tt.blockNumber)
+			tt.network.providerHealthCheck(tt.providerName, tt.provider, tt.blockNumber)
 
 			if tt.provider.healthStatus != tt.want {
 				t.Errorf("consistencyHealthCheck() health status = %v, want %v", tt.provider.healthStatus, tt.want)
@@ -782,7 +784,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				CheckedProviders: make(map[string][]healthCheckEntry),
 			},
 			percentile: 0.75,
-			want:      0,
+			want:       0,
 		},
 		{
 			name: "single provider",
@@ -795,7 +797,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				},
 			},
 			percentile: 0.75,
-			want:      1000,
+			want:       1000,
 		},
 		{
 			name: "multiple providers - 75th percentile",
@@ -814,7 +816,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				},
 			},
 			percentile: 0.75,
-			want:      1200,
+			want:       1200,
 		},
 		{
 			name: "providers with no health checks",
@@ -826,7 +828,7 @@ func TestGetPercentileBlockNumber(t *testing.T) {
 				CheckedProviders: make(map[string][]healthCheckEntry),
 			},
 			percentile: 0.75,
-			want:      0,
+			want:       0,
 		},
 	}
 

--- a/modules/provider.go
+++ b/modules/provider.go
@@ -3,11 +3,12 @@ package modules
 import (
 	"net/url"
 
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
+	"go.uber.org/zap"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
-	"go.uber.org/zap"
 )
 
 type provider struct {
@@ -123,6 +124,15 @@ func (p *provider) Healthy() bool {
 // Warning returns True if the node is returning warning in healthchecks, False otherwise
 func (p *provider) Warning() bool {
 	if p.healthStatus == Warning {
+		return true
+	} else {
+		return false
+	}
+}
+
+// Warning returns True if the node is returning warning in healthchecks, False otherwise
+func (p *provider) Unhealthy() bool {
+	if p.healthStatus == Unhealthy {
 		return true
 	} else {
 		return false


### PR DESCRIPTION
## Context

Unhealthy providers can contribute to the `referenceBlock`  which is used to consider other providers healthy or unhealthy, and therefore if multiple providers end up falling behind they will be considered healthy even if they should not be.

In addition, when the total amount of providers is more than ONE we can make any provider unhealthy, THEREFORE if 2 out of 3 are unhealthy and they have big discrepancies like in case of Unichain Sepolia it might lead to all being flagged as unhealthy.

https://github.com/DIN-center/din-caddy-plugins/blob/develop/modules/network.go#L170 (edit

## Changes
- Simply provider status updates
- Prevent all providers to be flagged as Unhealthy if there is more than 1 available
- Consider only Healthy/Warning provider to contribute to referenceBlock


