### PR TITLE
Chain ID Migration: Removing CAIP-2 Prefixes

### DIFF
--- a/.github/workflows/e2e_integration_test/Caddyfile
+++ b/.github/workflows/e2e_integration_test/Caddyfile
@@ -25,7 +25,7 @@
 							priority 1
 						}
 					}
-					chain_id eip155:0x1
+					chain_id 0x1
 				}
 			}
 		}

--- a/Caddyfile
+++ b/Caddyfile
@@ -42,7 +42,7 @@
 							}
 						}
 					}
-					chain_id eip155:0x1
+					chain_id 0x1
 				}
 				holesky {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -54,7 +54,7 @@
 							priority 1
 						}
 					}
-					chain_id eip155:0x4268
+					chain_id 0x4268
 				}
 				blast-mainnet {
 					providers {
@@ -65,7 +65,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x13e31
+					chain_id 0x13e31
 					archive_enabled true
 				}
 				blast-testnet {
@@ -77,7 +77,7 @@
 							priority 1
 						}
 					}
-					chain_id eip155:0xa0c71fd
+					chain_id 0xa0c71fd
 					archive_enabled true
 				}
 				polygon {
@@ -92,35 +92,35 @@
 						https://polygon-mainnet.blastapi.io/key
 						https://api.infstones.com/polygon/mainnet/key
 					}
-					chain_id eip155:0x89
+					chain_id 0x89
 				}
 				polygon-testnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof bor_getSignersAtHash bor_getSnapshot bor_getRootHash bor_getAuthor bor_getCurrentValidators bor_getCurrentProposer eth_getTransactionReceiptsByBlock eth_getBorBlockReceipt
 					providers {
 						https://polygon-amoy.blastapi.io/key
 					}
-					chain_id eip155:0x13882
+					chain_id 0x13882
 				}
 				optimism-mainnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
 					providers {
 						https://optimism-mainnet.blastapi.io/key
 					}
-					chain_id eip155:0xa
+					chain_id 0xa
 				}
 				arbitrum-mainnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
 					providers {
 						https://infura.liquify.com/api=key/arb
 					}
-					chain_id eip155:0xa4b1
+					chain_id 0xa4b1
 				}
 				arbitrum-archive {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
 					providers {
 						https://infura.liquify.com/api=key/arb
 					}
-					chain_id eip155:0xa4b1
+					chain_id 0xa4b1
 					archive_enabled true
 				}
 				arbitrum-mainnet-archive {
@@ -135,7 +135,7 @@
 					providers {
 						https://infura.liquify.com/api=key/avax
 					}
-					chain_id eip155:0xa86a
+					chain_id 0xa86a
 				}
 				mantle-mainnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -150,7 +150,7 @@
 							priority 1
 						}
 					}
-					chain_id eip155:0x1388
+					chain_id 0x1388
 					archive_enabled true
 				}
 				mantle-sepolia {
@@ -166,7 +166,7 @@
 							priority 1
 						}
 					}
-					chain_id eip155:0x138b
+					chain_id 0x138b
 					archive_enabled true
 				}
 				optimism-sepolia {
@@ -174,7 +174,7 @@
 					providers {
 						https://optimism-sepolia.blastapi.io/key
 					}
-					chain_id eip155:0xaa37dc
+					chain_id 0xaa37dc
 				}
 				zksync-mainnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -192,7 +192,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x144
+					chain_id 0x144
 					archive_enabled true
 				}
 				zksync-sepolia {
@@ -200,7 +200,7 @@
 					providers {
 						https://zksync-sepolia.core.chainstack.com/key
 					}
-					chain_id eip155:0x12c
+					chain_id 0x12c
 				}
 				bsc-mainnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -218,7 +218,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x38
+					chain_id 0x38
 					archive_enabled true
 				}
 				bsc-testnet {
@@ -231,7 +231,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x61
+					chain_id 0x61
 				}
 				starknet-sepolia {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -245,7 +245,7 @@
 					}
 					healthcheck_method starknet_blockNumber
 					chainid_method starknet_chainId
-					chain_id starknet:0x534e5f5345504f4c4941
+					chain_id 0x534e5f5345504f4c4941
 					call_contract_method starknet_call
 					archive_enabled true
 				}
@@ -261,7 +261,7 @@
 					}
 					healthcheck_method starknet_blockNumber
 					chainid_method starknet_chainId
-					chain_id starknet:0x534e5f4d41494e
+					chain_id 0x534e5f4d41494e
 					call_contract_method starknet_call
 					archive_enabled true
 				}
@@ -271,7 +271,7 @@
 						https://api.infstones.com/opbnb/mainnet/key
 						https://mainnet.opbnb.validationcloud.io/v1/key
 					}
-					chain_id eip155:0xcc
+					chain_id 0xcc
 				}
 				opbnb-testnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -279,7 +279,7 @@
 						https://api.infstones.com/opbnb/testnet/key
 						https://testnet.opbnb.validationcloud.io/v1/key
 					}
-					chain_id eip155:0x15eb
+					chain_id 0x15eb
 				}
 				scroll-mainnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -288,7 +288,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x82750
+					chain_id 0x82750
 					archive_enabled true
 				}
 				scroll-sepolia {
@@ -298,7 +298,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x14a34
+					chain_id 0x14a34
 				}
 				swellchain-mainnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -307,7 +307,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x783
+					chain_id 0x783
 					archive_enabled true
 				}
 				swellchain-sepolia {
@@ -317,7 +317,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x784
+					chain_id 0x784
 					archive_enabled true
 				}
 				unichain-mainnet {
@@ -327,7 +327,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x82
+					chain_id 0x82
 					archive_enabled true
 				}
 				unichain-sepolia {
@@ -337,7 +337,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x515
+					chain_id 0x515
 					archive_enabled true
 				}
 				base-mainnet {
@@ -347,7 +347,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x2105
+					chain_id 0x2105
 					archive_enabled true
 				}
 				base-sepolia {
@@ -357,7 +357,7 @@
 							priority 0
 						}
 					}
-					chain_id eip155:0x14a34
+					chain_id 0x14a34
 					archive_enabled true
 				}
 				scroll-mainnet {
@@ -374,7 +374,7 @@
 							}
 						}
 					}
-					chain_id eip155:0x82750
+					chain_id 0x82750
 					archive_enabled true
 				}
 				scroll-sepolia {
@@ -390,7 +390,7 @@
 							}
 						}
 					}
-					chain_id eip155:0x8274f
+					chain_id 0x8274f
 					archive_enabled true
 				}
 				unichain-sepolia {
@@ -452,7 +452,7 @@
 					healthcheck_method getBlockHeight
 					chainid_method getGenesisHash
 					get_block_by_number_method getBlock
-					chain_id solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+					chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
 				}
 				solana-devnet {
 					methods web3_sha3 web3_clientVersion net_listening net_peerCount net_version eth_call eth_getBalance eth_estimateGas eth_createAccessList eth_getStorageAt eth_getCode eth_blockNumber eth_protocolVersion eth_syncing eth_sendRawTransaction eth_chainId eth_getLogs eth_getTransactionByHash eth_getTransactionReceipt eth_getTransactionCount eth_feeHistory eth_getBlockByNumber eth_getBlockByHash eth_gasPrice eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getBlockTransactionCountByNumber eth_getBlockTransactionCountByHash eth_getUncleCountByBlockNumber eth_getUncleCountByBlockHash eth_subscribe eth_unsubscribe eth_getUncleByBlockHashAndIndex eth_maxPriorityFeePerGas eth_getProof
@@ -461,7 +461,7 @@
 					}
 					healthcheck_method getBlockHeight
 					chainid_method getGenesisHash
