### PR TITLE
Fix logging to include context

### DIFF
--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -319,8 +319,8 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	// 2. Retryable JSON-RPC errors (server errors, timeouts, rate limits, etc.)
 	// Non-retryable JSON-RPC errors (method not found, invalid params) will not trigger retries
 	for attempt := 0; attempt < networkObj.RequestAttemptCount; attempt++ {
-		if err := checkRequestContext(d.logger.Logger, r, networkPath, attempt); err != nil {
-			handleContextCancellation(d.logger.Logger, rw, r, networkPath, attempt, err, reqStartTime)
+		if err := checkRequestContext(d.logger, r, networkPath, attempt); err != nil {
+			handleContextCancellation(d.logger, rw, r, networkPath, attempt, err, reqStartTime)
 			return nil
 		}
 		rww = NewResponseWriterWrapper(rw)

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -474,7 +474,7 @@ func createGetBlockByNumberRequestContext(networkName, providerHost, method stri
 
 // checkRequestContext checks if the request context has been cancelled or exceeded deadline
 // Returns an error if the context is done, nil if the context is still active
-func checkRequestContext(l *zap.Logger, r *http.Request, networkPath string, attempt int) error {
+func checkRequestContext(l *logger.LoggerClient, r *http.Request, networkPath string, attempt int) error {
 	select {
 	case <-r.Context().Done():
 		switch r.Context().Err() {
@@ -503,7 +503,7 @@ func checkRequestContext(l *zap.Logger, r *http.Request, networkPath string, att
 
 // handleContextCancellation handles context cancellation by returning appropriate HTTP responses
 // and logging comprehensive information about the cancellation
-func handleContextCancellation(l *zap.Logger, rw http.ResponseWriter, r *http.Request, networkPath string, attempt int, err error, reqStartTime time.Time) {
+func handleContextCancellation(l *logger.LoggerClient, rw http.ResponseWriter, r *http.Request, networkPath string, attempt int, err error, reqStartTime time.Time) {
 	duration := time.Since(reqStartTime)
 
 	// Determine the appropriate HTTP status code and response based on the error type

--- a/modules/helpers_test.go
+++ b/modules/helpers_test.go
@@ -603,7 +603,7 @@ func TestCheckRequestContext(t *testing.T) {
 			req = req.WithContext(tt.setupCtx())
 
 			// Call the function
-			err := checkRequestContext(loggerClient.Logger, req, tt.networkPath, tt.attempt)
+			err := checkRequestContext(loggerClient, req, tt.networkPath, tt.attempt)
 
 			// Verify results
 			if tt.expectError {
@@ -741,7 +741,7 @@ func TestHandleContextCancellation(t *testing.T) {
 			reqStartTime := time.Now().Add(-5 * time.Second) // Simulate 5 second duration
 
 			// Call the function
-			handleContextCancellation(loggerClient.Logger, rw, req, tt.networkPath, tt.attempt, err, reqStartTime)
+			handleContextCancellation(loggerClient, rw, req, tt.networkPath, tt.attempt, err, reqStartTime)
 
 			// Verify HTTP response
 			assert.Equal(t, tt.expectedStatusCode, rw.Code)


### PR DESCRIPTION
Logging should always use `logger.LoggerClient` to ensure that context such as `environment` and `machine_id` is included in the logs. This is essential for differentiating data in SigNoz dashboards.