### PR TITLE
Add Bitcoin JSON-RPC Handler Support

### DIFF
--- a/lib/network/bitcoin_handler.go
+++ b/lib/network/bitcoin_handler.go
@@ -1,0 +1,521 @@
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth"
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+)
+
+type BitcoinHandler struct {
+	config  *NetworkConfig
+	version string
+	logger  *logger.LoggerClient
+}
+
+func NewBitcoinHandler(config *NetworkConfig) *BitcoinHandler {
+	return &BitcoinHandler{
+		config:  config,
+		version: "1.0.0",
+		logger:  config.Logger,
+	}
+}
+
+// Metadata methods for registry
+func (h *BitcoinHandler) GetType() string {
+	return "bitcoin" // Must match modules.BitcoinHandler constant value
+}
+
+func (h *BitcoinHandler) GetName() string {
+	return "Bitcoin JSON-RPC Handler"
+}
+
+func (h *BitcoinHandler) GetVersion() string {
+	return h.version
+}
+
+func (h *BitcoinHandler) GetRequestType() RequestType {
+	return RequestTypeRPC
+}
+
+// Lifecycle methods
+func (h *BitcoinHandler) Initialize(config *NetworkConfig) error {
+	h.config = config
+
+	if config.Logger != nil {
+		h.logger = config.Logger
+	}
+
+	return nil
+}
+
+func (h *BitcoinHandler) Shutdown() error {
+	return nil
+}
+
+// === EXISTING METHODS ===
+
+func (h *BitcoinHandler) ProcessRequest(req *http.Request) error {
+	// Validate the request using our validation logic
+	if err := h.ValidateRequest(req); err != nil {
+		return err
+	}
+
+	// Path translation is handled in DinSelect module
+	return nil
+}
+
+// ExtractMethod extracts the JSON-RPC method from the request body
+func (h *BitcoinHandler) ExtractMethod(req *http.Request, body []byte) (string, error) {
+	if len(body) == 0 {
+		return "", fmt.Errorf("empty request body")
+	}
+
+	var rpcRequest din_http.JSONRPCRequest
+	if err := json.Unmarshal(body, &rpcRequest); err != nil {
+		return "", fmt.Errorf("failed to parse JSON-RPC request: %w", err)
+	}
+
+	if rpcRequest.Method == "" {
+		return "", fmt.Errorf("missing method in JSON-RPC request")
+	}
+
+	return rpcRequest.Method, nil
+}
+
+// ConfigureRequestPath configures the request path for JSON-RPC requests
+func (h *BitcoinHandler) ConfigureRequestPath(req *http.Request, providerPath string, networkName string) error {
+	ConfigureJSONRPCRequestPath(req, providerPath)
+	return nil
+}
+
+func (h *BitcoinHandler) ValidateRequest(req *http.Request) error {
+	// Check content type
+	contentType := req.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		return fmt.Errorf("invalid content type for Bitcoin JSON-RPC: %s", contentType)
+	}
+
+	// Check method
+	if req.Method != "POST" {
+		return fmt.Errorf("bitcoin JSON-RPC requires POST method, got %s", req.Method)
+	}
+
+	return nil
+}
+
+func (h *BitcoinHandler) ParseResponse(body []byte, statusCode int) error {
+	// Use the shared JSON-RPC response parser
+	return ParseJSONRPCResponse(body, statusCode)
+}
+
+func (h *BitcoinHandler) IsRetryableError(err error, statusCode int) bool {
+	// Use the shared JSON-RPC error retry logic
+	return IsRetryableJSONRPCError(err, statusCode)
+}
+
+// === NEW NETWORK-SPECIFIC METHODS ===
+
+// Chain ID and Namespace methods
+func (h *BitcoinHandler) GetNamespace() string {
+	return "bitcoin"
+}
+
+func (h *BitcoinHandler) ValidateChainID(chainID string) error {
+	// Fail if there's a colon (old CAIP-2 format)
+	if strings.Contains(chainID, ":") {
+		return fmt.Errorf("invalid Bitcoin chain ID format: %s, chain ID should not contain ':' (CAIP-2 prefix no longer required)", chainID)
+	}
+
+	if len(chainID) == 0 {
+		return fmt.Errorf("empty chain ID")
+	}
+
+	// Valid chain IDs for Bitcoin
+	validChainIDs := map[string]bool{
+		"main":    true,
+		"test":    true,
+		"regtest": true,
+		"signet":  true,
+	}
+
+	if !validChainIDs[chainID] {
+		return fmt.Errorf("invalid Bitcoin chain ID: %s, expected one of: main, test, regtest, signet", chainID)
+	}
+
+	return nil
+}
+
+func (h *BitcoinHandler) ExtractChainReference(result interface{}) (string, error) {
+	// Bitcoin's getblockchaininfo returns an object with a "chain" field
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("invalid chain info response type: %T", result)
+	}
+
+	chain, ok := resultMap["chain"].(string)
+	if !ok {
+		return "", fmt.Errorf("missing or invalid chain field in response")
+	}
+
+	return chain, nil
+}
+
+// Block Operations methods
+func (h *BitcoinHandler) FormatBlockHeight(blockNum int64) string {
+	return strconv.FormatInt(blockNum, 10) // Decimal format for Bitcoin
+}
+
+func (h *BitcoinHandler) CreateBlockRequest(method string, blockNum int64, includeTransactions bool) ([]byte, error) {
+	// Bitcoin requires two-step process: getblockhash then getblock
+	// This method will be called twice in the process
+
+	switch method {
+	case "getblockhash":
+		// First step: get block hash from block number
+		payload := fmt.Sprintf(`{"jsonrpc":"2.0","method":"getblockhash","params":[%d],"id":1}`, blockNum)
+		return []byte(payload), nil
+	case "getblock":
+		// This will be handled by a separate method since we need the hash
+		return nil, fmt.Errorf("getblock requires block hash, use CreateBlockRequestWithHash")
+	default:
+		return nil, fmt.Errorf("unsupported method for block request: %s", method)
+	}
+}
+
+// CreateBlockRequestWithHash creates a getblock request with a block hash
+func (h *BitcoinHandler) CreateBlockRequestWithHash(blockHash string, includeTransactions bool) ([]byte, error) {
+	// verbosity: 0 = hex, 1 = JSON without tx details, 2 = JSON with tx details
+	verbosity := 1
+	if includeTransactions {
+		verbosity = 2
+	}
+
+	payload := fmt.Sprintf(`{"jsonrpc":"2.0","method":"getblock","params":["%s",%d],"id":1}`, blockHash, verbosity)
+	return []byte(payload), nil
+}
+
+func (h *BitcoinHandler) ParseBlockResponse(body []byte) (interface{}, error) {
+	// First check for JSON-RPC errors using generic response
+	var genericResponse din_http.JSONRPCResponse
+	if err := json.Unmarshal(body, &genericResponse); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON-RPC response: %w", err)
+	}
+
+	// Check for JSON-RPC errors in getBlock response
+	if genericResponse.Error != nil {
+		return nil, fmt.Errorf("bitcoin getBlock error: %s", genericResponse.Error.Message)
+	}
+
+	// Return the raw result for Bitcoin block
+	// The result structure will vary based on verbosity parameter
+	return genericResponse.Result, nil
+}
+
+// ParseBlockNumberResponse parses the block number from a raw response
+func (h *BitcoinHandler) ParseBlockNumberResponse(body []byte, statusCode int) (int64, error) {
+	// Check HTTP status first
+	if statusCode >= 400 {
+		if statusCode == 429 {
+			return 0, fmt.Errorf("rate limit error (status code: %d)", statusCode)
+		}
+		return 0, fmt.Errorf("error status code: %d", statusCode)
+	}
+
+	// Parse JSON-RPC response
+	var response JSONRPCResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return 0, fmt.Errorf("failed to parse JSON-RPC response: %w", err)
+	}
+
+	// Check for JSON-RPC error
+	if response.Error != nil {
+		return 0, fmt.Errorf("JSON-RPC error %d: %s", response.Error.Code, response.Error.Message)
+	}
+
+	// Bitcoin returns block numbers as numeric values
+	return ParseNumericBlockNumber(response.Result)
+}
+
+// RequiresSeparateBlockInfoCall returns false for Bitcoin as health check includes block info
+func (h *BitcoinHandler) RequiresSeparateBlockInfoCall() bool {
+	return false
+}
+
+// GetBlockInfoMethod returns empty for Bitcoin as it uses the same endpoint for health and block info
+func (h *BitcoinHandler) GetBlockInfoMethod() string {
+	return "" // Not used for JSON-RPC chains
+}
+
+// GetChainID retrieves the chain ID from the Bitcoin provider
+func (h *BitcoinHandler) GetChainID(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (string, error) {
+	// Use the shared JSON-RPC logic with Bitcoin-specific parsing
+	return GetChainIDViaJSONRPC(httpUrl, headers, httpClient, authClient, requestAttempts, h.GetChainIDMethod(), h.ParseChainIDResponse)
+}
+
+// Archive Mode methods
+func (h *BitcoinHandler) SupportsArchiveMode() bool {
+	return false // Bitcoin doesn't need special archive mode handling
+}
+
+func (h *BitcoinHandler) GetArchiveMethod() string {
+	return ""
+}
+
+func (h *BitcoinHandler) CreateArchivePayload(method string, blockHeight string) ([]byte, error) {
+	return nil, fmt.Errorf("bitcoin does not support archive mode")
+}
+
+func (h *BitcoinHandler) ParseArchiveResponse(body []byte) error {
+	return fmt.Errorf("bitcoin does not support archive mode")
+}
+
+// Network Capabilities methods
+func (h *BitcoinHandler) SupportsGetBlockByNumber() bool {
+	return true // Bitcoin supports it via two-step process
+}
+
+func (h *BitcoinHandler) GetSupportedMethods() []string {
+	return []string{
+		"getblockcount",
+		"getblockhash",
+		"getblock",
+		"getblockchaininfo",
+		"getbestblockhash",
+		"getdifficulty",
+		"getmempoolinfo",
+		"getrawmempool",
+		"getrawtransaction",
+		"sendrawtransaction",
+		"getnetworkinfo",
+		"getpeerinfo",
+		"getmininginfo",
+	}
+}
+
+func (h *BitcoinHandler) GetBlockByNumberMethod() string {
+	return "getblockhash" // First step in the two-step process
+}
+
+// Data Format Conversions methods
+func (h *BitcoinHandler) ExtractBlockHash(blockData interface{}) string {
+	// For Bitcoin, the block hash can be in the result directly (from getblockhash)
+	// or in the block object (from getblock)
+
+	// Check if it's a string (from getblockhash)
+	if hash, ok := blockData.(string); ok {
+		return hash
+	}
+
+	// Check if it's a block object (from getblock)
+	if blockMap, ok := blockData.(map[string]interface{}); ok {
+		if hash, ok := blockMap["hash"].(string); ok {
+			return hash
+		}
+	}
+
+	// Check if it's a RawMessage that needs parsing
+	if rawMsg, ok := blockData.(json.RawMessage); ok {
+		var hash string
+		if err := json.Unmarshal(rawMsg, &hash); err == nil {
+			return hash
+		}
+
+		var blockMap map[string]interface{}
+		if err := json.Unmarshal(rawMsg, &blockMap); err == nil {
+			if hash, ok := blockMap["hash"].(string); ok {
+				return hash
+			}
+		}
+	}
+
+	return ""
+}
+
+func (h *BitcoinHandler) ExtractBlockNumber(response []byte) (int64, error) {
+	var respObject map[string]interface{}
+	if err := json.Unmarshal(response, &respObject); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	result, ok := respObject["result"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("invalid Bitcoin block count response format")
+	}
+
+	return int64(result), nil
+}
+
+// Health Check Specifics methods
+func (h *BitcoinHandler) GetHealthCheckMethod() string {
+	return "getblockcount" // Returns the current block height
+}
+
+func (h *BitcoinHandler) GetHealthCheckHTTPMethod() string {
+	return "POST" // Bitcoin uses JSON-RPC POST requests
+}
+
+func (h *BitcoinHandler) GetChainIDMethod() string {
+	return "getblockchaininfo" // Returns chain info including chain name
+}
+
+func (h *BitcoinHandler) CreateHealthCheckPayload(method string) ([]byte, error) {
+	payload := fmt.Sprintf(`{"jsonrpc":"2.0","method":"%s","id":1}`, method)
+	return []byte(payload), nil
+}
+
+func (h *BitcoinHandler) ParseHealthCheckResponse(body []byte) (*BlockInfo, error) {
+	var respObject map[string]interface{}
+	if err := json.Unmarshal(body, &respObject); err != nil {
+		return nil, fmt.Errorf("failed to parse Bitcoin health check response: %w", err)
+	}
+
+	result, ok := respObject["result"].(float64)
+	if !ok {
+		return nil, fmt.Errorf("invalid Bitcoin health check response format")
+	}
+
+	return &BlockInfo{
+		Number:    int64(result),
+		Hash:      "",
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (h *BitcoinHandler) ParseChainIDResponse(body []byte, statusCode int) (string, error) {
+	if statusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error: %d", statusCode)
+	}
+
+	var respObject map[string]interface{}
+	if err := json.Unmarshal(body, &respObject); err != nil {
+		return "", fmt.Errorf("failed to parse Bitcoin chain ID response: %w", err)
+	}
+
+	// Check for JSON-RPC error
+	if errorField, exists := respObject["error"]; exists && errorField != nil {
+		return "", fmt.Errorf("JSON-RPC error: %v", errorField)
+	}
+
+	// Extract result field
+	result, ok := respObject["result"]
+	if !ok {
+		return "", fmt.Errorf("missing result field in chain ID response")
+	}
+
+	// Extract chain reference
+	chainReference, err := h.ExtractChainReference(result)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract chain reference: %w", err)
+	}
+
+	return chainReference, nil
+}
+
+// GetLatestBlockNumber retrieves the latest block number for Bitcoin chains
+// Uses the JSON-RPC method getblockcount to get the current block height
+func (h *BitcoinHandler) GetLatestBlockNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (*LatestBlockResult, error) {
+	// Use the shared JSON-RPC helper with Bitcoin-specific numeric parsing
+	return GetLatestBlockNumberViaJSONRPC(
+		httpUrl,
+		headers,
+		httpClient,
+		authClient,
+		requestAttempts,
+		h.GetHealthCheckMethod(), // "getblockcount"
+		ParseNumericBlockNumber,  // Bitcoin returns numeric block heights
+	)
+}
+
+// PerformArchiveCheck performs archive mode check for Bitcoin chains using JSON-RPC
+func (h *BitcoinHandler) PerformArchiveCheck(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error {
+	// Bitcoin doesn't need archive mode check
+	return fmt.Errorf("bitcoin does not support archive mode")
+}
+
+// PerformGetBlockByNumber performs get block by number operation for Bitcoin chains using JSON-RPC
+// This implements the two-step process: getblockhash -> getblock
+func (h *BitcoinHandler) PerformGetBlockByNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (interface{}, error) {
+	var lastErr error
+
+	// Step 1: Get block hash from block number
+	for attempt := 0; attempt < requestAttempts; attempt++ {
+		// Create getblockhash request
+		hashPayload, err := h.CreateBlockRequest("getblockhash", blockNumber, false)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to create getblockhash request: %w", err)
+			continue
+		}
+
+		// Make POST request for block hash
+		hashResBytes, statusCode, err := httpClient.Post(httpUrl, headers, hashPayload, authClient)
+		if err != nil {
+			lastErr = fmt.Errorf("error sending getblockhash request: %w", err)
+			continue
+		}
+
+		// Check HTTP status
+		if statusCode != nil && *statusCode >= 400 {
+			lastErr = fmt.Errorf("HTTP error for getblockhash: %d", *statusCode)
+			continue
+		}
+
+		// Parse response to get block hash
+		var hashResponse JSONRPCResponse
+		if err := json.Unmarshal(hashResBytes, &hashResponse); err != nil {
+			lastErr = fmt.Errorf("failed to parse getblockhash response: %w", err)
+			continue
+		}
+
+		// Check for JSON-RPC error
+		if hashResponse.Error != nil {
+			lastErr = fmt.Errorf("getblockhash error %d: %s", hashResponse.Error.Code, hashResponse.Error.Message)
+			continue
+		}
+
+		// Extract block hash from result
+		var blockHash string
+		if err := json.Unmarshal(hashResponse.Result, &blockHash); err != nil {
+			lastErr = fmt.Errorf("failed to extract block hash: %w", err)
+			continue
+		}
+
+		// Step 2: Get block details using the hash
+		blockPayload, err := h.CreateBlockRequestWithHash(blockHash, false)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to create getblock request: %w", err)
+			continue
+		}
+
+		// Make POST request for block details
+		blockResBytes, statusCode, err := httpClient.Post(httpUrl, headers, blockPayload, authClient)
+		if err != nil {
+			lastErr = fmt.Errorf("error sending getblock request: %w", err)
+			continue
+		}
+
+		// Check HTTP status
+		if statusCode != nil && *statusCode >= 400 {
+			lastErr = fmt.Errorf("HTTP error for getblock: %d", *statusCode)
+			continue
+		}
+
+		// Parse block response
+		blockData, err := h.ParseBlockResponse(blockResBytes)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Success!
+		return blockData, nil
+	}
+
+	return nil, fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+}