-					chain_id solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG
+					chain_id EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG
 				}
 				bitcoin-mainnet {
 					providers {
@@ -469,7 +469,7 @@
 					}
 					healthcheck_method getblockcount
 					chainid_method getblockchaininfo
-					chain_id bip:main
+					chain_id main
 				}
 			}
 			din_registry {

--- a/docs/chain-id-migration.md
+++ b/docs/chain-id-migration.md
@@ -1,0 +1,399 @@
+# Chain ID Migration Guide: Removing CAIP-2 Prefixes
+
+## Overview
+
+As of this update, the DIN Caddy plugins no longer require CAIP-2 format prefixes for chain IDs. This change simplifies configuration and removes redundancy since network types are now determined by explicit handler declarations.
+
+## What Changed?
+
+### Before (Old Format)
+Chain IDs required CAIP-2 prefixes to identify the network type:
+```
+eip155:0x1      # Ethereum Mainnet
+solana:5eykt... # Solana Mainnet  
+starknet:0x534... # Starknet Mainnet
+beacon:1        # Beacon Chain
+```
+
+### After (New Format)
+Chain IDs now use their native format without prefixes:
+```
+0x1             # Ethereum Mainnet
+5eykt...        # Solana Mainnet
+0x534...        # Starknet Mainnet
+1               # Beacon Chain
+```
+
+## Migration Steps
+
+### 1. Update Your Caddyfile
+
+#### EVM Networks (Ethereum, Polygon, Arbitrum, etc.)
+**Old:**
+```caddyfile
+networks {
+    eth {
+        providers {
+            https://eth-mainnet.example.com
+        }
+        chain_id eip155:0x1
+    }
+    polygon {
+        providers {
+            https://polygon-mainnet.example.com
+        }
+        chain_id eip155:0x89
+    }
+}
+```
+
+**New:**
+```caddyfile
+networks {
+    eth {
+        providers {
+            https://eth-mainnet.example.com
+        }
+        chain_id 0x1
+    }
+    polygon {
+        providers {
+            https://polygon-mainnet.example.com
+        }
+        chain_id 0x89
+    }
+}
+```
+
+#### Solana Networks
+**Old:**
+```caddyfile
+networks {
+    solana-mainnet {
+        handler solana
+        providers {
+            https://solana.example.com
+        }
+        chain_id solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+    }
+}
+```
+
+**New:**
+```caddyfile
+networks {
+    solana-mainnet {
+        handler solana
+        providers {
+            https://solana.example.com
+        }
+        chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+    }
+}
+```
+
+#### Starknet Networks
+**Old:**
+```caddyfile
+networks {
+    starknet-mainnet {
+        handler starknet
+        providers {
+            https://starknet.example.com
+        }
+        chain_id starknet:0x534e5f4d41494e
+    }
+}
+```
+
+**New:**
+```caddyfile
+networks {
+    starknet-mainnet {
+        handler starknet
+        providers {
+            https://starknet.example.com
+        }
+        chain_id 0x534e5f4d41494e
+    }
+}
+```
+
+#### Beacon Chain
+**Old:**
+```caddyfile
+networks {
+    eth-beacon {
+        handler beacon-chain
+        providers {
+            https://beacon.example.com
+        }
+        chain_id beacon:1
+    }
+}
+```
+
+**New:**
+```caddyfile
+networks {
+    eth-beacon {
+        handler beacon-chain
+        providers {
+            https://beacon.example.com
+        }
+        chain_id 1
+    }
+}
+```
+
+## Common Chain IDs Reference
+
+### EVM Networks
+| Network | Old Format | New Format |
+|---------|------------|------------|
+| Ethereum Mainnet | `eip155:0x1` | `0x1` |
+| Ethereum Goerli | `eip155:0x5` | `0x5` |
+| Ethereum Sepolia | `eip155:0xaa36a7` | `0xaa36a7` |
+| Ethereum Holesky | `eip155:0x4268` | `0x4268` |
+| Polygon Mainnet | `eip155:0x89` | `0x89` |
+| Polygon Amoy | `eip155:0x13882` | `0x13882` |
+| Arbitrum One | `eip155:0xa4b1` | `0xa4b1` |
+| Arbitrum Sepolia | `eip155:0x66eee` | `0x66eee` |
+| Optimism Mainnet | `eip155:0xa` | `0xa` |
+| Optimism Sepolia | `eip155:0xaa37dc` | `0xaa37dc` |
+| Base Mainnet | `eip155:0x2105` | `0x2105` |
+| Base Sepolia | `eip155:0x14a34` | `0x14a34` |
+| BSC Mainnet | `eip155:0x38` | `0x38` |
+| BSC Testnet | `eip155:0x61` | `0x61` |
+| Avalanche C-Chain | `eip155:0xa86a` | `0xa86a` |
+| zkSync Era | `eip155:0x144` | `0x144` |
+| zkSync Sepolia | `eip155:0x12c` | `0x12c` |
+| Scroll Mainnet | `eip155:0x82750` | `0x82750` |
+| Scroll Sepolia | `eip155:0x8274f` | `0x8274f` |
+| Mantle Mainnet | `eip155:0x1388` | `0x1388` |
+| Mantle Sepolia | `eip155:0x138b` | `0x138b` |
+| Blast Mainnet | `eip155:0x13e31` | `0x13e31` |
+| Blast Sepolia | `eip155:0xa0c71fd` | `0xa0c71fd` |
+
+### Solana Networks
+| Network | Old Format | New Format |
+|---------|------------|------------|
+| Solana Mainnet | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d` | `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d` |
+| Solana Devnet | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG` | `EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG` |
+| Solana Testnet | `solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY` | `4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY` |
+
+### Starknet Networks
+| Network | Old Format | New Format |
+|---------|------------|------------|
+| Starknet Mainnet | `starknet:0x534e5f4d41494e` | `0x534e5f4d41494e` |
+| Starknet Sepolia | `starknet:0x534e5f5345504f4c4941` | `0x534e5f5345504f4c4941` |
+
+### Beacon Chain
+| Network | Old Format | New Format |
+|---------|------------|------------|
+| Ethereum Beacon Mainnet | `beacon:1` | `1` |
+| Goerli Beacon | `beacon:5` | `5` |
+| Sepolia Beacon | `beacon:11155111` | `11155111` |
+| Holesky Beacon | `beacon:17000` | `17000` |
+
+## Validation Changes
+
+### What's Now Invalid
+The system will now **reject** chain IDs containing colons (`:`):
+- ❌ `eip155:0x1`
+- ❌ `solana:5eykt...`
+- ❌ `starknet:0x534...`
+- ❌ `beacon:1`
+
+Error message example:
+```
+invalid EVM chain ID format: eip155:0x1, chain ID should not contain ':' (CAIP-2 prefix no longer required)
+```
+
+### What's Valid
+- ✅ Hex format for EVM: `0x1`, `0x89`, `0xa4b1`
+- ✅ Decimal format for EVM: `1`, `137`, `42161`
+- ✅ Base58 hashes for Solana: `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d`
+- ✅ Hex format for Starknet: `0x534e5f4d41494e`
+- ✅ Numeric format for Beacon: `1`, `5`, `11155111`
+
+## Handler Types
+
+Remember to explicitly set handler types for non-EVM networks:
+
+```caddyfile
+networks {
+    # EVM networks - handler defaults to 'evm' if not specified
+    ethereum {
+        chain_id 0x1
+        # handler evm  # Optional, this is the default
+    }
+    
+    # Non-EVM networks - handler must be specified
+    solana-mainnet {
+        handler solana  # Required for Solana
+        chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+    }
+    
+    starknet-mainnet {
+        handler starknet  # Required for Starknet
+        chain_id 0x534e5f4d41494e
+    }
+    
+    eth-beacon {
+        handler beacon-chain  # Required for Beacon Chain
+        chain_id 1
+    }
+}
+```
+
+## Why This Change?
+
+The CAIP-2 (Chain Agnostic Improvement Proposal 2) format was originally designed to provide a universal way to identify blockchain networks across different ecosystems. However, in our implementation:
+
+1. **Handler Types Already Differentiate Networks**: Each network in the Caddyfile can explicitly declare its handler type (`handler evm`, `handler solana`, etc.), making the prefix redundant.
+
+2. **Simplified Configuration**: Removing prefixes makes configuration files cleaner and easier to read.
+
+3. **Native Format Alignment**: Chain IDs now match what the blockchains themselves use internally.
+
+4. **Reduced Complexity**: One less thing to remember and one less place for typos.
+
+## Troubleshooting
+
+### Error: "chain ID should not contain ':'"
+**Cause:** Your configuration still uses the old CAIP-2 format with prefixes.
+
+**Solution:** Remove the prefix (everything before and including the colon) from your chain_id values.
+
+### Error: "invalid chain ID format"
+**Cause:** The chain ID format doesn't match what the handler expects.
+
+**Solution:** Ensure you're using the correct format for your network type:
+- EVM: Hex (`0x1`) or decimal (`1`)
+- Solana: Base58 hash
+- Starknet: Hex with `0x` prefix
+- Beacon: Numeric
+
+### Error: "no handler registered for network type"
+**Cause:** The handler type isn't specified for a non-EVM network.
+
+**Solution:** Add the appropriate handler declaration to your network configuration.
+
+### Error: "failed to parse beacon config response"
+**Cause:** The beacon API response format varies between providers.
+
+**Solution:** The beacon handler has been updated to handle multiple response formats. Ensure you're using the latest version.
+
+## Complete Migration Example
+
+Here's a complete before/after example showing multiple network types:
+
+**Before:**
+```caddyfile
+{
+    admin :2019
+}
+:8000 {
+    route /* {
+        din {
+            networks {
+                eth {
+                    providers {
+                        https://eth-mainnet.example.com
+                    }
+                    chain_id eip155:0x1
+                }
+                polygon {
+                    providers {
+                        https://polygon-mainnet.example.com
+                    }
+                    chain_id eip155:0x89
+                }
+                solana-mainnet {
+                    handler solana
+                    providers {
+                        https://solana-mainnet.example.com
+                    }
+                    chain_id solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+                }
+                starknet-mainnet {
+                    handler starknet
+                    providers {
+                        https://starknet-mainnet.example.com
+                    }
+                    chain_id starknet:0x534e5f4d41494e
+                }
+            }
+        }
+        reverse_proxy {
+            lb_policy din_reverse_proxy_policy
+            dynamic din_reverse_proxy_policy
+        }
+    }
+}
+```
+
+**After:**
+```caddyfile
+{
+    admin :2019
+}
+:8000 {
+    route /* {
+        din {
+            networks {
+                eth {
+                    providers {
+                        https://eth-mainnet.example.com
+                    }
+                    chain_id 0x1
+                }
+                polygon {
+                    providers {
+                        https://polygon-mainnet.example.com
+                    }
+                    chain_id 0x89
+                }
+                solana-mainnet {
+                    handler solana
+                    providers {
+                        https://solana-mainnet.example.com
+                    }
+                    chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+                }
+                starknet-mainnet {
+                    handler starknet
+                    providers {
+                        https://starknet-mainnet.example.com
+                    }
+                    chain_id 0x534e5f4d41494e
+                }
+            }
+        }
+        reverse_proxy {
+            lb_policy din_reverse_proxy_policy
+            dynamic din_reverse_proxy_policy
+        }
+    }
+}
+```
+
+## Benefits of This Change
+
+1. **Simpler Configuration**: No need to remember CAIP-2 prefixes
+2. **Clearer Intent**: Handler type explicitly declares the network type
+3. **Reduced Errors**: Fewer chances for prefix typos
+4. **Better Alignment**: Chain IDs now match their native blockchain format
+5. **Easier Migration**: New networks can be added without worrying about prefix standards
+6. **Improved Maintainability**: Less code complexity in validation logic
+
+## Need Help?
+
+If you encounter any issues during migration:
+1. Check that all chain_id values have been updated
+2. Verify handler types are set for non-EVM networks
+3. Ensure your Caddy server has been restarted after configuration changes
+4. Review the error logs for specific validation messages
+
+For additional support, please open an issue on the [DIN Caddy Plugins GitHub repository](https://github.com/DIN-center/din-caddy-plugins/issues).

--- a/docs/chain-id-migration.md
+++ b/docs/chain-id-migration.md
@@ -4,6 +4,8 @@
 
 As of this update, the DIN Caddy plugins no longer require CAIP-2 format prefixes for chain IDs. This change simplifies configuration and removes redundancy since network types are now determined by explicit handler declarations.
 
+**Note:** EVM networks maintain backwards compatibility and support both formats.
+
 ## What Changed?
 
 ### Before (Old Format)
@@ -15,14 +17,22 @@ starknet:0x534... # Starknet Mainnet
 beacon:1        # Beacon Chain
 ```
 
-### After (New Format)
+### After (New Format - Recommended)
 Chain IDs now use their native format without prefixes:
 ```
-0x1             # Ethereum Mainnet
+0x1             # Ethereum Mainnet (both formats supported)
 5eykt...        # Solana Mainnet
 0x534...        # Starknet Mainnet
 1               # Beacon Chain
 ```
+
+### Backwards Compatibility
+
+**EVM Networks Only:** For backwards compatibility, EVM networks (handler type `evm`) continue to support both formats:
+- ✅ `0x1` (recommended)
+- ✅ `eip155:0x1` (supported for backwards compatibility)
+
+Other network types (Solana, Starknet, Beacon) require the new format without prefixes.
 
 ## Migration Steps
 
@@ -199,20 +209,21 @@ networks {
 ## Validation Changes
 
 ### What's Now Invalid
-The system will now **reject** chain IDs containing colons (`:`):
-- ❌ `eip155:0x1`
-- ❌ `solana:5eykt...`
-- ❌ `starknet:0x534...`
-- ❌ `beacon:1`
+For non-EVM networks, the system will **reject** chain IDs containing colons (`:`):
+- ❌ `solana:5eykt...` (Solana networks)
+- ❌ `starknet:0x534...` (Starknet networks)
+- ❌ `beacon:1` (Beacon Chain)
 
-Error message example:
+Error message examples:
 ```
-invalid EVM chain ID format: eip155:0x1, chain ID should not contain ':' (CAIP-2 prefix no longer required)
+invalid Solana chain ID format: solana:5eykt..., chain ID should not contain ':' (CAIP-2 prefix no longer required)
+invalid Beacon Chain chain ID format: beacon:1, chain ID should not contain ':' (CAIP-2 prefix no longer required)
 ```
 
 ### What's Valid
 - ✅ Hex format for EVM: `0x1`, `0x89`, `0xa4b1`
 - ✅ Decimal format for EVM: `1`, `137`, `42161`
+- ✅ **CAIP-2 format for EVM (backwards compatibility)**: `eip155:0x1`, `eip155:1`
 - ✅ Base58 hashes for Solana: `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d`
 - ✅ Hex format for Starknet: `0x534e5f4d41494e`
 - ✅ Numeric format for Beacon: `1`, `5`, `11155111`

--- a/docs/gateway/gateway.md
+++ b/docs/gateway/gateway.md
@@ -52,7 +52,7 @@ A minimal Caddyfile for DIN Edge configuration looks like this:
 							}
 						}
 					}
-					chain_id eip155:0x1
+					chain_id 0x1
 				}
 				holesky {
 					providers {
@@ -66,7 +66,7 @@ A minimal Caddyfile for DIN Edge configuration looks like this:
 							}
 						}
 					}
-					chain_id eip155:0x4268
+					chain_id 0x4268
 				}
 			}
 			din_registry {
@@ -160,7 +160,7 @@ networks {
 				}
 			}
 		}
-		chain_id eip155:0x1
+		chain_id 0x1
 	}
 ```
 
@@ -184,7 +184,7 @@ Then, we have another network:
 				}
 			}
 		}
