### PR TITLE
Enable naive method-based routing

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -224,6 +224,46 @@ This maintains a rolling history of block numbers and health statuses, which is 
 
 For more information on the overall DIN proxy architecture, see the [main README.md](../README.md#healthchecks).
 
+# Network-specific Routing Rules
+
+The **din_provider_filter.go** offers an interface for filtering which providers are capable of handling specific requests. The current 
+implementation only supports method based routing, but this may be extended in the future.
+
+This routing can be activated by updating the network configuration with:
+
+```
+din {
+  services {
+    ethereum {
+        # Method routing configuration
+        routed_methods debug_traceBlockByNumber
+        providers {
+          https://debug.tracer/ {
+            priority 0
+            methods debug_traceBlockByNumber
+          }
+          https://other.provider/ {
+            priority 0
+          }
+        }
+    }
+  }
+}
+```
+
+In this case any methods other than `debug_traceBlockByNumber` may be routed to either provider, but `debug_traceBlockByNumber` calls will
+only be routed to the `debug.tracer` provider.
+
+## Consistency Notes
+
+Normally the DIN router ensures consistency across requests by routing requests with the same Din-Session-Id header to the same provider. This
+might mean that most requests for a given Din-Session-Id are routed to `other.provider`, but if they make a `debug_traceBlockByNumber` request,
+it must be routed to `debug.tracer` as the only provider capable of handling the request. In this case it's possible that the `debug_traceBlockByNumber`
+requests may go to a provider that is ahead or behind other requests in the same session, or perhaps even on a different side of a small reorg.
+
+We have method based routing with more sophisticated consistency guards on the roadmap, but right now it should be clearly communicated to clients that
+`routed_methods` may not share the consistency guarantees seen on other methods.
+
 # Module Overview
 
 The DIN Caddy plugin consists of several key files:

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -162,16 +162,18 @@ func (d *DinMiddleware) initialize(context caddy.Context) error {
 				return fmt.Errorf("error initializing provider: %v", err)
 			}
 		}
