### PR TITLE
support env and blocknumber in prometheus

### DIFF
--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -36,7 +36,8 @@ var (
 	DinRequestBodyBytes            *prometheus.HistogramVec
 
 	// Din Health Check Metrics
-	DinHealthCheckCount *prometheus.CounterVec
+	DinHealthCheckCount       *prometheus.CounterVec
+	DinHealthCheckBlockNumber *prometheus.GaugeVec
 )
 
 // RegisterMetrics registers the prometheus metrics
@@ -47,7 +48,7 @@ func RegisterMetrics() {
 			Name: "din_http_request_count",
 			Help: "Metric for counting the number of requests to the din http server",
 		},
-		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "machine_id"},
+		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "machine_id", "environment"},
 	)
 	DinRequestDurationMilliseconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -55,7 +56,7 @@ func RegisterMetrics() {
 			Help:    "Metric for measuring the duration of requests to the din http server",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "machine_id"},
+		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "machine_id", "environment"},
 	)
 
 	DinRequestBodyBytes = prometheus.NewHistogramVec(
@@ -64,7 +65,7 @@ func RegisterMetrics() {
 			Help:    "Metric for measuring the size of the request body in bytes",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "machine_id"},
+		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "machine_id", "environment"},
 	)
 
 	// Register health check count metric for din health checks
@@ -73,10 +74,18 @@ func RegisterMetrics() {
 			Name: "din_health_check_count",
 			Help: "Metric for counting din health checks with network, provider, response_status and health_status",
 		},
-		[]string{"service", "provider", "health_status", "machine_id"},
+		[]string{"service", "provider", "health_status", "machine_id", "environment"},
 	)
 
