### PR TITLE
Enhanced Provider Health Check Logging

### DIFF
--- a/modules/network.go
+++ b/modules/network.go
@@ -138,6 +138,10 @@ func (n *network) handleErrorWithGracePeriod(provider *provider, healthStatus He
 	}
 
 	// Provider has exceeded grace period - mark as unhealthy
+	n.logProviderWarning("Provider has exceeded grace period, marking as unhealthy", provider,
+		zap.Int64("block_number", blockNum),
+		zap.Int("consecutive_unhealthy_checks", provider.consecutiveUnhealthyChecks),
+		zap.Int("healthcheck_threshold", n.HCThreshold))
 	return Unhealthy
 }
 
@@ -158,6 +162,9 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 
 	// if provider has no block history, set it to unhealthy
 	if len(provider.BlockHistory()) == 0 {
+		n.logProviderWarning("Provider has no block history, marking as unhealthy", provider,
+			zap.Int64("current_block", currentBlock),
+			zap.Int64("latest_network_block", latestNetworkBlock))
 		return Unhealthy
 	}
 
@@ -203,39 +210,46 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 		isStalled := n.isStalled(provider)
 		if isStalled {
 			// Provider is both stalled and lagged - more serious issue
-			n.logProviderWarning("Provider is stalled and lagged", provider)
+			n.logProviderWarning("Provider is stalled and lagged", provider,
+				zap.Int64("block_lag", blockLag),
+				zap.Int64("provider_block", currentBlock),
+				zap.Int64("network_block", latestNetworkBlock))
 			return Unhealthy
 		}
 	} else if n.isStalled(provider) && !n.allProvidersStalled() {
 		// Edge case: Provider is stalled but not yet lagged, while others are making progress
-		n.logProviderWarning("Provider is stalled while others are progressing", provider)
+		n.logProviderWarning("Provider is stalled while others are progressing", provider,
+			zap.Int64("provider_block", currentBlock),
+			zap.Int64("network_block", latestNetworkBlock))
 		return Warning
 	}
 
 	// chainId check health check
 	chainId, err := n.getChainID(provider.HttpUrl, provider.Headers, provider.AuthClient())
 	if err != nil {
-		n.logProviderWarning("Error getting chain ID", provider, zap.Error(err))
+		n.logProviderWarning("Error getting chain ID", provider, zap.Error(err),
+			zap.String("chain_id", chainId),
+			zap.String("expected_chain_id", n.ChainId))
 		return Unhealthy
 	}
 
 	if !n.verifyChainID(chainId) {
-		n.logProviderWarning("Provider has incorrect chain ID", provider)
+		n.logProviderWarning("Provider has incorrect chain ID", provider,
+			zap.String("chain_id", chainId),
+			zap.String("expected_chain_id", n.ChainId))
 		return Unhealthy
 	}
 
 	// Archive Health Check
 	// if the provider name doesn't contains "bitcoin or solana and archive is enabled, return unhealthy
-	// then check if the provider can return back block data from half of its block height
+	// then check if the provider can return back block data from a quarter of its block height
 	if n.ArchiveEnabled && !strings.Contains(n.Name, "bitcoin") && !strings.Contains(n.Name, "solana") && !strings.Contains(n.Name, "starknet") {
-		// check if the provider can return back block data from half of its block height
-		currentBlock := provider.getLatestHealthyBlockEntry()
-		if currentBlock == nil {
-			// if the provider has no healthy block history, return unhealthy
+		if currentBlock == 0 {
+			n.logProviderWarning("Provider has no block history for archive check, marking as unhealthy", provider)
 			return Unhealthy
 		}
 		// get a quarter of the block height
-		quarterBlockHeight := currentBlock.blockNumber / 4
+		quarterBlockHeight := currentBlock / 4
 
 		// convert quarterBlockHeight to hex string
 		quarterBlockHeightHex := fmt.Sprintf("%#x", quarterBlockHeight)
@@ -243,7 +257,9 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 		// call the network method
 		err := n.archiveModeCheck(provider.HttpUrl, provider.Headers, provider.AuthClient(), quarterBlockHeightHex)
 		if err != nil {
-			n.logProviderWarning("Error testing archive mode", provider, zap.Error(err))
+			n.logProviderWarning("Error testing archive mode", provider, zap.Error(err),
+				zap.Int64("quarter_block_height", quarterBlockHeight),
+				zap.String("quarter_block_height_hex", quarterBlockHeightHex))
 			return Unhealthy
 		}
 	}

--- a/modules/network.go
+++ b/modules/network.go
@@ -99,6 +99,7 @@ func (n *network) healthCheck() {
 			n.logProviderWarning("Error getting latest block number for provider", provider,
 				zap.Int64("block_number", blockNum),
 				zap.String("provider", provider.host),
+				zap.String("health_status", initialHealth.String()),
 				zap.Error(err))
 			// Handle error cases with grace period logic
 			healthStatus := n.handleErrorWithGracePeriod(provider, initialHealth, blockNum)
@@ -139,7 +140,8 @@ func (n *network) handleErrorWithGracePeriod(provider *provider, healthStatus He
 	n.logProviderWarning("Provider has exceeded grace period, marking as unhealthy", provider,
 		zap.Int64("block_number", blockNum),
 		zap.Int("consecutive_unhealthy_checks", provider.consecutiveUnhealthyChecks),
-		zap.Int("healthcheck_threshold", n.HCThreshold))
+		zap.Int("healthcheck_threshold", n.HCThreshold),
+		zap.String("health_status", Unhealthy.String()))
 	return Unhealthy
 }
 
@@ -162,7 +164,8 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 	if len(provider.BlockHistory()) == 0 {
 		n.logProviderWarning("Provider has no block history, marking as unhealthy", provider,
 			zap.Int64("current_block", currentBlock),
-			zap.Int64("latest_network_block", latestNetworkBlock))
+			zap.Int64("latest_network_block", latestNetworkBlock),
+			zap.String("health_status", Unhealthy.String()))
 		return Unhealthy
 	}
 