-		for method, _ := range network.FilteredMethods {
-			match := false
-			for _, provider := range network.Providers {
-				if _, ok := provider.Methods[method]; ok {
-					match = true
-					break
+		if network.MethodFilter != nil {
+			for method, _ := range network.MethodFilter.FilteredMethods {
+				match := false
+				for _, provider := range network.Providers {
+					if _, ok := provider.Methods[method]; ok {
+						match = true
+						break
+					}
 				}
-			}
-			if !match {
-				d.logger.Warn("Method marked as routed, but not offered by any providers", zap.String("network", networkName), zap.String("method", method))
+				if !match {
+					d.logger.Warn("Method marked as routed, but not offered by any providers", zap.String("network", networkName), zap.String("method", method))
+				}
 			}
 		}
 	}

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -266,8 +266,14 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	// Create a new response writer wrapper to capture the response body and status code
 	var rww *ResponseWriterWrapper
 
-	// Set the upstreams in the context for the request
-	repl.Set(DinUpstreamsContextKey, network.Providers)
+	if network.MethodFilter != nil {
+		// Set the upstreams in the context for the request
+		repl.Set(DinUpstreamsContextKey, network.MethodFilter.FilterProviders(r, network.Providers))
+	} else {
+		// Set the upstreams in the context for the request
+		repl.Set(DinUpstreamsContextKey, network.Providers)
+	}
+
 
 	reqStartTime := time.Now()
 
@@ -426,6 +432,21 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 						if !dispenser.Args(d.Networks[networkName].Methods...) {
 							return dispenser.Errf("invalid 'methods' argument for network %s", networkName)
 						}
+					case "routed_methods":
+						methods := make([]*string, dispenser.CountRemainingArgs())
+						for i := 0; i < dispenser.CountRemainingArgs(); i++ {
+							methods[i] = new(string)
+						}
+						if !dispenser.Args(methods...) {
+							return dispenser.Errf("invalid 'routed_methods' argument for network %s", networkName)
+						}
+						methodMap := make(map[string]struct{})
+						for _, method := range methods {
+							methodMap[*method] = struct{}{}
+						}
+						d.Networks[networkName].MethodFilter = &methodFilter{
+							FilteredMethods: methodMap,
+						}
 					case "providers":
 						for dispenser.NextBlock(nesting + 1) {
 							providerObj, err := NewProvider(dispenser.Val())
@@ -434,6 +455,18 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 							}
 							for dispenser.NextBlock(nesting + 2) {
 								switch dispenser.Val() {
+								case "methods":
+									methods := make([]*string, dispenser.CountRemainingArgs())
+									for i := 0; i < dispenser.CountRemainingArgs(); i++ {
+										methods[i] = new(string)
+									}
+									if !dispenser.Args(methods...) {
+										return dispenser.Errf("invalid 'methods' argument for provider %s", providerObj.HttpUrl)
+									}
+									providerObj.Methods = make(map[string]struct{})
+									for _, method := range methods {
+										providerObj.Methods[*method] = struct{}{}
+									}
 								case "auth":
 									auth := siweSignerClient.CreateNewSIWEAuth(strings.TrimSuffix(providerObj.HttpUrl, "/")+"/auth", 16)
 									for dispenser.NextBlock(nesting + 3) {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -162,6 +162,18 @@ func (d *DinMiddleware) initialize(context caddy.Context) error {
 				return fmt.Errorf("error initializing provider: %v", err)
 			}
 		}
+		for method, _ := range network.FilteredMethods {
+			match := false
+			for _, provider := range network.Providers {
+				if _, ok := provider.Methods[method]; ok {
+					match = true
+					break
+				}
+			}
+			if !match {
+				d.logger.Warn("Method marked as routed, but not offered by any providers", zap.String("network", networkName), zap.String("method", method))
+			}
+		}
 	}
 
 	d.logger.Info("Din middleware provisioned")

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -337,7 +337,12 @@ func (d *DinMiddleware) createNewProvider(provider *provider, authConfig *dinreg
 	if err != nil {
 		return nil, fmt.Errorf("failed to get network service methods: %w", err)
 	}
-	provider.Methods = networkServiceMethods
+
+	// TODO: Figure out how to customize this per provider via registry
+	provider.Methods = make(map[string]struct{})
+	for _, method := range networkServiceMethods {
+		provider.Methods[*method] = struct{}{}
+	}
 
 	return provider, nil
 }

--- a/modules/din_middleware_helpers_test.go
+++ b/modules/din_middleware_helpers_test.go
@@ -588,6 +588,14 @@ func TestSyncNetworkConfig(t *testing.T) {
 	}
 }
 
+func expectedMethodsMap(m []*string) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, k := range m {
+		result[*k] = struct{}{}
+	}
+	return result
+}
+
 func TestCreateNewProvider(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -727,7 +735,7 @@ func TestCreateNewProvider(t *testing.T) {
 				assert.NotNil(t, createdProvider)
 
 				// Verify that the provider was updated correctly
-				assert.DeepEqual(t, tt.expectedMethods, createdProvider.Methods)
+				assert.DeepEqual(t, expectedMethodsMap(tt.expectedMethods), createdProvider.Methods)
 				assert.Equal(t, dinMiddleware.RegistryPriority, createdProvider.Priority)
 				assert.Equal(t, tt.expectedAuth, createdProvider.Auth)
 			}

--- a/modules/din_provider_filter.go
+++ b/modules/din_provider_filter.go
@@ -7,10 +7,19 @@ import (
 	"github.com/caddyserver/caddy/v2"
 )
 
+
+// ProviderFilter offers an interface for determining which providers can handle
+// a particular request. This is similar to what happens in the upstreams module,
+// but lets us attach filtering logic to specific networks.
 type ProviderFilter interface {
     FilterProviders(*http.Request, map[string]*provider) map[string]*provider
 }
 
+
+// methodFilter implements the ProviderFilter. If a network needs to route specific
+// methods to a subset of providers, they can indicate the method's importance here,
+// and the methodFilter will compare against the providers' method sets to decide where
+// to route.
 type methodFilter struct {
 	FilteredMethods map[string]struct{}
 }
@@ -43,6 +52,7 @@ func (mf *methodFilter) FilterProviders(r *http.Request, p map[string]*provider)
 	}
 	for k, provider := range p {
 		if _, ok := provider.Methods[request.Method]; ok {
+			// This provider supports the specified filtered method, and is elligible to serve the request
 			result[k] = provider
 		}
 	}

--- a/modules/din_provider_filter.go
+++ b/modules/din_provider_filter.go
@@ -1,0 +1,54 @@
+package modules
+
+import (
+	"encoding/json"
+	"net/http"
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	"github.com/caddyserver/caddy/v2"
+)
+
+type ProviderFilter interface {
+    FilterProviders(*http.Request, map[string]*provider) map[string]*provider
+}
+
+type methodFilter struct {
+	FilteredMethods map[string]struct{}
+}
+
+
+func (mf *methodFilter) FilterProviders(r *http.Request, p map[string]*provider) map[string]*provider {
+	if len(mf.FilteredMethods) == 0 {
+		return p
+	}
+	result := make(map[string]*provider)
+	
+	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+
+	var bodyData []byte
+	var request din_http.JSONRPCRequest
+
+	if v, ok := repl.Get(RequestBodyKey); ok {
+		bodyData = v.([]byte)
+	}
+
+	// Unmarshal the byte array into the struct
+	err := json.Unmarshal(bodyData, &request)
+	if err != nil {
+		// Body isn't JSON, send it to any provider and good luck
+		return p
+	}
+	if _, ok := mf.FilteredMethods[request.Method]; !ok {
+		// Method isn't an important one, send to any provider
+		return p
+	}
+	for k, provider := range p {
+		if _, ok := provider.Methods[request.Method]; ok {
+			result[k] = provider
+		}
+	}
+	if len(result) == 0 {
+		// Nothing supports this method. Send it to any provider and good luck
+		return p
+	}
+	return result
+}

--- a/modules/din_select.go
+++ b/modules/din_select.go
@@ -83,7 +83,7 @@ func (d *DinSelect) Select(pool reverseproxy.UpstreamPool, r *http.Request, rw h
 		}
 	}
 