-		chain_id eip155:0x4268
+		chain_id 0x4268
 	}
 }
 ```

--- a/docs/multi_network_type_support.md
+++ b/docs/multi_network_type_support.md
@@ -205,7 +205,7 @@ din {
         # EVM Network
         ethereum {
             handler evm
-            chain_id eip155:0x1
+            chain_id 0x1
             providers {
                 https://mainnet.infura.io/v3/YOUR-KEY {
                     priority 0
@@ -216,7 +216,7 @@ din {
         # Solana Network
         solana-mainnet {
             handler solana
-            chain_id solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+            chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
             providers {
                 https://api.mainnet-beta.solana.com {
                     priority 0
@@ -227,7 +227,7 @@ din {
         # Beacon Chain (REST API)
         ethereum-beacon {
             handler beacon-chain
-            chain_id beacon:mainnet
+            chain_id mainnet
             healthcheck_endpoint "/eth/v1/beacon/headers/head"
             providers {
                 https://beacon-api.example.com {

--- a/docs/providers/edge.md
+++ b/docs/providers/edge.md
@@ -22,7 +22,7 @@ A minimal Caddyfile for DIN Edge configuration looks like this:
 						http://10.0.0.32:3000/API_KEY
 						http://10.0.0.34:6000/ALTERNATIVE_API_KEY
 					}
-					chain_id eip155:0xNetworkChainID
+					chain_id 0xNetworkChainID
 				}
 				another-network {
 					providers {
@@ -34,7 +34,7 @@ A minimal Caddyfile for DIN Edge configuration looks like this:
 						http://10.0.0.55:8545
 						http://10.0.0.56:8545
 					}
-					chain_id eip155:0xAnotherNetworkChainID
+					chain_id 0xAnotherNetworkChainID
 				}
 			}
 		}
@@ -84,7 +84,7 @@ din {
 				http://10.0.0.32:3000/API_KEY
 				http://10.0.0.34:6000/ALTERNATIVE_API_KEY
 			}
-			chain_id eip155:0xNetworkChainID
+			chain_id 0xNetworkChainID
 		}
 		another-network {
 			providers {
@@ -96,7 +96,7 @@ din {
 				http://10.0.0.55:8545
 				http://10.0.0.56:8545
 			}
-			chain_id eip155:0xAnotherNetworkChainID
+			chain_id 0xAnotherNetworkChainID
 		}
 	}
 }

--- a/docs/providers/sidecar.md
+++ b/docs/providers/sidecar.md
@@ -21,7 +21,7 @@ A minimal Caddyfile for DIN Sidecar configuration looks like this:
 					providers {
 						http://localhost:8545
 					}
-                    chain_id eip155:0xNetworkChainID
+                    chain_id 0xNetworkChainID
 				}
 			}
 		}
@@ -70,7 +70,7 @@ din {
             providers {
                 http://localhost:8545
             }
-            chain_id eip155:0xNetworkChainID
+            chain_id 0xNetworkChainID
         }
     }
 }

--- a/lib/network/beacon_handler.go
+++ b/lib/network/beacon_handler.go
@@ -424,22 +424,46 @@ func (h *BeaconChainHandler) ParseChainIDResponse(body []byte, statusCode int) (
 		return "", fmt.Errorf("HTTP error: %d", statusCode)
 	}
 
-	// Parse the config/spec response
+	// First try to parse as the standard format with data as a map
 	var specResponse struct {
 		Data map[string]string `json:"data"`
 	}
 
-	if err := json.Unmarshal(body, &specResponse); err != nil {
+	if err := json.Unmarshal(body, &specResponse); err == nil && specResponse.Data != nil {
+		// Extract DEPOSIT_CHAIN_ID which is the actual Ethereum chain ID
+		chainID, exists := specResponse.Data["DEPOSIT_CHAIN_ID"]
+		if exists && chainID != "" {
+			return chainID, nil
+		}
+	}
+
+	// If that fails, try parsing as a generic interface to handle different response formats
+	var genericResponse map[string]interface{}
+	if err := json.Unmarshal(body, &genericResponse); err != nil {
 		return "", fmt.Errorf("failed to parse beacon config response: %w", err)
 	}
 
-	// Extract DEPOSIT_CHAIN_ID which is the actual Ethereum chain ID
-	chainID, exists := specResponse.Data["DEPOSIT_CHAIN_ID"]
+	// Check if data exists and what type it is
+	dataField, exists := genericResponse["data"]
 	if !exists {
-		return "", fmt.Errorf("DEPOSIT_CHAIN_ID not found in beacon config response")
+		return "", fmt.Errorf("data field not found in beacon config response")
 	}
 
-	return chainID, nil
+	// Handle data as a map (standard format)
+	if dataMap, ok := dataField.(map[string]interface{}); ok {
+		if chainIDValue, exists := dataMap["DEPOSIT_CHAIN_ID"]; exists {
+			if chainID, ok := chainIDValue.(string); ok && chainID != "" {
+				return chainID, nil
+			}
+			// Handle case where DEPOSIT_CHAIN_ID might be a number
+			if chainIDNum, ok := chainIDValue.(float64); ok {
+				return fmt.Sprintf("%d", int64(chainIDNum)), nil
+			}
+		}
+	}
+
+	// If data is an array or other format, return a more helpful error
+	return "", fmt.Errorf("DEPOSIT_CHAIN_ID not found in beacon config response (data type: %T)", dataField)
 }
 
 // GetChainID retrieves the chain ID for beacon chain

--- a/lib/network/beacon_handler.go
+++ b/lib/network/beacon_handler.go
@@ -193,33 +193,23 @@ func (h *BeaconChainHandler) GetNamespace() string {
 }
 
 func (h *BeaconChainHandler) ValidateChainID(chainID string) error {
-	// Beacon chain uses the same chain ID format as Ethereum mainnet
-	if !strings.HasPrefix(chainID, "beacon:") {
-		return fmt.Errorf("invalid Beacon Chain chain ID format: %s, expected format: beacon:{chainId}", chainID)
+	// Fail if there's a colon (old CAIP-2 format)
+	if strings.Contains(chainID, ":") {
+		return fmt.Errorf("invalid Beacon Chain chain ID format: %s, chain ID should not contain ':' (CAIP-2 prefix no longer required)", chainID)
 	}
 
-	// Extract chain ID number and validate it's numeric
-	parts := strings.Split(chainID, ":")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid Beacon Chain chain ID format: %s", chainID)
-	}
-
-	chainIDNum := parts[1]
-	if chainIDNum == "" {
-		return fmt.Errorf("empty chain ID number in: %s", chainID)
+	if chainID == "" {
+		return fmt.Errorf("empty chain ID")
 	}
 
 	// Convert to ensure it's a valid number
-	if _, err := strconv.ParseInt(chainIDNum, 10, 64); err != nil {
-		return fmt.Errorf("invalid chain ID number in %s: %w", chainID, err)
+	if _, err := strconv.ParseInt(chainID, 10, 64); err != nil {
+		return fmt.Errorf("invalid chain ID number %s: %w", chainID, err)
 	}
 
 	return nil
 }
 
-func (h *BeaconChainHandler) FormatChainID(networkReference string) string {
-	return h.GetNamespace() + ":" + networkReference
-}
 
 func (h *BeaconChainHandler) ExtractChainReference(result interface{}) (string, error) {
 	// For beacon chain, we extract chain reference from genesis response
@@ -449,7 +439,7 @@ func (h *BeaconChainHandler) ParseChainIDResponse(body []byte, statusCode int) (
 		return "", fmt.Errorf("DEPOSIT_CHAIN_ID not found in beacon config response")
 	}
 
-	return h.FormatChainID(chainID), nil
+	return chainID, nil
 }
 
 // GetChainID retrieves the chain ID for beacon chain

--- a/lib/network/beacon_handler_test.go
+++ b/lib/network/beacon_handler_test.go
@@ -50,32 +50,37 @@ func TestBeaconChainHandler_ValidateChainID(t *testing.T) {
 	}{
 		{
 			name:      "valid mainnet chain ID",
-			chainID:   "beacon:1",
+			chainID:   "1",
 			shouldErr: false,
 		},
 		{
 			name:      "valid sepolia chain ID",
-			chainID:   "beacon:11155111",
+			chainID:   "11155111",
 			shouldErr: false,
 		},
 		{
 			name:      "valid goerli chain ID",
-			chainID:   "beacon:5",
+			chainID:   "5",
 			shouldErr: false,
 		},
 		{
-			name:      "invalid prefix",
+			name:      "invalid - contains colon (old CAIP-2 format)",
+			chainID:   "beacon:1",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid - contains colon with different prefix",
 			chainID:   "starknet:0x1",
 			shouldErr: true,
 		},
 		{
-			name:      "missing colon",
-			chainID:   "eip1551",
+			name:      "invalid - not a number",
+			chainID:   "abc",
 			shouldErr: true,
 		},
 		{
-			name:      "empty chain reference",
-			chainID:   "eip155:",
+			name:      "empty chain ID",
+			chainID:   "",
 			shouldErr: true,
 		},
 	}
@@ -93,40 +98,6 @@ func TestBeaconChainHandler_ValidateChainID(t *testing.T) {
 	}
 }
 
-func TestBeaconChainHandler_FormatChainID(t *testing.T) {
-	handler := NewBeaconChainHandler(&NetworkConfig{})
-
-	tests := []struct {
-		name             string
-		networkReference string
-		expected         string
-	}{
-		{
-			name:             "mainnet",
-			networkReference: "1",
-			expected:         "beacon:1",
-		},
-		{
-			name:             "sepolia",
-			networkReference: "11155111",
-			expected:         "beacon:11155111",
-		},
-		{
-			name:             "goerli",
-			networkReference: "5",
-			expected:         "beacon:5",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := handler.FormatChainID(tt.networkReference)
-			if result != tt.expected {
-				t.Errorf("FormatChainID(%s) = %s, expected %s", tt.networkReference, result, tt.expected)
-			}
-		})
-	}
-}
 
 func TestBeaconChainHandler_ExtractChainReference(t *testing.T) {
 	handler := NewBeaconChainHandler(&NetworkConfig{})
@@ -800,8 +771,8 @@ func TestBeaconChainHandler_ParseChainIDResponse_RealData(t *testing.T) {
 			t.Fatalf("Expected no error parsing real config data, got: %v", err)
 		}
 
-		// Should format as beacon:1 for mainnet
-		expectedChainID := "beacon:1"
+		// Should return just "1" for mainnet (no prefix)
+		expectedChainID := "1"
 		if chainID != expectedChainID {
 			t.Errorf("Expected chain ID %s, got %s", expectedChainID, chainID)
 		}

--- a/lib/network/evm_handler.go
+++ b/lib/network/evm_handler.go
@@ -167,37 +167,29 @@ func (h *EVMHandler) GetNamespace() string {
 }
 
 func (h *EVMHandler) ValidateChainID(chainID string) error {
-	if !strings.HasPrefix(chainID, "eip155:") {
-		return fmt.Errorf("invalid EVM chain ID format: %s, expected format: eip155:{chainId}", chainID)
+	// Fail if there's a colon (old CAIP-2 format)
+	if strings.Contains(chainID, ":") {
+		return fmt.Errorf("invalid EVM chain ID format: %s, chain ID should not contain ':' (CAIP-2 prefix no longer required)", chainID)
 	}
 
-	// Extract chain ID number and validate it's numeric
-	parts := strings.Split(chainID, ":")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid EVM chain ID format: %s", chainID)
-	}
-
-	chainIDNum := parts[1]
-	if chainIDNum == "" {
-		return fmt.Errorf("empty chain ID number in: %s", chainID)
+	if chainID == "" {
+		return fmt.Errorf("empty chain ID")
 	}
 
 	// Remove 0x prefix if present and validate hex
+	chainIDNum := chainID
 	if strings.HasPrefix(chainIDNum, "0x") {
 		chainIDNum = strings.TrimPrefix(chainIDNum, "0x")
 	}
 
 	// Convert to ensure it's a valid number
 	if _, err := strconv.ParseInt(chainIDNum, 16, 64); err != nil {
-		return fmt.Errorf("invalid chain ID number in %s: %w", chainID, err)
+		return fmt.Errorf("invalid chain ID number %s: %w", chainID, err)
 	}
 
 	return nil
 }
 
-func (h *EVMHandler) FormatChainID(networkReference string) string {
-	return "eip155:" + networkReference
-}
 
 func (h *EVMHandler) ExtractChainReference(result interface{}) (string, error) {
 	chainRef, ok := result.(string)
@@ -417,13 +409,13 @@ func (h *EVMHandler) ParseChainIDResponse(body []byte, statusCode int) (string, 
 		return "", fmt.Errorf("missing result field in chain ID response")
 	}
 
-	// Extract chain reference and format full chain ID
+	// Extract chain reference (already in correct format without prefix)
 	chainReference, err := h.ExtractChainReference(result)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract chain reference: %w", err)
 	}
 
-	return h.FormatChainID(chainReference), nil
+	return chainReference, nil
 }
 
 // GetLatestBlockNumber retrieves the latest block number for EVM chains

--- a/lib/network/evm_handler.go
+++ b/lib/network/evm_handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	"go.uber.org/zap"
 )
 
 // EVMHandler handles EVM-compatible JSON-RPC networks
@@ -167,29 +168,47 @@ func (h *EVMHandler) GetNamespace() string {
 }
 
 func (h *EVMHandler) ValidateChainID(chainID string) error {
-	// Fail if there's a colon (old CAIP-2 format)
-	if strings.Contains(chainID, ":") {
-		return fmt.Errorf("invalid EVM chain ID format: %s, chain ID should not contain ':' (CAIP-2 prefix no longer required)", chainID)
-	}
-
 	if chainID == "" {
 		return fmt.Errorf("empty chain ID")
 	}
 
-	// Remove 0x prefix if present and validate hex
-	chainIDNum := chainID
+	// Support both formats for backwards compatibility
+	actualChainID := chainID
+	
+	// If it contains a colon, it might be CAIP-2 format
+	if strings.Contains(chainID, ":") {
+		parts := strings.Split(chainID, ":")
+		if len(parts) == 2 && parts[0] == "eip155" {
+			// Valid CAIP-2 format for EVM, extract the actual chain ID
+			actualChainID = parts[1]
+			// Log that we're using backwards compatibility
+			if h.logger != nil {
+				h.logger.Debug("Using CAIP-2 format for backwards compatibility",
+					zap.String("original", chainID),
+					zap.String("extracted", actualChainID))
+			}
+		} else {
+			// Invalid format
+			return fmt.Errorf("invalid EVM chain ID format: %s, expected format 'eip155:chainID' or just 'chainID'", chainID)
+		}
+	}
+
+	// Validate the actual chain ID (with or without 0x prefix)
+	chainIDNum := actualChainID
 	if strings.HasPrefix(chainIDNum, "0x") {
 		chainIDNum = strings.TrimPrefix(chainIDNum, "0x")
 	}
 
 	// Convert to ensure it's a valid number
 	if _, err := strconv.ParseInt(chainIDNum, 16, 64); err != nil {
-		return fmt.Errorf("invalid chain ID number %s: %w", chainID, err)
+		// Try decimal format as well
+		if _, err := strconv.ParseInt(actualChainID, 10, 64); err != nil {
+			return fmt.Errorf("invalid chain ID number %s: must be hex (0x...) or decimal", actualChainID)
+		}
 	}
 
 	return nil
 }
-
 
 func (h *EVMHandler) ExtractChainReference(result interface{}) (string, error) {
 	chainRef, ok := result.(string)

--- a/lib/network/evm_handler_test.go
+++ b/lib/network/evm_handler_test.go
@@ -68,13 +68,23 @@ func TestEVMHandler_ValidateChainID(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:      "invalid - contains colon (old CAIP-2 format)",
+			name:      "valid - CAIP-2 format supported for backwards compatibility",
 			chainID:   "eip155:1",
-			shouldErr: true,
+			shouldErr: false,
+		},
+		{
+			name:      "valid - CAIP-2 format with hex",
+			chainID:   "eip155:0x1",
+			shouldErr: false,
 		},
 		{
 			name:      "invalid - contains colon with different prefix",
 			chainID:   "starknet:0x1",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid - wrong CAIP-2 prefix for EVM",
+			chainID:   "solana:0x1",
 			shouldErr: true,
 		},
 		{

--- a/lib/network/evm_handler_test.go
+++ b/lib/network/evm_handler_test.go
@@ -48,33 +48,38 @@ func TestEVMHandler_ValidateChainID(t *testing.T) {
 		shouldErr bool
 	}{
 		{
-			name:      "valid mainnet chain ID",
-			chainID:   "eip155:1",
+			name:      "valid mainnet chain ID decimal",
+			chainID:   "1",
+			shouldErr: false,
+		},
+		{
+			name:      "valid mainnet chain ID hex",
+			chainID:   "0x1",
 			shouldErr: false,
 		},
 		{
 			name:      "valid polygon chain ID",
-			chainID:   "eip155:137",
+			chainID:   "0x89",
 			shouldErr: false,
 		},
 		{
 			name:      "valid arbitrum chain ID",
-			chainID:   "eip155:42161",
+			chainID:   "0xa4b1",
 			shouldErr: false,
 		},
 		{
-			name:      "invalid prefix",
+			name:      "invalid - contains colon (old CAIP-2 format)",
+			chainID:   "eip155:1",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid - contains colon with different prefix",
 			chainID:   "starknet:0x1",
 			shouldErr: true,
 		},
 		{
-			name:      "missing colon",
-			chainID:   "eip1551",
-			shouldErr: true,
-		},
-		{
-			name:      "empty chain reference",
-			chainID:   "eip155:",
+			name:      "empty chain ID",
+			chainID:   "",
 			shouldErr: true,
 		},
 	}
@@ -92,40 +97,6 @@ func TestEVMHandler_ValidateChainID(t *testing.T) {
 	}
 }
 
-func TestEVMHandler_FormatChainID(t *testing.T) {
-	handler := NewEVMHandler(&NetworkConfig{})
-
-	tests := []struct {
-		name             string
-		networkReference string
-		expected         string
-	}{
-		{
-			name:             "mainnet",
-			networkReference: "1",
-			expected:         "eip155:1",
-		},
-		{
-			name:             "polygon",
-			networkReference: "137",
-			expected:         "eip155:137",
-		},
-		{
-			name:             "arbitrum",
-			networkReference: "42161",
-			expected:         "eip155:42161",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := handler.FormatChainID(tt.networkReference)
-			if result != tt.expected {
-				t.Errorf("FormatChainID(%s) = %s, expected %s", tt.networkReference, result, tt.expected)
-			}
-		})
-	}
-}
 
 func TestEVMHandler_ExtractChainReference(t *testing.T) {
 	handler := NewEVMHandler(&NetworkConfig{})

--- a/lib/network/handler_test.go
+++ b/lib/network/handler_test.go
@@ -77,9 +77,6 @@ func (m *MockHandler) GetChainID(httpUrl string, headers map[string]string, http
 	return "mock:1", nil
 }
 
-func (m *MockHandler) FormatChainID(networkReference string) string {
-	return "mock:" + networkReference
-}
 
 func (m *MockHandler) ExtractChainReference(result interface{}) (string, error) {
 	return "mockchain", nil

--- a/lib/network/solana_handler.go
+++ b/lib/network/solana_handler.go
@@ -48,11 +48,11 @@ func (h *SolanaHandler) GetRequestType() RequestType {
 // Lifecycle methods
 func (h *SolanaHandler) Initialize(config *NetworkConfig) error {
 	h.config = config
-	
+
 	if config.Logger != nil {
 		h.logger = config.Logger
 	}
-	
+
 	return nil
 }
 
@@ -67,7 +67,7 @@ func (h *SolanaHandler) ProcessRequest(req *http.Request) error {
 	if err := h.ValidateRequest(req); err != nil {
 		return err
 	}
-	
+
 	// Path translation is handled in DinSelect module
 	return nil
 }
@@ -77,16 +77,16 @@ func (h *SolanaHandler) ExtractMethod(req *http.Request, body []byte) (string, e
 	if len(body) == 0 {
 		return "", fmt.Errorf("empty request body")
 	}
-	
+
 	var rpcRequest din_http.JSONRPCRequest
 	if err := json.Unmarshal(body, &rpcRequest); err != nil {
 		return "", fmt.Errorf("failed to parse JSON-RPC request: %w", err)
 	}
-	
+
 	if rpcRequest.Method == "" {
 		return "", fmt.Errorf("missing method in JSON-RPC request")
 	}
-	
+
 	return rpcRequest.Method, nil
 }
 
@@ -129,32 +129,21 @@ func (h *SolanaHandler) GetNamespace() string {
 }
 
 func (h *SolanaHandler) ValidateChainID(chainID string) error {
-	// Solana chain IDs are in format: solana:base58_encoded_genesis_hash
-	if !strings.HasPrefix(chainID, "solana:") {
-		return fmt.Errorf("invalid Solana chain ID format: %s, expected format: solana:{base58_hash}", chainID)
+	// Fail if there's a colon (old CAIP-2 format)
+	if strings.Contains(chainID, ":") {
+		return fmt.Errorf("invalid Solana chain ID format: %s, chain ID should not contain ':' (CAIP-2 prefix no longer required)", chainID)
 	}
 
-	// Extract the genesis hash part
-	parts := strings.Split(chainID, ":")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid Solana chain ID format: %s", chainID)
-	}
-
-	genesisHash := parts[1]
-	if len(genesisHash) == 0 {
-		return fmt.Errorf("empty genesis hash in Solana chain ID: %s", chainID)
+	if len(chainID) == 0 {
+		return fmt.Errorf("empty chain ID")
 	}
 
 	// Basic validation - Solana genesis hashes are base58 encoded, typically 44 characters
-	if len(genesisHash) < 32 || len(genesisHash) > 50 {
-		return fmt.Errorf("invalid Solana genesis hash length: %s", genesisHash)
+	if len(chainID) < 32 || len(chainID) > 50 {
+		return fmt.Errorf("invalid Solana genesis hash length: %s", chainID)
 	}
 
 	return nil
-}
-
-func (h *SolanaHandler) FormatChainID(networkReference string) string {
-	return "solana:" + networkReference
 }
 
 func (h *SolanaHandler) ExtractChainReference(result interface{}) (string, error) {
@@ -369,13 +358,13 @@ func (h *SolanaHandler) ParseChainIDResponse(body []byte, statusCode int) (strin
 		return "", fmt.Errorf("missing result field in chain ID response")
 	}
 
-	// Extract chain reference and format full chain ID
+	// Extract chain reference (already in correct format without prefix)
 	chainReference, err := h.ExtractChainReference(result)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract chain reference: %w", err)
 	}
 
-	return h.FormatChainID(chainReference), nil
+	return chainReference, nil
 }
 
 // GetLatestBlockNumber retrieves the latest block number for Solana chains

--- a/lib/network/solana_handler_test.go
+++ b/lib/network/solana_handler_test.go
@@ -40,32 +40,32 @@ func TestSolanaHandler_ValidateChainID(t *testing.T) {
 	}{
 		{
 			name:    "valid_mainnet",
-			chainID: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+			chainID: "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
 			valid:   true,
 		},
 		{
 			name:    "valid_devnet",
-			chainID: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
+			chainID: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
 			valid:   true,
 		},
 		{
-			name:    "invalid_prefix",
+			name:    "invalid - contains colon (old CAIP-2 format)",
+			chainID: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+			valid:   false,
+		},
+		{
+			name:    "invalid - contains colon with different prefix",
 			chainID: "ethereum:0x1",
 			valid:   false,
 		},
 		{
-			name:    "invalid_format",
-			chainID: "solana",
-			valid:   false,
-		},
-		{
-			name:    "empty_hash",
-			chainID: "solana:",
+			name:    "empty chain ID",
+			chainID: "",
 			valid:   false,
 		},
 		{
 			name:    "hash_too_short",
-			chainID: "solana:abc123",
+			chainID: "abc123",
 			valid:   false,
 		},
 	}

--- a/lib/network/starknet_handler.go
+++ b/lib/network/starknet_handler.go
@@ -128,22 +128,22 @@ func (h *StarknetHandler) GetNamespace() string {
 }
 
 func (h *StarknetHandler) ValidateChainID(chainID string) error {
-	// Starknet chain IDs have format: starknet:0x{hex}
+	// Starknet chain IDs are now just 0x{hex} without prefix
 	// Examples:
-	// - starknet:0x534e5f4d41494e (mainnet)
-	// - starknet:0x534e5f5345504f4c4941 (sepolia)
+	// - 0x534e5f4d41494e (mainnet)
+	// - 0x534e5f5345504f4c4941 (sepolia)
 
-	if !strings.HasPrefix(chainID, "starknet:") {
-		return fmt.Errorf("invalid Starknet chain ID format: %s, expected format: starknet:0x{hex}", chainID)
+	// Fail if there's a colon (old CAIP-2 format)
+	if strings.Contains(chainID, ":") {
+		return fmt.Errorf("invalid Starknet chain ID format: %s, chain ID should not contain ':' (CAIP-2 prefix no longer required)", chainID)
 	}
 
-	hexPart := strings.TrimPrefix(chainID, "starknet:")
-	if !strings.HasPrefix(hexPart, "0x") {
-		return fmt.Errorf("invalid Starknet chain ID hex format: %s", chainID)
+	if !strings.HasPrefix(chainID, "0x") {
+		return fmt.Errorf("invalid Starknet chain ID format: %s, expected format: 0x{hex}", chainID)
 	}
 
 	// Validate hex format
-	hexDigits := strings.TrimPrefix(hexPart, "0x")
+	hexDigits := strings.TrimPrefix(chainID, "0x")
 	if len(hexDigits) == 0 {
 		return fmt.Errorf("empty hex part in Starknet chain ID: %s", chainID)
 	}
@@ -160,9 +160,6 @@ func (h *StarknetHandler) ValidateChainID(chainID string) error {
 	return nil
 }
 
-func (h *StarknetHandler) FormatChainID(networkReference string) string {
-	return "starknet:" + networkReference
-}
 
 func (h *StarknetHandler) ExtractChainReference(result interface{}) (string, error) {
 	chainRef, ok := result.(string)
@@ -405,13 +402,13 @@ func (h *StarknetHandler) ParseChainIDResponse(body []byte, statusCode int) (str
 		return "", fmt.Errorf("missing result field in chain ID response")
 	}
 
-	// Extract chain reference and format full chain ID
+	// Extract chain reference (already in correct format without prefix)
 	chainReference, err := h.ExtractChainReference(result)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract chain reference: %w", err)
 	}
 
-	return h.FormatChainID(chainReference), nil
+	return chainReference, nil
 }
 
 // GetLatestBlockNumber retrieves the latest block number for Starknet chains

--- a/lib/network/starknet_handler_test.go
+++ b/lib/network/starknet_handler_test.go
@@ -39,37 +39,42 @@ func TestStarknetHandler_ValidateChainID(t *testing.T) {
 	}{
 		{
 			name:      "valid mainnet chain ID",
-			chainID:   "starknet:0x534e5f4d41494e",
+			chainID:   "0x534e5f4d41494e",
 			shouldErr: false,
 		},
 		{
 			name:      "valid sepolia chain ID",
-			chainID:   "starknet:0x534e5f5345504f4c4941",
+			chainID:   "0x534e5f5345504f4c4941",
 			shouldErr: false,
 		},
 		{
-			name:      "invalid prefix",
+			name:      "invalid - contains colon (old CAIP-2 format)",
+			chainID:   "starknet:0x534e5f4d41494e",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid - contains colon with different prefix",
 			chainID:   "ethereum:0x1",
 			shouldErr: true,
 		},
 		{
 			name:      "missing 0x prefix",
-			chainID:   "starknet:534e5f4d41494e",
+			chainID:   "534e5f4d41494e",
 			shouldErr: true,
 		},
 		{
 			name:      "empty hex part",
-			chainID:   "starknet:0x",
+			chainID:   "0x",
 			shouldErr: true,
 		},
 		{
 			name:      "invalid hex characters",
-			chainID:   "starknet:0xghi",
+			chainID:   "0xghi",
 			shouldErr: true,
 		},
 		{
 			name:      "uppercase hex",
-			chainID:   "starknet:0x534E5F4D41494E",
+			chainID:   "0x534E5F4D41494E",
 			shouldErr: false,
 		},
 	}

--- a/modules/din_middleware_test.go
+++ b/modules/din_middleware_test.go
@@ -384,7 +384,7 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 							priority 2
 						}
 					}
-					chain_id eip155:0x1
+					chain_id 0x1
 					healthcheck_threshold 2
 					healthcheck_interval 5
 					healthcheck_blocklag_limit 10

--- a/modules/handler_set_test.go
+++ b/modules/handler_set_test.go
@@ -25,7 +25,7 @@ func TestHandlerSetOnce(t *testing.T) {
 	// Simulate Caddyfile parsing
 	caddyfileContent := `networks {
 		ethereum-mainnet {
-			chain_id "eip155:0x1"
+			chain_id "0x1"
 			handler evm
 			providers {
 				http://localhost:8545
@@ -67,7 +67,7 @@ func TestHandlerSetForJSONLoadedConfig(t *testing.T) {
 	network := &network{
 		Name:        "ethereum-mainnet",
 		HandlerType: EVMHandler,
-		ChainId:     "eip155:0x1",
+		ChainId:     "0x1",
 		Providers: map[string]*provider{
 			"localhost:8545": {
 				HttpUrl: "http://localhost:8545",

--- a/modules/network_evaluate_health_test.go
+++ b/modules/network_evaluate_health_test.go
@@ -153,7 +153,7 @@ func TestEvaluateProviderHealth(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Configure network
-			n.ChainId = "eip155:1"
+			n.ChainId = "0x1"
 			n.BlockLagLimit = tt.networkConfig.blockLagLimit
 			n.BlockJumpLimit = tt.networkConfig.blockJumpLimit
 			n.ProviderBlockHistorySize = 5
@@ -192,12 +192,12 @@ func TestEvaluateProviderHealth(t *testing.T) {
 			// Setup mocks for chain ID validation
 			if tt.chainIDValid {
 				mockHandler.EXPECT().GetChainID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return("eip155:1", nil).AnyTimes()
-				mockHandler.EXPECT().ValidateChainID("eip155:1").Return(nil).AnyTimes()
+					Return("0x1", nil).AnyTimes()
+				mockHandler.EXPECT().ValidateChainID("0x1").Return(nil).AnyTimes()
 			} else {
 				mockHandler.EXPECT().GetChainID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return("eip155:5", nil).AnyTimes()
-				mockHandler.EXPECT().ValidateChainID("eip155:5").Return(errors.New("invalid chain ID")).AnyTimes()
+					Return("0x5", nil).AnyTimes()
+				mockHandler.EXPECT().ValidateChainID("0x5").Return(errors.New("invalid chain ID")).AnyTimes()
 			}
 
 			// Setup mocks for archive mode

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -338,7 +338,7 @@ func TestProcessBlockNumberResponse(t *testing.T) {
 			config := &networklib.NetworkConfig{
 				Name:    "test",
 				Type:    string(EVMHandler),
-				ChainID: "eip155:1",
+				ChainID: "1",
 			}
 			n.SetHandler(networklib.NewEVMHandler(config))
 			
@@ -645,7 +645,7 @@ func TestBlockJumpBehavior(t *testing.T) {
 			assert.NoError(t, err)
 			n.BlockJumpLimit = tt.blockJumpLimit
 			n.Providers = make(map[string]*provider)
-			n.ChainId = "eip155:0x1" // Set expected chain ID to match mock response
+			n.ChainId = "0x1" // Set expected chain ID to match mock response
 
 			// Initialize logger to prevent panic
 			n.logger = logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
@@ -1227,7 +1227,7 @@ func TestNetwork_processBlockNumberResponse(t *testing.T) {
 			config := &networklib.NetworkConfig{
 				Name:    "test",
 				Type:    string(EVMHandler),
-				ChainID: "eip155:1",
+				ChainID: "1",
 			}
 			n.SetHandler(networklib.NewEVMHandler(config))
 

--- a/modules/rest_middleware_flow_test.go
+++ b/modules/rest_middleware_flow_test.go
@@ -136,7 +136,7 @@ func TestRESTAPIMiddlewareIntegration(t *testing.T) {
 					tt.networkName: {
 						Name:    tt.networkName,
 						HandlerType: HandlerType(tt.networkType),
-						ChainId: "beacon:1",
+						ChainId: "1",
 						Providers: map[string]*provider{
 							"test-provider": {
 								HttpUrl:  "http://test-provider",
@@ -305,7 +305,7 @@ func TestRESTAPIMiddlewareErrorHandling(t *testing.T) {
 				network := &network{
 					Name:    tt.networkName,
 					HandlerType: HandlerType(tt.networkType),
-					ChainId: "beacon:1",
+					ChainId: "1",
 					Providers: map[string]*provider{
 						"test-provider": {
 							HttpUrl: "http://test-provider",
@@ -390,7 +390,7 @@ func TestRESTAPIProviderSelection(t *testing.T) {
 			"beacon": {
 				Name:    "beacon",
 				HandlerType: BeaconHandler,
-				ChainId: "beacon:1",
+				ChainId: "1",
 				Providers: map[string]*provider{
 					"provider1": {
 						HttpUrl:  "http://provider1",
@@ -469,7 +469,7 @@ func TestMiddlewareRESTFlow(t *testing.T) {
 			network: &network{
 				Name:                    "ethereum-beacon",
 				HandlerType:             BeaconHandler,
-				ChainId:                 "beacon:1",
+				ChainId:                 "1",
 				MaxRequestPayloadSizeKB: DefaultMaxRequestPayloadSizeKB,
 			},
 			requestPath:        "/ethereum-beacon/eth/v1/beacon/genesis",
@@ -495,7 +495,7 @@ func TestMiddlewareRESTFlow(t *testing.T) {
 			network: &network{
 				Name:                    "beacon",
 				HandlerType:             BeaconHandler,
-				ChainId:                 "beacon:1",
+				ChainId:                 "1",
 				MaxRequestPayloadSizeKB: DefaultMaxRequestPayloadSizeKB,
 			},
 			requestPath:        "/beacon/eth/v1/beacon/pool/attestations",
@@ -518,7 +518,7 @@ func TestMiddlewareRESTFlow(t *testing.T) {
 			network: &network{
 				Name:                    "ethereum",
 				HandlerType:             EVMHandler,
-				ChainId:                 "eip155:0x1",
+				ChainId:                 "0x1",
 				MaxRequestPayloadSizeKB: DefaultMaxRequestPayloadSizeKB,
 			},
 			requestPath:        "/ethereum",
@@ -542,7 +542,7 @@ func TestMiddlewareRESTFlow(t *testing.T) {
 			network: &network{
 				Name:                    "beacon",
 				HandlerType:             BeaconHandler,
-				ChainId:                 "beacon:1",
+				ChainId:                 "1",
 				MaxRequestPayloadSizeKB: DefaultMaxRequestPayloadSizeKB,
 			},
 			requestPath:        "/beacon/eth/v1/beacon/states/head/validators?id=1,2,3&status=active",
@@ -560,7 +560,7 @@ func TestMiddlewareRESTFlow(t *testing.T) {
 			network: &network{
 				Name:                    "unknown",
 				HandlerType:             BeaconHandler,
-				ChainId:                 "beacon:1",
+				ChainId:                 "1",
 				MaxRequestPayloadSizeKB: DefaultMaxRequestPayloadSizeKB,
 			},
 			requestPath:        "/different-network/eth/v1/beacon/genesis",
@@ -573,7 +573,7 @@ func TestMiddlewareRESTFlow(t *testing.T) {
 			network: &network{
 				Name:                    "beacon",
 				HandlerType:             BeaconHandler,
-				ChainId:                 "beacon:1",
+				ChainId:                 "1",
 				MaxRequestPayloadSizeKB: 0, // 0 means 1KB limit
 			},
 			requestPath:        "/beacon/eth/v1/beacon/pool/attestations",
@@ -793,7 +793,7 @@ func TestMiddlewareRESTMetrics(t *testing.T) {
 			"beacon": {
 				Name:                    "beacon",
 				HandlerType:             BeaconHandler,
-				ChainId:                 "beacon:1",
+				ChainId:                 "1",
 				MaxRequestPayloadSizeKB: DefaultMaxRequestPayloadSizeKB,
 				Providers: map[string]*provider{
 					"test-provider": {
@@ -850,9 +850,9 @@ func TestMiddlewareRESTMetrics(t *testing.T) {
 func getValidChainIDForType(networkType string) string {
 	switch networkType {
 	case string(BeaconHandler):
-		return "beacon:1"
+		return "1"
 	case string(EVMHandler):
-		return "eip155:0x1"
+		return "0x1"
 	default:
 		return "unknown:1"
 	}


### PR DESCRIPTION
# Chain ID Migration Guide: Removing CAIP-2 Prefixes

## Overview

As of this update, the DIN Caddy plugins no longer require CAIP-2 format prefixes for chain IDs. This change simplifies configuration and removes redundancy since network types are now determined by explicit handler declarations.

## What Changed?

### Before (Old Format)
Chain IDs required CAIP-2 prefixes to identify the network type:
```
eip155:0x1      # Ethereum Mainnet
solana:5eykt... # Solana Mainnet  
starknet:0x534... # Starknet Mainnet
beacon:1        # Beacon Chain
```

### After (New Format)
Chain IDs now use their native format without prefixes:
```
0x1             # Ethereum Mainnet
5eykt...        # Solana Mainnet
0x534...        # Starknet Mainnet
1               # Beacon Chain
```

## Migration Steps

### 1. Update Your Caddyfile

#### EVM Networks (Ethereum, Polygon, Arbitrum, etc.)
**Old:**
```caddyfile
networks {
    eth {
        providers {
            https://eth-mainnet.example.com
        }
        chain_id eip155:0x1
    }
    polygon {
        providers {
            https://polygon-mainnet.example.com
        }
        chain_id eip155:0x89
    }
}
```

**New:**
```caddyfile
networks {
    eth {
        providers {
            https://eth-mainnet.example.com
        }
        chain_id 0x1
    }
    polygon {
        providers {
            https://polygon-mainnet.example.com
        }
        chain_id 0x89
    }
}
```

#### Solana Networks
**Old:**
```caddyfile
networks {
    solana-mainnet {
        handler solana
        providers {
            https://solana.example.com
        }
        chain_id solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
    }
}
```

**New:**
```caddyfile
networks {
    solana-mainnet {
        handler solana
        providers {
            https://solana.example.com
        }
        chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
    }
}
```

#### Starknet Networks
**Old:**
```caddyfile
networks {
    starknet-mainnet {
        handler starknet
        providers {
            https://starknet.example.com
        }
        chain_id starknet:0x534e5f4d41494e
    }
}
```

**New:**
```caddyfile
networks {
    starknet-mainnet {
        handler starknet
        providers {
            https://starknet.example.com
        }
        chain_id 0x534e5f4d41494e
    }
}
```

#### Beacon Chain
**Old:**
```caddyfile
networks {
    eth-beacon {
        handler beacon-chain
        providers {
            https://beacon.example.com
        }
        chain_id beacon:1
    }
}
```

**New:**
```caddyfile
networks {
    eth-beacon {
        handler beacon-chain
        providers {
            https://beacon.example.com
        }
        chain_id 1
    }
}
```

## Common Chain IDs Reference

### EVM Networks
| Network | Old Format | New Format |
|---------|------------|------------|
| Ethereum Mainnet | `eip155:0x1` | `0x1` |
| Ethereum Goerli | `eip155:0x5` | `0x5` |
| Ethereum Sepolia | `eip155:0xaa36a7` | `0xaa36a7` |
| Ethereum Holesky | `eip155:0x4268` | `0x4268` |
| Polygon Mainnet | `eip155:0x89` | `0x89` |
| Polygon Amoy | `eip155:0x13882` | `0x13882` |
| Arbitrum One | `eip155:0xa4b1` | `0xa4b1` |
| Arbitrum Sepolia | `eip155:0x66eee` | `0x66eee` |
| Optimism Mainnet | `eip155:0xa` | `0xa` |
| Optimism Sepolia | `eip155:0xaa37dc` | `0xaa37dc` |
| Base Mainnet | `eip155:0x2105` | `0x2105` |
| Base Sepolia | `eip155:0x14a34` | `0x14a34` |
| BSC Mainnet | `eip155:0x38` | `0x38` |
| BSC Testnet | `eip155:0x61` | `0x61` |
| Avalanche C-Chain | `eip155:0xa86a` | `0xa86a` |
| zkSync Era | `eip155:0x144` | `0x144` |
| zkSync Sepolia | `eip155:0x12c` | `0x12c` |
| Scroll Mainnet | `eip155:0x82750` | `0x82750` |
| Scroll Sepolia | `eip155:0x8274f` | `0x8274f` |
| Mantle Mainnet | `eip155:0x1388` | `0x1388` |
| Mantle Sepolia | `eip155:0x138b` | `0x138b` |
| Blast Mainnet | `eip155:0x13e31` | `0x13e31` |
| Blast Sepolia | `eip155:0xa0c71fd` | `0xa0c71fd` |

### Solana Networks
| Network | Old Format | New Format |
|---------|------------|------------|
| Solana Mainnet | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d` | `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d` |
| Solana Devnet | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG` | `EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG` |
| Solana Testnet | `solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY` | `4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY` |

### Starknet Networks
| Network | Old Format | New Format |
|---------|------------|------------|
| Starknet Mainnet | `starknet:0x534e5f4d41494e` | `0x534e5f4d41494e` |
| Starknet Sepolia | `starknet:0x534e5f5345504f4c4941` | `0x534e5f5345504f4c4941` |

### Beacon Chain
| Network | Old Format | New Format |
|---------|------------|------------|
| Ethereum Beacon Mainnet | `beacon:1` | `1` |
| Goerli Beacon | `beacon:5` | `5` |
| Sepolia Beacon | `beacon:11155111` | `11155111` |
| Holesky Beacon | `beacon:17000` | `17000` |

## Validation Changes

### What's Now Invalid
The system will now **reject** chain IDs containing colons (`:`):
- ❌ `eip155:0x1`
- ❌ `solana:5eykt...`
- ❌ `starknet:0x534...`
- ❌ `beacon:1`

Error message example:
```
invalid EVM chain ID format: eip155:0x1, chain ID should not contain ':' (CAIP-2 prefix no longer required)
```

### What's Valid
- ✅ Hex format for EVM: `0x1`, `0x89`, `0xa4b1`
- ✅ Decimal format for EVM: `1`, `137`, `42161`
- ✅ Base58 hashes for Solana: `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d`
- ✅ Hex format for Starknet: `0x534e5f4d41494e`
- ✅ Numeric format for Beacon: `1`, `5`, `11155111`

## Handler Types

Remember to explicitly set handler types for non-EVM networks:

```caddyfile
networks {
    # EVM networks - handler defaults to 'evm' if not specified
    ethereum {
        chain_id 0x1
        # handler evm  # Optional, this is the default
    }
    
    # Non-EVM networks - handler must be specified
    solana-mainnet {
        handler solana  # Required for Solana
        chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
    }
    
    starknet-mainnet {
        handler starknet  # Required for Starknet
        chain_id 0x534e5f4d41494e
    }
    
    eth-beacon {
        handler beacon-chain  # Required for Beacon Chain
        chain_id 1
    }
}
```

## Why This Change?

The CAIP-2 (Chain Agnostic Improvement Proposal 2) format was originally designed to provide a universal way to identify blockchain networks across different ecosystems. However, in our implementation:

1. **Handler Types Already Differentiate Networks**: Each network in the Caddyfile can explicitly declare its handler type (`handler evm`, `handler solana`, etc.), making the prefix redundant.

2. **Simplified Configuration**: Removing prefixes makes configuration files cleaner and easier to read.

3. **Native Format Alignment**: Chain IDs now match what the blockchains themselves use internally.

4. **Reduced Complexity**: One less thing to remember and one less place for typos.

## Troubleshooting

### Error: "chain ID should not contain ':'"
**Cause:** Your configuration still uses the old CAIP-2 format with prefixes.

**Solution:** Remove the prefix (everything before and including the colon) from your chain_id values.

### Error: "invalid chain ID format"
**Cause:** The chain ID format doesn't match what the handler expects.

**Solution:** Ensure you're using the correct format for your network type:
- EVM: Hex (`0x1`) or decimal (`1`)
- Solana: Base58 hash
- Starknet: Hex with `0x` prefix
- Beacon: Numeric

### Error: "no handler registered for network type"
**Cause:** The handler type isn't specified for a non-EVM network.

**Solution:** Add the appropriate handler declaration to your network configuration.

### Error: "failed to parse beacon config response"
**Cause:** The beacon API response format varies between providers.

**Solution:** The beacon handler has been updated to handle multiple response formats. Ensure you're using the latest version.

## Complete Migration Example

Here's a complete before/after example showing multiple network types:

**Before:**
```caddyfile
{
    admin :2019
}
:8000 {
    route /* {
        din {
            networks {
                eth {
                    providers {
                        https://eth-mainnet.example.com
                    }
                    chain_id eip155:0x1
                }
                polygon {
                    providers {
                        https://polygon-mainnet.example.com
                    }
                    chain_id eip155:0x89
                }
                solana-mainnet {
                    handler solana
                    providers {
                        https://solana-mainnet.example.com
                    }
                    chain_id solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
                }
                starknet-mainnet {
                    handler starknet
                    providers {
                        https://starknet-mainnet.example.com
                    }
                    chain_id starknet:0x534e5f4d41494e
                }
            }
        }
        reverse_proxy {
            lb_policy din_reverse_proxy_policy
            dynamic din_reverse_proxy_policy
        }
    }
}
```

**After:**
```caddyfile
{
    admin :2019
}
:8000 {
    route /* {
        din {
            networks {
                eth {
                    providers {
                        https://eth-mainnet.example.com
                    }
                    chain_id 0x1
                }
                polygon {
                    providers {
                        https://polygon-mainnet.example.com
                    }
                    chain_id 0x89
                }
                solana-mainnet {
                    handler solana
                    providers {
                        https://solana-mainnet.example.com
                    }
                    chain_id 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
                }
                starknet-mainnet {
                    handler starknet
                    providers {
                        https://starknet-mainnet.example.com
                    }
                    chain_id 0x534e5f4d41494e
                }
            }
        }
        reverse_proxy {
            lb_policy din_reverse_proxy_policy
            dynamic din_reverse_proxy_policy
        }
    }
}
```

## Benefits of This Change

1. **Simpler Configuration**: No need to remember CAIP-2 prefixes
2. **Clearer Intent**: Handler type explicitly declares the network type
3. **Reduced Errors**: Fewer chances for prefix typos
4. **Better Alignment**: Chain IDs now match their native blockchain format
5. **Easier Migration**: New networks can be added without worrying about prefix standards
6. **Improved Maintainability**: Less code complexity in validation logic

## Need Help?

If you encounter any issues during migration:
1. Check that all chain_id values have been updated
2. Verify handler types are set for non-EVM networks
3. Ensure your Caddy server has been restarted after configuration changes
4. Review the error logs for specific validation messages

For additional support, please open an issue on the [DIN Caddy Plugins GitHub repository](https://github.com/DIN-center/din-caddy-plugins/issues).