--- a/lib/network/bitcoin_handler_test.go
+++ b/lib/network/bitcoin_handler_test.go
@@ -1,0 +1,547 @@
+package network
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestBitcoinHandler_GetType(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	if handler.GetType() != "bitcoin" {
+		t.Errorf("Expected type 'bitcoin', got '%s'", handler.GetType())
+	}
+}
+
+func TestBitcoinHandler_GetName(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	expected := "Bitcoin JSON-RPC Handler"
+	if handler.GetName() != expected {
+		t.Errorf("Expected name '%s', got '%s'", expected, handler.GetName())
+	}
+}
+
+func TestBitcoinHandler_GetRequestType(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	if handler.GetRequestType() != RequestTypeRPC {
+		t.Errorf("Expected RequestTypeRPC, got %v", handler.GetRequestType())
+	}
+}
+
+func TestBitcoinHandler_ValidateChainID(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name    string
+		chainID string
+		valid   bool
+	}{
+		{
+			name:    "valid_mainnet",
+			chainID: "main",
+			valid:   true,
+		},
+		{
+			name:    "valid_testnet",
+			chainID: "test",
+			valid:   true,
+		},
+		{
+			name:    "valid_regtest",
+			chainID: "regtest",
+			valid:   true,
+		},
+		{
+			name:    "valid_signet",
+			chainID: "signet",
+			valid:   true,
+		},
+		{
+			name:    "invalid - contains colon (old CAIP-2 format)",
+			chainID: "bitcoin:main",
+			valid:   false,
+		},
+		{
+			name:    "invalid - unknown chain",
+			chainID: "unknown",
+			valid:   false,
+		},
+		{
+			name:    "empty chain ID",
+			chainID: "",
+			valid:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.ValidateChainID(tt.chainID)
+			if tt.valid && err != nil {
+				t.Errorf("Expected valid chain ID '%s', but got error: %v", tt.chainID, err)
+			}
+			if !tt.valid && err == nil {
+				t.Errorf("Expected invalid chain ID '%s', but no error returned", tt.chainID)
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_ValidateRequest(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name        string
+		method      string
+		contentType string
+		expectError bool
+	}{
+		{
+			name:        "valid_request",
+			method:      "POST",
+			contentType: "application/json",
+			expectError: false,
+		},
+		{
+			name:        "valid_request_with_charset",
+			method:      "POST",
+			contentType: "application/json; charset=utf-8",
+			expectError: false,
+		},
+		{
+			name:        "invalid_method_GET",
+			method:      "GET",
+			contentType: "application/json",
+			expectError: true,
+		},
+		{
+			name:        "invalid_content_type",
+			method:      "POST",
+			contentType: "text/plain",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(tt.method, "http://example.com", nil)
+			req.Header.Set("Content-Type", tt.contentType)
+
+			err := handler.ValidateRequest(req)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_GetHealthCheckMethod(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	expected := "getblockcount"
+	if handler.GetHealthCheckMethod() != expected {
+		t.Errorf("Expected health check method '%s', got '%s'", expected, handler.GetHealthCheckMethod())
+	}
+}
+
+func TestBitcoinHandler_GetChainIDMethod(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	expected := "getblockchaininfo"
+	if handler.GetChainIDMethod() != expected {
+		t.Errorf("Expected chain ID method '%s', got '%s'", expected, handler.GetChainIDMethod())
+	}
+}
+
+func TestBitcoinHandler_CreateHealthCheckPayload(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	payload, err := handler.CreateHealthCheckPayload("getblockcount")
+	if err != nil {
+		t.Fatalf("Failed to create health check payload: %v", err)
+	}
+
+	expected := `{"jsonrpc":"2.0","method":"getblockcount","id":1}`
+	if string(payload) != expected {
+		t.Errorf("Expected payload '%s', got '%s'", expected, string(payload))
+	}
+}
+
+func TestBitcoinHandler_ParseHealthCheckResponse(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name        string
+		response    string
+		expectedNum int64
+		expectError bool
+	}{
+		{
+			name:        "valid_response",
+			response:    `{"jsonrpc":"2.0","result":910901,"id":1}`,
+			expectedNum: 910901,
+			expectError: false,
+		},
+		{
+			name:        "invalid_json",
+			response:    `invalid json`,
+			expectedNum: 0,
+			expectError: true,
+		},
+		{
+			name:        "missing_result",
+			response:    `{"jsonrpc":"2.0","id":1}`,
+			expectedNum: 0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blockInfo, err := handler.ParseHealthCheckResponse([]byte(tt.response))
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if blockInfo.Number != tt.expectedNum {
+					t.Errorf("Expected block number %d, got %d", tt.expectedNum, blockInfo.Number)
+				}
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_ParseChainIDResponse(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name         string
+		response     string
+		statusCode   int
+		expectedID   string
+		expectError  bool
+	}{
+		{
+			name: "valid_mainnet_response",
+			response: `{
+				"jsonrpc": "2.0",
+				"result": {
+					"chain": "main",
+					"blocks": 910909,
+					"headers": 910909,
+					"bestblockhash": "00000000000000000001063d6678998c1bb56431f5b161c043bec1c8dc0d36c7"
+				},
+				"id": 1
+			}`,
+			statusCode: http.StatusOK,
+			expectedID: "main",
+			expectError: false,
+		},
+		{
+			name: "valid_testnet_response",
+			response: `{
+				"jsonrpc": "2.0",
+				"result": {
+					"chain": "test"
+				},
+				"id": 1
+			}`,
+			statusCode: http.StatusOK,
+			expectedID: "test",
+			expectError: false,
+		},
+		{
+			name:         "http_error",
+			response:     `{}`,
+			statusCode:   http.StatusInternalServerError,
+			expectedID:   "",
+			expectError:  true,
+		},
+		{
+			name: "json_rpc_error",
+			response: `{
+				"jsonrpc": "2.0",
+				"error": {
+					"code": -32600,
+					"message": "Invalid Request"
+				},
+				"id": null
+			}`,
+			statusCode:  http.StatusOK,
+			expectedID:  "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chainID, err := handler.ParseChainIDResponse([]byte(tt.response), tt.statusCode)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if chainID != tt.expectedID {
+					t.Errorf("Expected chain ID '%s', got '%s'", tt.expectedID, chainID)
+				}
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_CreateBlockRequest(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name                string
+		method              string
+		blockNum            int64
+		includeTransactions bool
+		expectedPayload     string
+		expectError         bool
+	}{
+		{
+			name:                "getblockhash_request",
+			method:              "getblockhash",
+			blockNum:            910905,
+			includeTransactions: false,
+			expectedPayload:     `{"jsonrpc":"2.0","method":"getblockhash","params":[910905],"id":1}`,
+			expectError:         false,
+		},
+		{
+			name:                "getblock_requires_hash",
+			method:              "getblock",
+			blockNum:            910905,
+			includeTransactions: false,
+			expectedPayload:     "",
+			expectError:         true,
+		},
+		{
+			name:                "unsupported_method",
+			method:              "unsupported",
+			blockNum:            910905,
+			includeTransactions: false,
+			expectedPayload:     "",
+			expectError:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := handler.CreateBlockRequest(tt.method, tt.blockNum, tt.includeTransactions)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if string(payload) != tt.expectedPayload {
+					t.Errorf("Expected payload '%s', got '%s'", tt.expectedPayload, string(payload))
+				}
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_CreateBlockRequestWithHash(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name                string
+		blockHash           string
+		includeTransactions bool
+		expectedPayload     string
+	}{
+		{
+			name:                "without_transactions",
+			blockHash:           "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+			includeTransactions: false,
+			expectedPayload:     `{"jsonrpc":"2.0","method":"getblock","params":["00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",1],"id":1}`,
+		},
+		{
+			name:                "with_transactions",
+			blockHash:           "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+			includeTransactions: true,
+			expectedPayload:     `{"jsonrpc":"2.0","method":"getblock","params":["00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",2],"id":1}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := handler.CreateBlockRequestWithHash(tt.blockHash, tt.includeTransactions)
+			if err != nil {
+				t.Fatalf("Failed to create block request with hash: %v", err)
+			}
+			if string(payload) != tt.expectedPayload {
+				t.Errorf("Expected payload '%s', got '%s'", tt.expectedPayload, string(payload))
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_ExtractBlockHash(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name         string
+		blockData    interface{}
+		expectedHash string
+	}{
+		{
+			name:         "string_hash",
+			blockData:    "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+			expectedHash: "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+		},
+		{
+			name: "block_object_with_hash",
+			blockData: map[string]interface{}{
+				"hash":   "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+				"height": 910905,
+			},
+			expectedHash: "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+		},
+		{
+			name:         "raw_message_string",
+			blockData:    json.RawMessage(`"00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253"`),
+			expectedHash: "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+		},
+		{
+			name:         "raw_message_object",
+			blockData:    json.RawMessage(`{"hash":"00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253"}`),
+			expectedHash: "00000000000000000000badb5c06bab4232d2f5a3e975b7abe4747d2edd85253",
+		},
+		{
+			name:         "invalid_data",
+			blockData:    123,
+			expectedHash: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := handler.ExtractBlockHash(tt.blockData)
+			if hash != tt.expectedHash {
+				t.Errorf("Expected hash '%s', got '%s'", tt.expectedHash, hash)
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_GetSupportedMethods(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	methods := handler.GetSupportedMethods()
+	
+	// Check that critical methods are included
+	expectedMethods := []string{
+		"getblockcount",
+		"getblockhash",
+		"getblock",
+		"getblockchaininfo",
+	}
+
+	for _, expected := range expectedMethods {
+		found := false
+		for _, method := range methods {
+			if method == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected method '%s' not found in supported methods", expected)
+		}
+	}
+}
+
+func TestBitcoinHandler_ParseBlockNumberResponse(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name         string
+		response     string
+		statusCode   int
+		expectedNum  int64
+		expectError  bool
+	}{
+		{
+			name:         "valid_response",
+			response:     `{"jsonrpc":"2.0","result":910901,"id":1}`,
+			statusCode:   http.StatusOK,
+			expectedNum:  910901,
+			expectError:  false,
+		},
+		{
+			name:         "rate_limit_error",
+			response:     `{}`,
+			statusCode:   429,
+			expectedNum:  0,
+			expectError:  true,
+		},
+		{
+			name:         "http_error",
+			response:     `{}`,
+			statusCode:   500,
+			expectedNum:  0,
+			expectError:  true,
+		},
+		{
+			name: "json_rpc_error",
+			response: `{
+				"jsonrpc": "2.0",
+				"error": {
+					"code": -32601,
+					"message": "Method not found"
+				},
+				"id": 1
+			}`,
+			statusCode:  http.StatusOK,
+			expectedNum: 0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blockNum, err := handler.ParseBlockNumberResponse([]byte(tt.response), tt.statusCode)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !tt.expectError {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if blockNum != tt.expectedNum {
+					t.Errorf("Expected block number %d, got %d", tt.expectedNum, blockNum)
+				}
+			}
+		})
+	}
+}
+
+func TestBitcoinHandler_SupportsGetBlockByNumber(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	if !handler.SupportsGetBlockByNumber() {
+		t.Errorf("Expected Bitcoin handler to support get block by number")
+	}
+}
+
+func TestBitcoinHandler_SupportsArchiveMode(t *testing.T) {
+	handler := NewBitcoinHandler(&NetworkConfig{})
+
+	if handler.SupportsArchiveMode() {
+		t.Errorf("Expected Bitcoin handler to not support archive mode")
+	}
+}

--- a/lib/network/handler_test.go
+++ b/lib/network/handler_test.go
@@ -455,7 +455,7 @@ func TestDefaultRegistry_Initialization(t *testing.T) {
 	// Test that default registry is initialized with built-in handlers
 	handlers := DefaultRegistry.ListHandlers()
 
-	expectedHandlers := []string{"evm", "beacon-chain", "starknet", "solana", "bitcoin-esplora"}
+	expectedHandlers := []string{"evm", "beacon-chain", "starknet", "solana", "bitcoin", "bitcoin-esplora"}
 
 	if len(handlers) != len(expectedHandlers) {
 		t.Errorf("Expected %d handlers, got %d", len(expectedHandlers), len(handlers))

--- a/lib/network/handlers.go
+++ b/lib/network/handlers.go
@@ -199,6 +199,13 @@ func RegisterBuiltinHandlers() {
 		panic(fmt.Sprintf("Failed to register Beacon Chain handler: %v", err))
 	}
 
+	// Register Bitcoin handler - matches modules.BitcoinHandler constant
+	if err := DefaultRegistry.RegisterHandler("bitcoin", func(config *NetworkConfig) (NetworkHandler, error) {
+		return NewBitcoinHandler(config), nil
+	}); err != nil {
+		panic(fmt.Sprintf("Failed to register Bitcoin handler: %v", err))
+	}
+
 	// Register Bitcoin Esplora handler - matches modules.BitcoinEsploraHandler constant
 	if err := DefaultRegistry.RegisterHandler("bitcoin-esplora", func(config *NetworkConfig) (NetworkHandler, error) {
 		return NewBitcoinEsploraHandler(config), nil

--- a/modules/consts.go
+++ b/modules/consts.go
@@ -11,6 +11,7 @@ const (
 	BeaconHandler         HandlerType = "beacon-chain"
 	StarknetHandler       HandlerType = "starknet"
 	SolanaHandler         HandlerType = "solana"
+	BitcoinHandler        HandlerType = "bitcoin"
 	BitcoinEsploraHandler HandlerType = "bitcoin-esplora"
 )
 


### PR DESCRIPTION
# Add Bitcoin JSON-RPC Handler Support

## Summary

This PR adds native Bitcoin JSON-RPC handler support to the DIN Gateway, enabling direct integration with Bitcoin Core nodes via the JSON-RPC 2.0 protocol. This complements the existing Bitcoin Esplora REST API handler and provides users with more deployment options.

## Key Features

### 1. Full Bitcoin Core JSON-RPC Support
- Implements the complete `NetworkHandler` interface
- Compatible with Bitcoin Core nodes

### 2. Two-Step Block Retrieval
Bitcoin's unique requirement for block retrieval is properly handled:
```
1. getblockhash(blockNumber) → returns block hash
2. getblock(blockHash) → returns block details
```

### 3. Chain ID Support
- Validates Bitcoin network types: `main`, `test`, `regtest`, `signet`
- Uses `getblockchaininfo` RPC method to retrieve chain information
- No longer requires CAIP-2 prefixes (follows the new chain ID format)

### 4. Supported RPC Methods
- `getblockcount` - Get latest block height
- `getblockhash` - Convert block number to hash
- `getblock` - Get block details by hash
- `getblockchaininfo` - Get chain information
- `getbestblockhash` - Get best block hash
- `getdifficulty` - Get current difficulty
- `getmempoolinfo` - Get mempool information
- `getrawmempool` - Get raw mempool
- `getrawtransaction` - Get raw transaction
- `sendrawtransaction` - Send raw transaction
- `getnetworkinfo` - Get network information
- `getpeerinfo` - Get peer information
- `getmininginfo` - Get mining information

### 5. Shared Infrastructure
- Leverages existing JSON-RPC utilities (`json_rpc_client.go`, `json_rpc_parser.go`)
- Uses common error handling and retry logic
- Maintains consistency with other JSON-RPC handlers (Solana, Starknet, EVM)

## Configuration Example

Users can now configure Bitcoin networks using the JSON-RPC handler:

```caddyfile
bitcoin-mainnet {
    handler bitcoin
    chain_id "main"
    
    providers {
        https://bitcoin-rpc.example.com{key} {
            priority 0
        }
    }
}
```