-	d.logger.Debug("Selected upstream", zap.String("upstream", selectedUpstream.Dial))
+	// d.logger.Debug("Selected upstream", zap.String("upstream", selectedUpstream.Dial))
 
 	// if the request body is nil, return without setting the context for request metrics
 	if r.Body == nil {

--- a/modules/network.go
+++ b/modules/network.go
@@ -29,6 +29,8 @@ type network struct {
 	HCThreshold      int
 	BlockHistorySize int
 
+	// MethodFilter can be used to route requests based on the method. It implements
+	// the ProviderFilter interface, but for now is the only implementation.
 	MethodFilter     *methodFilter
 
 	// Registry configuration values

--- a/modules/network.go
+++ b/modules/network.go
@@ -29,6 +29,8 @@ type network struct {
 	HCThreshold      int
 	BlockHistorySize int
 
+	MethodFilter     *methodFilter
+
 	// Registry configuration values
 	Providers               map[string]*provider `json:"providers"`
 	Methods                 []*string            `json:"methods"`

--- a/modules/provider.go
+++ b/modules/provider.go
@@ -26,7 +26,7 @@ type provider struct {
 	Priority   int
 
 	// Registry Configuration Values
-	Methods []*string            `json:"methods"`
+	Methods map[string]struct{}  `json:"methods"`
 	Auth    *siwe.SIWEClientAuth `json:"auth"`
 
 	consecutiveUnhealthyChecks int


### PR DESCRIPTION
This implements a very simple version of method based routing. Networks can specify a list of `routed_methods`, and providers can specify a list of `methods`.

If the network specifies a list of `routed_methods`, any request that has a method in the `routed_methods` list will only be eligible to be routed to providers that specify the same method in `methods`.

This does very little to ensure consistency. It will make sure that method routed requests with same Din-Session-Id will go to the same provider for the same method, but that may be a different provider than non-method-routed requests, so they may be on different blocks.