@@ -176,9 +179,11 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 		if blockLag > n.BlockLagLimit {
 			isLagged = true
 			n.logProviderWarning("Provider is lagging behind network", provider,
+				zap.Int64("block_lag_limit", n.BlockLagLimit),
 				zap.Int64("block_lag", blockLag),
 				zap.Int64("provider_block", currentBlock),
-				zap.Int64("network_block", latestNetworkBlock))
+				zap.Int64("network_block", latestNetworkBlock),
+				zap.String("health_status", Warning.String()))
 			if Warning > worstStatus {
 				worstStatus = Warning
 			}
@@ -188,9 +193,11 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 		blockJump := currentBlock - int64(latestNetworkBlock)
 		if blockJump > n.BlockJumpLimit {
 			n.logProviderWarning("Provider is too far ahead of network", provider,
+				zap.Int64("block_jump_limit", n.BlockJumpLimit),
 				zap.Int64("block_jump", blockJump),
 				zap.Int64("provider_block", currentBlock),
-				zap.Int64("network_block", latestNetworkBlock))
+				zap.Int64("network_block", latestNetworkBlock),
+				zap.String("health_status", Unhealthy.String()))
 			return Unhealthy
 		}
 	}
@@ -198,9 +205,11 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 	if isLagged {
 		// Provider is lagging behind
 		n.logProviderWarning("Provider is lagging behind network", provider,
+			zap.Int64("block_lag_limit", n.BlockLagLimit),
 			zap.Int64("block_lag", blockLag),
 			zap.Int64("provider_block", currentBlock),
-			zap.Int64("network_block", latestNetworkBlock))
+			zap.Int64("network_block", latestNetworkBlock),
+			zap.String("health_status", Warning.String()))
 		if Warning > worstStatus {
 			worstStatus = Warning
 		}
@@ -209,16 +218,19 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 		if isStalled {
 			// Provider is both stalled and lagged - more serious issue
 			n.logProviderWarning("Provider is stalled and lagged", provider,
+				zap.Int64("block_lag_limit", n.BlockLagLimit),
 				zap.Int64("block_lag", blockLag),
 				zap.Int64("provider_block", currentBlock),
-				zap.Int64("network_block", latestNetworkBlock))
+				zap.Int64("network_block", latestNetworkBlock),
+				zap.String("health_status", Unhealthy.String()))
 			return Unhealthy
 		}
 	} else if n.isStalled(provider) && !n.allProvidersStalled() {
 		// Edge case: Provider is stalled but not yet lagged, while others are making progress
 		n.logProviderWarning("Provider is stalled while others are progressing", provider,
 			zap.Int64("provider_block", currentBlock),
-			zap.Int64("network_block", latestNetworkBlock))
+			zap.Int64("network_block", latestNetworkBlock),
+			zap.String("health_status", Warning.String()))
 		return Warning
 	}
 
@@ -227,14 +239,16 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 	if err != nil {
 		n.logProviderWarning("Error getting chain ID", provider,
 			zap.String("chain_id", chainId),
-			zap.String("expected_chain_id", n.ChainId))
+			zap.String("expected_chain_id", n.ChainId),
+			zap.String("health_status", Unhealthy.String()))
 		return Unhealthy
 	}
 
 	if !n.verifyChainID(chainId) {
 		n.logProviderWarning("Provider has incorrect chain ID", provider,
 			zap.String("chain_id", chainId),
-			zap.String("expected_chain_id", n.ChainId))
+			zap.String("expected_chain_id", n.ChainId),
+			zap.String("health_status", Unhealthy.String()))
 		return Unhealthy
 	}
 