-	prometheus.MustRegister(DinRequestCount, DinHealthCheckCount, DinRequestDurationMilliseconds, DinRequestBodyBytes)
+	DinHealthCheckBlockNumber = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "din_health_check_block_number",
+			Help: "Metric for storing the block number of the latest health check",
+		},
+		[]string{"service", "provider", "machine_id", "environment"},
+	)
+
+	prometheus.MustRegister(DinRequestCount, DinHealthCheckCount, DinRequestDurationMilliseconds, DinRequestBodyBytes, DinHealthCheckBlockNumber)
 }
 
 type PromRequestMetricData struct {
@@ -86,6 +95,7 @@ type PromRequestMetricData struct {
 	HostName       string
 	ResponseStatus int
 	HealthStatus   string
+	Environment    string
 }
 
 // HandleRequestMetrics increments prometheus metric based on request data passed in
@@ -96,7 +106,7 @@ func (p *PrometheusClient) HandleRequestMetrics(data *PromRequestMetricData, req
 
 	err := json.Unmarshal(reqBodyBytes, &requestBody)
 	if err != nil {
-		p.logger.Warn("Error decoding request body", zap.Error(err), zap.String("request_body", string(reqBodyBytes)), zap.Int("response_status", http.StatusBadRequest))
+		p.logger.Warn("Error decoding request body", zap.Error(err), zap.String("request_body", string(reqBodyBytes)), zap.Int("response_status", http.StatusBadRequest), zap.String("environment", data.Environment))
 	}
 
 	method := requestBody.Method
@@ -107,13 +117,13 @@ func (p *PrometheusClient) HandleRequestMetrics(data *PromRequestMetricData, req
 
 	reqBodyByteSize := len(reqBodyBytes)
 
-	p.logger.Debug("Request metric data", zap.String("network", network), zap.String("method", method), zap.String("provider", data.Provider), zap.String("host_name", data.HostName), zap.String("response_status", status), zap.String("health_status", data.HealthStatus), zap.Int64("duration_milliseconds", durationMS), zap.Int("body_size", reqBodyByteSize))
+	p.logger.Debug("Request metric data", zap.String("network", network), zap.String("method", method), zap.String("provider", data.Provider), zap.String("host_name", data.HostName), zap.String("response_status", status), zap.String("health_status", data.HealthStatus), zap.Int64("duration_milliseconds", durationMS), zap.Int("body_size", reqBodyByteSize), zap.String("environment", data.Environment))
 
 	// Increment prometheus counter metric based on request data
-	DinRequestCount.WithLabelValues(network, method, data.Provider, data.HostName, status, data.HealthStatus, p.machineID).Inc()
+	DinRequestCount.WithLabelValues(network, method, data.Provider, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Inc()
 
 	// Observe prometheus histogram based on request duration and data
-	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.HostName, status, data.HealthStatus, p.machineID).Observe(float64(durationMS))
+	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Observe(float64(durationMS))
 
 	// Observe prometheus histogram based on request body size and data
 	// Disabled to avoid high metric count on prometheus
@@ -124,13 +134,18 @@ type PromHealthCheckMetricData struct {
 	Network      string
 	Provider     string
 	HealthStatus string
+	BlockNumber  int64
+	Environment  string
 }
 
 func (p *PrometheusClient) HandleHealthCheckMetric(data *PromHealthCheckMetricData) {
 	network := strings.TrimPrefix(data.Network, "/")
 
-	p.logger.Debug("Latest block metric data", zap.String("network", network), zap.String("provider", data.Provider), zap.String("health_status", data.HealthStatus))
+	p.logger.Debug("Latest block metric data", zap.String("network", network), zap.String("provider", data.Provider), zap.String("health_status", data.HealthStatus), zap.String("environment", data.Environment))
 
 	// Increment prometheus metric based on request data
-	DinHealthCheckCount.WithLabelValues(network, data.Provider, data.HealthStatus, p.machineID).Inc()
+	DinHealthCheckCount.WithLabelValues(network, data.Provider, data.HealthStatus, p.machineID, data.Environment).Inc()
+
+	// Update prometheus metric based on block number
+	DinHealthCheckBlockNumber.WithLabelValues(network, data.Provider, p.machineID, data.Environment).Set(float64(data.BlockNumber))
 }

--- a/lib/prometheus/prometheus_test.go
+++ b/lib/prometheus/prometheus_test.go
@@ -45,6 +45,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				HostName:       "node1",
 				ResponseStatus: 200,
 				HealthStatus:   "healthy",
+				Environment:    "test",
 			},
 			expectedLabels: map[string]string{
 				"service":         "ethereum",
@@ -54,6 +55,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				"response_status": "200",
 				"health_status":   "healthy",
 				"machine_id":      client.machineID,
+				"environment":     "test",
 			},
 			expectedValue: 1,
 		},
@@ -68,6 +70,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				HostName:       "node1",
 				ResponseStatus: 200,
 				HealthStatus:   "healthy",
+				Environment:    "test",
 			},
 			expectedLabels: map[string]string{
 				"service":         "ethereum",
@@ -77,6 +80,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				"response_status": "200",
 				"health_status":   "healthy",
 				"machine_id":      client.machineID,
+				"environment":     "test",
 			},
 			expectedValue: 1,
 		},
@@ -99,6 +103,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				tt.expectedLabels["response_status"],
 				tt.expectedLabels["health_status"],
 				tt.expectedLabels["machine_id"],
+				tt.expectedLabels["environment"],
 			))
 
 			assert.Equal(t, tt.expectedValue, metric, "Metric should be incremented once")
@@ -125,6 +130,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 				Network:      "/ethereum",
 				Provider:     "infura",
 				HealthStatus: "healthy",
+				Environment:  "test",
 			},
 			expectedLabels: map[string]string{
 				"service":         "ethereum",
@@ -132,6 +138,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 				"response_status": "200",
 				"health_status":   "healthy",
 				"machine_id":      client.machineID,
+				"environment":     "test",
 			},
 		},
 		{
@@ -140,6 +147,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 				Network:      "/ethereum",
 				Provider:     "infura",
 				HealthStatus: "unhealthy",
+				Environment:  "test",
 			},
 			expectedLabels: map[string]string{
 				"service":         "ethereum",
@@ -147,6 +155,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 				"response_status": "500",
 				"health_status":   "unhealthy",
 				"machine_id":      client.machineID,
+				"environment":     "test",
 			},
 		},
 	}
