### PR TITLE
feat(network): add guards to NetworkHandler implementations

### DIFF
--- a/lib/network/beacon_handler.go
+++ b/lib/network/beacon_handler.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var _ NetworkHandler = (*BeaconChainHandler)(nil)
+
 // BeaconChainHandler handles Ethereum Beacon Chain REST API requests
 type BeaconChainHandler struct {
 	config  *NetworkConfig

--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -31,6 +31,8 @@ type BitcoinEsploraBlock struct {
 	Difficulty        float64 `json:"difficulty"`
 }
 
+var _ NetworkHandler = (*BitcoinEsploraHandler)(nil)
+
 // BitcoinEsploraHandler handles Bitcoin Esplora REST API requests
 type BitcoinEsploraHandler struct {
 	config              *NetworkConfig

--- a/lib/network/bitcoin_handler.go
+++ b/lib/network/bitcoin_handler.go
@@ -13,6 +13,8 @@ import (
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 )
 
+var _ NetworkHandler = (*BitcoinHandler)(nil)
+
 type BitcoinHandler struct {
 	config  *NetworkConfig
 	version string

--- a/lib/network/evm_handler.go
+++ b/lib/network/evm_handler.go
@@ -17,6 +17,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var _ NetworkHandler = (*EVMHandler)(nil)
+
 // EVMHandler handles EVM-compatible JSON-RPC networks
 type EVMHandler struct {
 	config  *NetworkConfig

--- a/lib/network/handler_test.go
+++ b/lib/network/handler_test.go
@@ -25,6 +25,8 @@ func (m *MockProvider) GetPath() string               { return m.path }
 func (m *MockProvider) GetHost() string               { return m.host }
 func (m *MockProvider) GetPriority() int              { return m.priority }
 
+var _ NetworkHandler = (*MockHandler)(nil)
+
 // Mock handler for testing
 type MockHandler struct {
 	handlerType string

--- a/lib/network/interface_mock.go
+++ b/lib/network/interface_mock.go
@@ -13,6 +13,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
+var _ NetworkHandler = (*MockNetworkHandler)(nil)
+
 // MockNetworkHandler is a mock of NetworkHandler interface.
 type MockNetworkHandler struct {
 	ctrl     *gomock.Controller

--- a/lib/network/solana_handler.go
+++ b/lib/network/solana_handler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 )
 
+var _ NetworkHandler = (*SolanaHandler)(nil)
+
 type SolanaHandler struct {
 	config  *NetworkConfig
 	version string

--- a/lib/network/starknet_handler.go
+++ b/lib/network/starknet_handler.go
@@ -13,6 +13,8 @@ import (
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 )
 
+var _ NetworkHandler = (*StarknetHandler)(nil)
+
 type StarknetHandler struct {
 	config  *NetworkConfig
 	version string


### PR DESCRIPTION
A simple PR to cause compiler errors if:

1. The `NetworkHandler` interface is changed in a way that causes existing handlers to no longer be implementations.
2. An implementation is changed in a way that causes it to no longer conform to the `NetworkHandler` interface.