### PR TITLE
Add instance and environment labels to metrics collection for pprof support

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -24,7 +24,6 @@
 	route /* {
 		# middleware declaration
 		din {
-			environment dev
 			siwe-signer {
 				secret_file /run/secrets/din-secret-key
 			}

--- a/compose.yml
+++ b/compose.yml
@@ -13,6 +13,7 @@ services:
       - ./caddy-data:/srv
     command: /bin/sh -c "chmod 644 /srv/caddy.log && caddy run --config /etc/caddy/Caddyfile"
     environment:
+      - ENV=dev 
       - OTEL_SERVICE_NAME=din-caddy
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://otel-collector:4317
@@ -29,3 +30,5 @@ services:
       - 4317:4317
       - 8888:8888 # for Prometheus metrics /metrics
     command: ["--config=/etc/otel/config/config.yml"]
+    environment:
+      - ENV=dev

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -16,6 +16,15 @@ const (
 	EnvTest Environment = "test"
 )
 
+// GetEnv returns the environment variable
+func GetEnv() Environment {
+	env := Environment(os.Getenv("ENV"))
+	if env != EnvProd && env != EnvBeta && env != EnvDev && env != EnvTest {
+		env = EnvDev
+	}
+	return env
+}
+
 // GetMachineId returns a unique string for the current running process
 func GetMachineId() string {
 	hostname, err := os.Hostname()

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -313,7 +313,6 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 		repl.Set(DinUpstreamsContextKey, network.Providers)
 	}
 
-
 	reqStartTime := time.Now()
 
 	// Retry the request if it fails up to the max attempt request count
@@ -410,18 +409,10 @@ func (d *DinMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) error
 	if d.Networks == nil {
 		d.Networks = make(map[string]*network)
 	}
+	d.Env = utils.GetEnv()
 	siweSignerClient := siwe.NewSIWESignerClient()
 	for dispenser.Next() { // Skip the directive name
 		switch dispenser.Val() {
-		case "environment":
-			// Signifier for production or beta etc.
-			dispenser.Next()
-			env := utils.Environment(dispenser.Val())
-			// Default to development stage if an invalid stage is provided
-			if env != utils.EnvProd && env != utils.EnvBeta && env != utils.EnvDev && env != utils.EnvTest {
-				env = utils.EnvDev
-			}
-			d.Env = env
 		case "siwe-signer":
 			var key []byte
 			for n1 := dispenser.Nesting(); dispenser.NextBlock(n1); {

--- a/services/otel-collector/config.yml
+++ b/services/otel-collector/config.yml
@@ -8,6 +8,12 @@ receivers:
           scrape_interval: 60s #default 60s
           static_configs:
             - targets: ['din-caddy:2019']
+          relabel_configs:
+            # Use hostname as instance ID
+            - target_label: instance_id
+              replacement: '${HOSTNAME}'
+            - target_label: environment
+              replacement: '${ENV}'
   otlp:
     # https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver
     protocols:


### PR DESCRIPTION
# Add instance and environment labels to metrics collection for pprof support

**BREAKING CHANGE: Must manually set the ENV var within the docker compose file now.** 

## Description
This PR enhances the OpenTelemetry collector configuration by adding dynamic instance identification and environment labeling to all collected metrics. Using the relabel_configs feature, each collector instance will now tag metrics with:

1. `instance_id` - Using the container/pod hostname as a unique identifier
2. `environment` - Using the ENV environment variable to identify deployment environments

## Benefits
- Enables multi-instance visibility in dashboards and alerts
- Allows filtering metrics by environment (dev/staging/prod)
- Makes troubleshooting easier by clearly identifying which instance a metric came from
- Facilitates comparing performance across instances