@@ -243,7 +257,9 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 	// then check if the provider can return back block data from a quarter of its block height
 	if n.ArchiveEnabled && !strings.Contains(n.Name, "bitcoin") && !strings.Contains(n.Name, "solana") && !strings.Contains(n.Name, "starknet") {
 		if currentBlock == 0 {
-			n.logProviderWarning("Provider has no block history for archive check, marking as unhealthy", provider)
+			n.logProviderWarning("Provider has no block history for archive check, marking as unhealthy", provider,
+				zap.Int64("current_block", currentBlock),
+				zap.String("health_status", Unhealthy.String()))
 			return Unhealthy
 		}
 		// get a quarter of the block height
@@ -258,7 +274,8 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 			n.logProviderWarning("Error testing archive mode", provider,
 				zap.Int64("quarter_block_height", quarterBlockHeight),
 				zap.String("quarter_block_height_hex", quarterBlockHeightHex),
-				zap.Error(err))
+				zap.Error(err),
+				zap.String("health_status", Unhealthy.String()))
 			return Unhealthy
 		}
 	}

--- a/modules/network.go
+++ b/modules/network.go
@@ -96,12 +96,10 @@ func (n *network) healthCheck() {
 		var healthStatus HealthStatus = Healthy
 		blockNum, initialHealth, err := n.getLatestBlockNumber(provider.HttpUrl, provider.Headers, provider.AuthClient())
 		if err != nil {
-			n.logProviderWarning(
-				"Error getting latest block number for provider",
-				provider,
-				zap.Error(err),
-			)
-
+			n.logProviderWarning("Error getting latest block number for provider", provider,
+				zap.Int64("block_number", blockNum),
+				zap.String("provider", provider.host),
+				zap.Error(err))
 			// Handle error cases with grace period logic
 			healthStatus := n.handleErrorWithGracePeriod(provider, initialHealth, blockNum)
 
@@ -227,7 +225,7 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 	// chainId check health check
 	chainId, err := n.getChainID(provider.HttpUrl, provider.Headers, provider.AuthClient())
 	if err != nil {
-		n.logProviderWarning("Error getting chain ID", provider, zap.Error(err),
+		n.logProviderWarning("Error getting chain ID", provider,
 			zap.String("chain_id", chainId),
 			zap.String("expected_chain_id", n.ChainId))
 		return Unhealthy
@@ -257,9 +255,10 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 		// call the network method
 		err := n.archiveModeCheck(provider.HttpUrl, provider.Headers, provider.AuthClient(), quarterBlockHeightHex)
 		if err != nil {
-			n.logProviderWarning("Error testing archive mode", provider, zap.Error(err),
+			n.logProviderWarning("Error testing archive mode", provider,
 				zap.Int64("quarter_block_height", quarterBlockHeight),
-				zap.String("quarter_block_height_hex", quarterBlockHeightHex))
+				zap.String("quarter_block_height_hex", quarterBlockHeightHex),
+				zap.Error(err))
 			return Unhealthy
 		}
 	}

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestHandleErrorWithGracePeriod(t *testing.T) {
@@ -72,6 +75,7 @@ func TestHandleErrorWithGracePeriod(t *testing.T) {
 			n := NewNetwork("test")
 			n.HCThreshold = tt.healthThreshold
 			n.PrometheusClient = mockPrometheus
+			n.logger = logger.NewLoggerClient(zap.NewNop(), utils.Environment("test"))
 
 			status := n.handleErrorWithGracePeriod(p, tt.currentStatus, 100)
 


### PR DESCRIPTION
# Enhanced Provider Health Check Logging

## Summary
This PR solves the archive issue that we were seeing in beta and enhances the logging in the network health check system by adding more detailed context to warning logs. The additional context helps with troubleshooting provider issues and provides better visibility into health check decisions.

## Required CaddyFile Update
bitcoin-mainnet chain id needs to go from `bip:main`--> `bip122:main`

## Solution
```
if currentBlock == 0 {
      n.logProviderWarning("Provider has no block history for archive check, marking as unhealthy", provider)
}
```

## Changes
- Added block numbers, provider names, and other relevant metrics to warning logs
- Improved log messages for provider grace period exceeded cases
- Added detailed context for stalled and lagged provider warnings
- Enhanced archive mode testing logs with relevant block height information
- Added chain ID information to chain ID verification logs

## Benefits
- Easier troubleshooting of provider health issues
- More context for understanding why providers are marked unhealthy
- Better visibility into the health check decision process
- Improved operational monitoring capabilities

## Testing
Tested the changes by running the health check system against multiple providers and verifying that the logs contain the expected additional context.