@@ -166,6 +175,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 				tt.expectedLabels["response_status"],
 				tt.expectedLabels["health_status"],
 				tt.expectedLabels["machine_id"],
+				tt.expectedLabels["environment"],
 			))
 
 			assert.Equal(t, float64(1), metric, "Metric should be incremented once")

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -353,6 +353,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 		HostName:       r.Host,
 		ResponseStatus: rww.statusCode,
 		HealthStatus:   healthStatus,
+		Environment:    string(d.Env),
 	}, bodyBytes, duration)
 
 	return nil
@@ -414,7 +415,7 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 		case "networks":
 			for n1 := dispenser.Nesting(); dispenser.NextBlock(n1); {
 				networkName := dispenser.Val()
-				d.Networks[networkName] = NewNetwork(networkName) // Create a new network object
+				d.Networks[networkName] = NewNetwork(networkName, d.Env) // Create a new network object
 				for nesting := dispenser.Nesting(); dispenser.NextBlock(nesting); {
 					switch dispenser.Val() {
 					case "methods":

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -92,7 +92,7 @@ func (d *DinMiddleware) processRegistryData(registryData *din.DinRegistryData) {
 
 // addNetworkWithRegistryData creates a new network object from the registry network data and adds it to the middleware object
 func (d *DinMiddleware) addNetworkWithRegistryData(regNetwork *din.Network) error {
-	network := NewNetwork(regNetwork.ProxyName)
+	network := NewNetwork(regNetwork.ProxyName, d.Env)
 	network, err := d.syncNetworkConfig(regNetwork, network)
 	if err != nil {
 		d.logger.Error("Failed to sync network config", zap.Error(err))

--- a/modules/network.go
+++ b/modules/network.go
@@ -12,6 +12,7 @@ import (
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -23,7 +24,7 @@ type network struct {
 	PrometheusClient prom.IPrometheusClient
 	logger           *logger.LoggerClient
 	machineID        string
-
+	Environment      utils.Environment
 	// internal health check values
 	HCThreshold      int
 	BlockHistorySize int
@@ -46,7 +47,7 @@ type network struct {
 // NewNetwork creates a new network with the given name
 // Only put values in the struct definition that are constant
 // Don't kick off any Background processes here
-func NewNetwork(name string) *network {
+func NewNetwork(name string, environment utils.Environment) *network {
 	return &network{
 		Name: name,
 		// Default health check values, to be overridden if specified in the Caddyfile
@@ -61,6 +62,7 @@ func NewNetwork(name string) *network {
 		RequestAttemptCount:     DefaultRequestAttemptCount,
 		BlockHistorySize:        BlockHistorySize,
 		ArchiveEnabled:          DefaultArchiveEnabled,
+		Environment:             environment,
 		Providers:               make(map[string]*provider),
 	}
 }
@@ -107,7 +109,7 @@ func (n *network) healthCheck() {
 			if healthStatus == Unhealthy {
 				// Add the block entry and send metric
 				provider.AddBlockEntry(blockNum, Unhealthy, n.BlockHistorySize)
-				n.sendHealthCheckMetric(provider.host, Unhealthy.String())
+				n.sendHealthCheckMetric(provider.host, Unhealthy.String(), blockNum, string(n.Environment))
 
 				continue // Skip further checks for confirmed unhealthy providers
 			}
@@ -117,7 +119,7 @@ func (n *network) healthCheck() {
 
 		// Update metrics and history
 		provider.AddBlockEntry(blockNum, newStatus, n.BlockHistorySize)
-		n.sendHealthCheckMetric(provider.host, newStatus.String())
+		n.sendHealthCheckMetric(provider.host, newStatus.String(), blockNum, string(n.Environment))
 	}
 }
 
@@ -357,11 +359,13 @@ func (n *network) getLatestHealthyBlock() int64 {
 	return latestBlockFromWarning
 }
 
-func (n *network) sendHealthCheckMetric(providerName string, healthStatus string) {
+func (n *network) sendHealthCheckMetric(providerName string, healthStatus string, blockNumber int64, environment string) {
 	n.PrometheusClient.HandleHealthCheckMetric(&prom.PromHealthCheckMetricData{
 		Network:      n.Name,
 		Provider:     providerName,
 		HealthStatus: healthStatus,
+		BlockNumber:  blockNumber,
+		Environment:  environment,
 	})
 }
 

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -716,7 +716,7 @@ func TestGetChainID(t *testing.T) {
 				networkName = "test"
 			}
 
-			n := NewNetwork("test", utils.Environment("test"))
+			n := NewNetwork(networkName, utils.Environment("test"))
 			n.HttpClient = mockHTTPClient
 			n.ChainIdMethod = "eth_chainId"
 			n.RequestAttemptCount = tt.requestAttemptCount

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -72,7 +72,7 @@ func TestHandleErrorWithGracePeriod(t *testing.T) {
 				host:                       "test.com",
 			}
 
-			n := NewNetwork("test")
+			n := NewNetwork("test", utils.Environment("test"))
 			n.HCThreshold = tt.healthThreshold
 			n.PrometheusClient = mockPrometheus
 			n.logger = logger.NewLoggerClient(zap.NewNop(), utils.Environment("test"))
@@ -114,7 +114,7 @@ func TestVerifyChainID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := NewNetwork("test")
+			n := NewNetwork("test", utils.Environment("test"))
 			n.ChainId = tt.networkChainID
 
 			result := n.verifyChainID(tt.providerChainID)
@@ -177,7 +177,7 @@ func TestIsStalled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := NewNetwork("test")
+			n := NewNetwork("test", utils.Environment("test"))
 			n.BlockHistorySize = tt.historySize
 
 			p := &provider{blockHistory: func() *list.List {
@@ -355,7 +355,7 @@ func TestGetLatestHealthyBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := NewNetwork("test")
+			n := NewNetwork("test", utils.Environment("test"))
 			n.Providers = tt.providers
 
 			result := n.getLatestHealthyBlock()
@@ -448,7 +448,7 @@ func TestProcessBlockNumberResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := NewNetwork("test")
+			n := NewNetwork("test", utils.Environment("test"))
 			block, health, err := n.processBlockNumberResponse(tt.response, &tt.statusCode)
 
 			if tt.expectError {
@@ -535,7 +535,7 @@ func TestArchiveModeCheck(t *testing.T) {
 				Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(tt.httpResponse, &tt.statusCode, tt.httpError)
 
-			n := NewNetwork("test")
+			n := NewNetwork("test", utils.Environment("test"))
 			n.HttpClient = mockHTTPClient
 			n.CallContractMethod = "eth_call"
 			n.RequestAttemptCount = tt.requestAttemptCount
@@ -716,7 +716,7 @@ func TestGetChainID(t *testing.T) {
 				networkName = "test"
 			}
 
-			n := NewNetwork(networkName)
+			n := NewNetwork("test", utils.Environment("test"))
 			n.HttpClient = mockHTTPClient
 			n.ChainIdMethod = "eth_chainId"
 			n.RequestAttemptCount = tt.requestAttemptCount


### PR DESCRIPTION
# Block Number Tracking and Environment Labeling

This PR introduces two key improvements to our metrics system:

1. **Block Number Tracking**: Added a new Prometheus gauge metric `din_health_check_block_number` to track the latest block number for each provider. This allows visualization of block height progression and detection of stalled nodes.

2. **Environment Labeling**: Added environment dimension to all metrics, enabling better filtering and segmentation of metrics across different deployment environments (dev, staging, prod).

The changes include:
- New Prometheus gauge for block numbers
- Environment field propagation throughout the metrics pipeline
- Updated Network constructor to accept environment parameter
- Corresponding test updates

These improvements enhance our observability capabilities for blockchain node monitoring and multi-environment metric analysis.