### PR TITLE
feat: make checks pass

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,40 @@
+version: "2"
+run:
+  go: "1.24"
+  modules-download-mode: readonly
+linters:
+  enable:
+    - errname
+    - errorlint
+    - gocyclo
+    - misspell
+    - staticcheck
+    - gosec
+  settings:
+    misspell:
+      locale: US
+    gosec:
+      severity: low
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  fix: true
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/DIN-center/din-caddy-plugins
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/siwe-token/main.go
+++ b/cmd/siwe-token/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 )
 
 func main() {
@@ -28,7 +32,7 @@ func main() {
 	privateKeyFile := flag.Arg(1)
 
 	// Read the private key file
-	hexKeyBytes, err := os.ReadFile(privateKeyFile)
+	hexKeyBytes, err := os.ReadFile(filepath.Clean(privateKeyFile))
 	if err != nil {
 		panic(fmt.Sprintf("Failed to read private key file: %v", err.Error()))
 	}
@@ -47,18 +51,26 @@ func main() {
 	}
 
 	// Generate a new keypair
-	(&siwe.SIWESignerClient{}).GenPrivKey(signer)
+	if err := (&siwe.SIWESignerClient{}).GenPrivKey(signer); err != nil {
+		panic(fmt.Sprintf("Failed to generate private key: %v", err.Error()))
+	}
 
 	// Print the address
-	os.Stderr.WriteString("Your signing address: ")
-	os.Stderr.WriteString(signer.Address)
-	os.Stderr.WriteString("\n")
+	if err := errors.Join(
+		fWriteString(os.Stderr, "Your signing address: "),
+		fWriteString(os.Stderr, signer.Address),
+		fWriteString(os.Stderr, "\n"),
+	); err != nil {
+		panic(fmt.Sprintf("Failed to display signer address on stder: %v", err.Error()))
+	}
 
 	// Create a new SIWE client
 	client := siwe.NewSIWEClient(url, 0, signer)
 
 	// Start the client
-	client.Start(zap.NewNop())
+	if err := client.Start(zap.NewNop()); err != nil {
+		panic(fmt.Sprintf("Failed to start SIWE client: %v", err.Error()))
+	}
 
 	// Get a token from the client
 	token, err := client.GetToken(nil)
@@ -69,7 +81,18 @@ func main() {
 	for k, v := range token.Headers {
 		result = append(result, fmt.Sprintf("%v: %v", k, v))
 	}
-	os.Stderr.WriteString("Add to CURL:\n-H '")
-	os.Stdout.WriteString(strings.Join(result, " "))
-	os.Stderr.WriteString("'\n")
+
+	if err := errors.Join(
+		fWriteString(os.Stderr, "Add to CURL:\n-H '"),
+		fWriteString(os.Stdout, strings.Join(result, " ")),
+		fWriteString(os.Stderr, "'\n"),
+	); err != nil {
+		panic(fmt.Sprintf("Failed to display cURL headers on stderr: %v", err.Error()))
+	}
+}
+
+func fWriteString(w io.Writer, s string) error {
+	_, err := w.Write([]byte(s))
+
+	return err
 }

--- a/lib/auth/oidc/client.go
+++ b/lib/auth/oidc/client.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 )
 
 // OIDCClient implements the IAuthClient interface for OIDC/OAuth2 authentication
@@ -297,6 +298,8 @@ func (c *OIDCClient) refreshTokenLoop() {
 
 // fetchToken fetches a new access token using client credentials
 func (c *OIDCClient) fetchToken() (string, time.Time, int, error) {
+	var err error
+
 	// Prepare request body
 	data := url.Values{}
 	data.Set("client_id", c.ClientID)
@@ -316,10 +319,13 @@ func (c *OIDCClient) fetchToken() (string, time.Time, int, error) {
 	if err != nil {
 		return "", time.Time{}, 0, fmt.Errorf("failed to execute token request: %w", err)
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		err = resp.Body.Close()
+	}()
 
 	// Read response body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", time.Time{}, 0, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -343,7 +349,7 @@ func (c *OIDCClient) fetchToken() (string, time.Time, int, error) {
 	// Calculate expiry time using the expires_in from response
 	expiry := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
-	return tokenResp.AccessToken, expiry, tokenResp.ExpiresIn, nil
+	return tokenResp.AccessToken, expiry, tokenResp.ExpiresIn, err
 }
 
 // Ensure OIDCClient implements IAuthClient interface

--- a/lib/auth/oidc/client_test.go
+++ b/lib/auth/oidc/client_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 )
 
 func TestOIDCClientStart(t *testing.T) {
@@ -30,10 +31,10 @@ func TestOIDCClientStart(t *testing.T) {
 		assert.Equal(t, "openid", r.Form.Get("scope"))
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": "test-token-123",
 			"expires_in":   3600,
-		})
+		}))
 	}))
 	defer server.Close()
 
@@ -163,9 +164,10 @@ func TestOIDCClientFetchToken(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tt.responseCode)
 				if str, ok := tt.responseBody.(string); ok {
-					w.Write([]byte(str))
+					_, err := w.Write([]byte(str))
+					require.NoError(t, err)
 				} else {
-					json.NewEncoder(w).Encode(tt.responseBody)
+					require.NoError(t, json.NewEncoder(w).Encode(tt.responseBody))
 				}
 			}))
 			defer server.Close()
@@ -287,10 +289,10 @@ func TestOIDCClientCalculateRefreshTime(t *testing.T) {
 func TestOIDCClientStop(t *testing.T) {
 	// Create a mock test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": "test-token",
 			"expires_in":   300, // Short expiry for testing
-		})
+		}))
 	}))
 	defer server.Close()
 
@@ -328,10 +330,10 @@ func TestOIDCClientRefreshLoop(t *testing.T) {
 	// Create a mock test server that returns different tokens
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenCount++
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": "token-" + string(rune(tokenCount)),
 			"expires_in":   2, // Very short expiry for quick testing
-		})
+		}))
 	}))
 	defer server.Close()
 
@@ -366,16 +368,18 @@ func TestOIDCClientRefreshLoopWithError(t *testing.T) {
 		if callCount >= errorOnCall {
 			// Return error response
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("Internal Server Error"))
+			_, err := w.Write([]byte("Internal Server Error"))
+			require.NoError(t, err)
+
 			return
 		}
 
 		// Return successful response with very short expiry
 		// Using 90 seconds so refresh happens at 30 seconds (minimum)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": fmt.Sprintf("token-%d", callCount),
 			"expires_in":   90,
-		})
+		}))
 	}))
 	defer server.Close()
 
@@ -427,10 +431,10 @@ func TestOIDCClientSimpleRefreshLoop(t *testing.T) {
 	tokenCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenCount++
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": fmt.Sprintf("token-%d", tokenCount),
 			"expires_in":   3600, // 1 hour
-		})
+		}))
 	}))
 	defer server.Close()
 
@@ -590,10 +594,10 @@ func TestOIDCClientShortTokenExpiration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a test server that returns tokens with specific expiry
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				json.NewEncoder(w).Encode(map[string]interface{}{
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
 					"access_token": "test-token",
 					"expires_in":   tt.expiresIn,
-				})
+				}))
 			}))
 			defer server.Close()
 
@@ -691,10 +695,10 @@ func TestOIDCClientShortConfiguredDuration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a test server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				json.NewEncoder(w).Encode(map[string]interface{}{
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{
 					"access_token": "test-token",
 					"expires_in":   tt.tokenExpiresIn,
-				})
+				}))
 			}))
 			defer server.Close()
 

--- a/lib/auth/siwe/client.go
+++ b/lib/auth/siwe/client.go
@@ -7,18 +7,19 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spruceid/siwe-go"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 )
 
 type ISIWESignerClient interface {
@@ -41,9 +42,16 @@ func NewSIWESignerClient() *SIWESignerClient {
 }
 
 func (s *SIWESignerClient) Sign(msg string, sc *SigningConfig) ([]byte, error) {
+	var err error
+
 	if sc.privateKey == nil && len(sc.PrivateKey) > 0 {
-		s.GenPrivKey(sc)
+		err = s.GenPrivKey(sc)
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
 	if sc.privateKey != nil {
 		// Sign Locally
 		return signMessage(msg, sc.privateKey)
@@ -244,7 +252,7 @@ func (c *SIWEClientAuth) GetToken(map[string]interface{}) (auth.AuthToken, error
 	}
 
 	var tok auth.AuthToken
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return tok, err
 	}
@@ -276,10 +284,10 @@ func (c *SIWEClientAuth) Sign(r *http.Request) error {
 }
 
 func hashStringToIndex(s string, listSize int) int {
-	hasher := fnv.New32a()        // Initialize a new 32-bit FNV-1a hash
-	hasher.Write([]byte(s))       // Hash the string
-	hash := hasher.Sum32()        // Get the hash as a 32-bit unsigned integer
-	index := int(hash) % listSize // Use modulo to ensure the index is within the bounds of the list
+	hasher := fnv.New32a()         // Initialize a new 32-bit FNV-1a hash
+	_, _ = hasher.Write([]byte(s)) // Hash the string
+	hash := hasher.Sum32()         // Get the hash as a 32-bit unsigned integer
+	index := int(hash) % listSize  // Use modulo to ensure the index is within the bounds of the list
 	return index
 }
 

--- a/lib/auth/siwe/client_test.go
+++ b/lib/auth/siwe/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	// "github.com/DIN-center/din-caddy-plugins/auth"
 )
@@ -22,7 +23,8 @@ func TestClientBasic(t *testing.T) {
 			t.Errorf("Expected to request '/auth', got: %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(fmt.Sprintf(`{"headers": {"x-api-key": "%v"}}`, counter)))
+		_, err := fmt.Fprintf(w, `{"headers": {"x-api-key": "%v"}}`, counter)
+		require.NoError(t, err)
 		counter++
 	}))
 	defer server.Close()
@@ -32,11 +34,11 @@ func TestClientBasic(t *testing.T) {
 		PrivateKey: keyBytes,
 	}
 	signerClient := NewSIWESignerClient()
-	signerClient.GenPrivKey(signer)
+	require.NoError(t, signerClient.GenPrivKey(signer))
 	fmt.Printf("Key: %#x\nAddress: %v", keyBytes, signer.Address)
 	client := NewSIWEClient(server.URL+"/auth", 16, signer)
 	if err := client.Start(zap.NewNop()); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Add("Din-Session-Id", "foo")

--- a/lib/auth/siwe/server.go
+++ b/lib/auth/siwe/server.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -20,6 +21,8 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/spruceid/siwe-go"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 )
 
 var (
@@ -37,8 +40,7 @@ var (
 
 func handleError(err error, rw http.ResponseWriter, code int) {
 	rw.WriteHeader(code)
-	rw.Write([]byte(fmt.Sprintf(`{"error": "%v"}`, err.Error())))
-	rw.Write([]byte("\n"))
+	_, _ = fmt.Fprintf(rw, `{"error": "%v"}\n`, err.Error()) // error is ignored as write failure here isn't recoverable
 }
 
 type SIWEAuthMiddleware struct {
@@ -61,7 +63,7 @@ func (d *SIWEAuthMiddleware) Provision(context caddy.Context) error {
 }
 
 func (d *SIWEAuthMiddleware) createSession(rw http.ResponseWriter, r *http.Request) error {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		handleError(err, rw, 500)
 		return err
@@ -109,9 +111,9 @@ func (d *SIWEAuthMiddleware) createSession(rw http.ResponseWriter, r *http.Reque
 		return err
 	}
 	rw.WriteHeader(200)
-	rw.Write(data)
-	rw.Write([]byte("\n"))
-	return nil
+	_, err = rw.Write(append(data, '\n'))
+
+	return err
 }
 
 func (d *SIWEAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
@@ -166,7 +168,7 @@ func (d *SIWEAuthMiddleware) UnmarshalCaddyfile(dispenser *caddyfile.Dispenser) 
 				if !dispenser.Args(&secretFilePath) {
 					return dispenser.ArgErr()
 				}
-				secret, err := ioutil.ReadFile(secretFilePath)
+				secret, err := os.ReadFile(filepath.Clean(secretFilePath))
 				if err != nil {
 					return dispenser.Errf("failed to read secret file: %v", err)
 				}

--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/pkg/errors"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 )
 
 type HTTPClient struct {
@@ -21,12 +22,17 @@ type HTTPClient struct {
 
 // decompressGzipIfNecessary decompresses gzip content if the Content-Encoding header indicates gzip
 func decompressGzipIfNecessary(resp *http.Response, body []byte) ([]byte, error) {
+	var err error
+
 	if strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
 		gzipReader, err := gzip.NewReader(bytes.NewReader(body))
 		if err != nil {
 			return body, err // Return original body if decompression fails
 		}
-		defer gzipReader.Close()
+
+		defer func() {
+			err = gzipReader.Close()
+		}()
 
 		decompressed, err := io.ReadAll(gzipReader)
 		if err != nil {
@@ -34,7 +40,8 @@ func decompressGzipIfNecessary(resp *http.Response, body []byte) ([]byte, error)
 		}
 		return decompressed, nil
 	}
-	return body, nil
+
+	return body, err
 }
 
 func NewHTTPClient(timeout time.Duration) *HTTPClient {
@@ -58,6 +65,8 @@ func NewHTTPClient(timeout time.Duration) *HTTPClient {
 }
 
 func (h *HTTPClient) Post(url string, headers map[string]string, payload []byte, auth auth.IAuthClient) ([]byte, *int, error) {
+	var err error
+
 	// Send the POST request
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
 	if err != nil {
@@ -77,7 +86,10 @@ func (h *HTTPClient) Post(url string, headers map[string]string, payload []byte,
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Error sending POST request")
 	}
-	defer res.Body.Close()
+
+	defer func() {
+		err = res.Body.Close()
+	}()
 
 	// Read the response body
 	body, err := io.ReadAll(res.Body)
@@ -91,10 +103,12 @@ func (h *HTTPClient) Post(url string, headers map[string]string, payload []byte,
 		return nil, nil, errors.Wrap(err, "Error decompressing gzip response")
 	}
 
-	return body, aws.Int(res.StatusCode), nil
+	return body, aws.Int(res.StatusCode), err
 }
 
 func (h *HTTPClient) Get(url string, headers map[string]string, auth auth.IAuthClient) ([]byte, *int, error) {
+	var err error
+
 	// Send the GET request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -114,7 +128,10 @@ func (h *HTTPClient) Get(url string, headers map[string]string, auth auth.IAuthC
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Error sending GET request")
 	}
-	defer res.Body.Close()
+
+	defer func() {
+		err = res.Body.Close()
+	}()
 
 	// Read the response body
 	body, err := io.ReadAll(res.Body)
@@ -128,5 +145,5 @@ func (h *HTTPClient) Get(url string, headers map[string]string, auth auth.IAuthC
 		return nil, nil, errors.Wrap(err, "Error decompressing gzip response")
 	}
 
-	return body, aws.Int(res.StatusCode), nil
+	return body, aws.Int(res.StatusCode), err
 }

--- a/lib/http/http_test.go
+++ b/lib/http/http_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 )
 
 func TestHTTPClientPost(t *testing.T) {
@@ -88,9 +90,11 @@ func TestHTTPClientPost(t *testing.T) {
 				w.WriteHeader(tc.serverStatus)
 
 				// Write the response body
-				w.Write([]byte(tc.serverResponse))
+				_, err := w.Write([]byte(tc.serverResponse))
+				require.NoError(t, err)
 			}))
-			defer server.Close()
+
+			t.Cleanup(server.Close)
 
 			// Make the POST request
 			body, status, err := client.Post(server.URL, tc.headers, tc.payload, tc.authClient)

--- a/lib/logger/client.go
+++ b/lib/logger/client.go
@@ -1,8 +1,9 @@
 package logger
 
 import (
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 )
 
 type LoggerClient struct {

--- a/lib/network/beacon_handler.go
+++ b/lib/network/beacon_handler.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	"go.uber.org/zap"
 )
 
 var _ NetworkHandler = (*BeaconChainHandler)(nil)
@@ -134,7 +135,7 @@ func (h *BeaconChainHandler) ParseResponse(body []byte, statusCode int) error {
 
 	// Check for error field in response
 	if errorField, exists := response["error"]; exists && errorField != nil {
-		apiErr := fmt.Errorf("Beacon Chain API error: %v", errorField)
+		apiErr := fmt.Errorf("error in Beacon Chain API: %v", errorField)
 		return apiErr
 	}
 
@@ -233,7 +234,7 @@ func (h *BeaconChainHandler) FormatBlockHeight(blockNum int64) string {
 
 func (h *BeaconChainHandler) CreateBlockRequest(method string, blockNum int64, includeTransactions bool) ([]byte, error) {
 	// Beacon chain uses REST API, not JSON-RPC
-	return nil, fmt.Errorf("Beacon Chain uses REST API, not JSON-RPC block requests")
+	return nil, fmt.Errorf("the Beacon Chain uses REST API, not JSON-RPC block requests")
 }
 
 func (h *BeaconChainHandler) ParseBlockResponse(body []byte) (interface{}, error) {
@@ -275,11 +276,11 @@ func (h *BeaconChainHandler) GetArchiveMethod() string {
 }
 
 func (h *BeaconChainHandler) CreateArchivePayload(method string, blockHeight string) ([]byte, error) {
-	return nil, fmt.Errorf("Beacon Chain does not support archive mode")
+	return nil, fmt.Errorf("the Beacon Chain does not support archive mode")
 }
 
 func (h *BeaconChainHandler) ParseArchiveResponse(body []byte) error {
-	return fmt.Errorf("Beacon Chain does not support archive mode")
+	return fmt.Errorf("the Beacon Chain does not support archive mode")
 }
 
 // Network Capabilities methods
@@ -518,7 +519,7 @@ func (h *BeaconChainHandler) GetChainID(httpUrl string, headers map[string]strin
 func (h *BeaconChainHandler) GetLatestBlockNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (*LatestBlockResult, error) {
 	var lastErr error
 	var lastResponseStatus int
-	var lastHealthStatus HealthStatus = Unhealthy
+	var lastHealthStatus = Unhealthy
 
 	// Use the block info endpoint to get latest slot
 	blockInfoMethod := h.GetBlockInfoMethod()

--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -172,7 +172,7 @@ func (h *BitcoinEsploraHandler) FormatBlockHeight(blockNum int64) string {
 }
 
 func (h *BitcoinEsploraHandler) CreateBlockRequest(method string, blockNum int64, includeTransactions bool) ([]byte, error) {
-	return nil, fmt.Errorf("Bitcoin Esplora uses REST API, not JSON-RPC")
+	return nil, fmt.Errorf("the Bitcoin Esplora uses REST API, not JSON-RPC")
 }
 
 func (h *BitcoinEsploraHandler) ParseBlockResponse(body []byte) (interface{}, error) {

--- a/lib/network/bitcoin_esplora_handler_test.go
+++ b/lib/network/bitcoin_esplora_handler_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -104,7 +105,8 @@ func TestBitcoinEsploraHandler_ValidateRequest_HTTPError(t *testing.T) {
 	require.Error(t, err)
 
 	// Check that it's an HTTPError with the correct status code
-	httpErr, ok := err.(*HTTPError)
+	httpErr := &HTTPError{}
+	ok := errors.As(err, &httpErr)
 	require.True(t, ok, "Expected HTTPError type")
 	assert.Equal(t, http.StatusMethodNotAllowed, httpErr.StatusCode)
 	assert.Equal(t, "POST method not allowed for Bitcoin Esplora API", httpErr.Message)

--- a/lib/network/evm_handler.go
+++ b/lib/network/evm_handler.go
@@ -12,9 +12,10 @@ import (
 
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 
+	"go.uber.org/zap"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	"go.uber.org/zap"
 )
 
 var _ NetworkHandler = (*EVMHandler)(nil)
@@ -196,10 +197,7 @@ func (h *EVMHandler) ValidateChainID(chainID string) error {
 	}
 
 	// Validate the actual chain ID (with or without 0x prefix)
-	chainIDNum := actualChainID
-	if strings.HasPrefix(chainIDNum, "0x") {
-		chainIDNum = strings.TrimPrefix(chainIDNum, "0x")
-	}
+	chainIDNum := strings.TrimPrefix(actualChainID, "0x")
 
 	// Convert to ensure it's a valid number
 	if _, err := strconv.ParseInt(chainIDNum, 16, 64); err != nil {

--- a/lib/network/json_rpc_client.go
+++ b/lib/network/json_rpc_client.go
@@ -52,7 +52,7 @@ func GetLatestBlockNumberViaJSONRPC(httpUrl string, headers map[string]string, h
 
 	var lastErr error
 	var lastResponseStatus int
-	var lastHealthStatus HealthStatus = Unhealthy
+	var lastHealthStatus = Unhealthy
 
 	for attempt := 0; attempt < requestAttempts; attempt++ {
 		// Make POST request with payload

--- a/lib/network/registry.go
+++ b/lib/network/registry.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 )
 
 // HandlerConstructor is a function that creates a new handler instance

--- a/lib/network/solana_handler.go
+++ b/lib/network/solana_handler.go
@@ -9,8 +9,7 @@ import (
 	"time"
 
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
-	dinHttp "github.com/DIN-center/din-caddy-plugins/lib/http"
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	dinhttp "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 )
 
@@ -80,7 +79,7 @@ func (h *SolanaHandler) ExtractMethod(req *http.Request, body []byte) (string, e
 		return "", fmt.Errorf("empty request body")
 	}
 
-	var rpcRequest din_http.JSONRPCRequest
+	var rpcRequest dinhttp.JSONRPCRequest
 	if err := json.Unmarshal(body, &rpcRequest); err != nil {
 		return "", fmt.Errorf("failed to parse JSON-RPC request: %w", err)
 	}
@@ -107,7 +106,7 @@ func (h *SolanaHandler) ValidateRequest(req *http.Request) error {
 
 	// Check method
 	if req.Method != "POST" {
-		return fmt.Errorf("Solana JSON-RPC requires POST method, got %s", req.Method)
+		return fmt.Errorf("the Solana JSON-RPC requires POST method, got %s", req.Method)
 	}
 
 	return nil
@@ -180,7 +179,7 @@ func (h *SolanaHandler) CreateBlockRequest(method string, blockNum int64, includ
 
 func (h *SolanaHandler) ParseBlockResponse(body []byte) (interface{}, error) {
 	// First check for JSON-RPC errors using generic response
-	var genericResponse dinHttp.JSONRPCResponse
+	var genericResponse dinhttp.JSONRPCResponse
 	if err := json.Unmarshal(body, &genericResponse); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JSON-RPC response: %w", err)
 	}
@@ -191,7 +190,7 @@ func (h *SolanaHandler) ParseBlockResponse(body []byte) (interface{}, error) {
 	}
 
 	// Parse as Solana-specific response if no errors
-	var response dinHttp.JSONRPCSolanaBlockResponse
+	var response dinhttp.JSONRPCSolanaBlockResponse
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal Solana block response: %w", err)
 	}
@@ -235,7 +234,7 @@ func (h *SolanaHandler) GetBlockInfoMethod() string {
 }
 
 // GetChainID retrieves the chain ID from the Solana provider
-func (h *SolanaHandler) GetChainID(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (string, error) {
+func (h *SolanaHandler) GetChainID(httpUrl string, headers map[string]string, httpClient dinhttp.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (string, error) {
 	// Use the shared JSON-RPC logic with Solana-specific parsing
 	return GetChainIDViaJSONRPC(httpUrl, headers, httpClient, authClient, requestAttempts, h.GetChainIDMethod(), h.ParseChainIDResponse)
 }
@@ -250,11 +249,11 @@ func (h *SolanaHandler) GetArchiveMethod() string {
 }
 
 func (h *SolanaHandler) CreateArchivePayload(method string, blockHeight string) ([]byte, error) {
-	return nil, fmt.Errorf("Solana does not support archive mode")
+	return nil, fmt.Errorf("the Solana does not support archive mode")
 }
 
 func (h *SolanaHandler) ParseArchiveResponse(body []byte) error {
-	return fmt.Errorf("Solana does not support archive mode")
+	return fmt.Errorf("the Solana does not support archive mode")
 }
 
 // Network Capabilities methods
@@ -281,7 +280,7 @@ func (h *SolanaHandler) GetBlockByNumberMethod() string {
 
 // Data Format Conversions methods
 func (h *SolanaHandler) ExtractBlockHash(blockData interface{}) string {
-	if blockResponse, ok := blockData.(dinHttp.JSONRPCSolanaBlockResponse); ok {
+	if blockResponse, ok := blockData.(dinhttp.JSONRPCSolanaBlockResponse); ok {
 		return blockResponse.Result.Blockhash
 	}
 	return ""
@@ -371,7 +370,7 @@ func (h *SolanaHandler) ParseChainIDResponse(body []byte, statusCode int) (strin
 
 // GetLatestBlockNumber retrieves the latest block number for Solana chains
 // Uses the JSON-RPC method getBlockHeight to get the current block height
-func (h *SolanaHandler) GetLatestBlockNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (*LatestBlockResult, error) {
+func (h *SolanaHandler) GetLatestBlockNumber(httpUrl string, headers map[string]string, httpClient dinhttp.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (*LatestBlockResult, error) {
 	// Use the shared JSON-RPC helper with Solana-specific numeric parsing
 	return GetLatestBlockNumberViaJSONRPC(
 		httpUrl,
@@ -385,7 +384,7 @@ func (h *SolanaHandler) GetLatestBlockNumber(httpUrl string, headers map[string]
 }
 
 // PerformArchiveCheck performs archive mode check for Solana chains using JSON-RPC
-func (h *SolanaHandler) PerformArchiveCheck(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error {
+func (h *SolanaHandler) PerformArchiveCheck(httpUrl string, headers map[string]string, httpClient dinhttp.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error {
 	// Use the shared JSON-RPC helper for archive checks
 	return PerformArchiveCheckViaJSONRPC(
 		httpUrl,
@@ -401,7 +400,7 @@ func (h *SolanaHandler) PerformArchiveCheck(httpUrl string, headers map[string]s
 }
 
 // PerformGetBlockByNumber performs get block by number operation for Solana chains using JSON-RPC
-func (h *SolanaHandler) PerformGetBlockByNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (interface{}, error) {
+func (h *SolanaHandler) PerformGetBlockByNumber(httpUrl string, headers map[string]string, httpClient dinhttp.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (interface{}, error) {
 	// Use the shared JSON-RPC helper for get block by number operations
 	return PerformGetBlockByNumberViaJSONRPC(
 		httpUrl,

--- a/lib/network/starknet_handler.go
+++ b/lib/network/starknet_handler.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -106,7 +107,7 @@ func (h *StarknetHandler) ValidateRequest(req *http.Request) error {
 
 	// Check method
 	if req.Method != "POST" {
-		return fmt.Errorf("Starknet JSON-RPC requires POST method, got %s", req.Method)
+		return fmt.Errorf("the Starknet JSON-RPC requires POST method, got %s", req.Method)
 	}
 
 	return nil
@@ -150,16 +151,9 @@ func (h *StarknetHandler) ValidateChainID(chainID string) error {
 		return fmt.Errorf("empty hex part in Starknet chain ID: %s", chainID)
 	}
 
-	// Check if all characters are valid hex
-	for _, char := range hexDigits {
-		if !((char >= '0' && char <= '9') ||
-			(char >= 'a' && char <= 'f') ||
-			(char >= 'A' && char <= 'F')) {
-			return fmt.Errorf("invalid hex character in Starknet chain ID: %s", chainID)
-		}
-	}
+	_, err := hex.DecodeString(hexDigits)
 
-	return nil
+	return err
 }
 
 func (h *StarknetHandler) ExtractChainReference(result interface{}) (string, error) {

--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"go.uber.org/zap"
 )

--- a/lib/prometheus/prometheus_test.go
+++ b/lib/prometheus/prometheus_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 	"time"
 
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 )
 
 func TestMain(m *testing.M) {

--- a/module.go
+++ b/module.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	caddy.RegisterModule(mod.DinUpstreams{})
 	caddy.RegisterModule(mod.DinSelect{})
-	caddy.RegisterModule(mod.DinMiddleware{})
+	caddy.RegisterModule(&mod.DinMiddleware{})
 	caddy.RegisterModule(siwe.SIWEAuthMiddleware{})
 
 	m := new(mod.DinMiddleware)

--- a/module.go
+++ b/module.go
@@ -1,12 +1,13 @@
 package din
 
 import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+
 	_ "github.com/DIN-center/din-caddy-plugins/lib/auth/oidc"
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 	mod "github.com/DIN-center/din-caddy-plugins/modules"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 )
 
 func init() {

--- a/modules/caddy_unmarshaller.go
+++ b/modules/caddy_unmarshaller.go
@@ -3,21 +3,22 @@ package modules
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"go.uber.org/zap"
 
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/oidc"
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
 	"github.com/DIN-center/din-caddy-plugins/lib/utils"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"go.uber.org/zap"
 )
 
 // caddyfileParser encapsulates the parsing logic for Caddyfile
@@ -296,7 +297,7 @@ func (p *caddyfileParser) parseProviders(network *network, parentNesting int) er
 func (p *caddyfileParser) parseProvider(network *network, providerUrl string, parentNesting int) error {
 	providerObj, err := NewProvider(providerUrl)
 	if err != nil {
-		return fmt.Errorf("error creating provider: %v", err)
+		return fmt.Errorf("error creating provider: %w", err)
 	}
 
 	// Parse provider fields
@@ -309,7 +310,7 @@ func (p *caddyfileParser) parseProvider(network *network, providerUrl string, pa
 	// Parse URL and set host
 	parsedUrl, err := url.Parse(providerObj.HttpUrl)
 	if err != nil {
-		return fmt.Errorf("error parsing provider URL: %v", err)
+		return fmt.Errorf("error parsing provider URL: %w", err)
 	}
 
 	// Initialize provider with a unique host
@@ -416,7 +417,7 @@ func (p *caddyfileParser) parseProviderAuth(provider *provider, parentNesting in
 			p.dispenser.NextBlock(parentNesting + 1)
 			duration, err := strconv.Atoi(p.dispenser.Val())
 			if err != nil {
-				return fmt.Errorf("invalid duration_seconds: %v", err)
+				return fmt.Errorf("invalid duration_seconds: %w", err)
 			}
 			oidcClient.DurationSeconds = duration
 		case "sessions":
@@ -426,7 +427,7 @@ func (p *caddyfileParser) parseProviderAuth(provider *provider, parentNesting in
 			p.dispenser.NextBlock(parentNesting + 1)
 			sessionCount, err := strconv.Atoi(p.dispenser.Val())
 			if err != nil {
-				return fmt.Errorf("invalid session count: %v", err)
+				return fmt.Errorf("invalid session count: %w", err)
 			}
 			siweAuth.SessionCount = sessionCount
 		case "signer":
@@ -441,7 +442,7 @@ func (p *caddyfileParser) parseProviderAuth(provider *provider, parentNesting in
 				PrivateKey: signerKey,
 			}
 			if err := p.siweSignerClient.GenPrivKey(siweAuth.Signer); err != nil {
-				return fmt.Errorf("failed to generate private key: %v", err)
+				return fmt.Errorf("failed to generate private key: %w", err)
 			}
 		default:
 			return p.dispenser.Errf("unrecognized auth option: %s", p.dispenser.Val())
@@ -492,7 +493,7 @@ func (p *caddyfileParser) parseProviderSigner(parentNesting int) ([]byte, error)
 			p.dispenser.NextBlock(parentNesting)
 			key, err = p.parseSecretKey(p.dispenser.Val())
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode secret: %v", err)
+				return nil, fmt.Errorf("failed to decode secret: %w", err)
 			}
 		}
 	}
@@ -519,7 +520,7 @@ func (p *caddyfileParser) parseProviderPriority(provider *provider, nesting int)
 	p.dispenser.NextBlock(nesting)
 	priority, err := strconv.Atoi(p.dispenser.Val())
 	if err != nil {
-		return fmt.Errorf("invalid priority: %v", err)
+		return fmt.Errorf("invalid priority: %w", err)
 	}
 	provider.Priority = priority
 	return nil
@@ -575,7 +576,7 @@ func (p *caddyfileParser) parseDinRegistry() error {
 				return err
 			}
 		case "registry_block_check_interval_sec":
-			if err := p.parseUint64Field(&p.middleware.RegistryBlockCheckIntervalSec, "registry block check interval"); err != nil {
+			if err := p.parseInt64Field(&p.middleware.RegistryBlockCheckIntervalSec, "registry block check interval"); err != nil {
 				return err
 			}
 		case "registry_endpoint_url":
@@ -628,7 +629,7 @@ func (p *caddyfileParser) parseIntField(field *int, fieldName string) error {
 	p.dispenser.Next()
 	val, err := strconv.Atoi(p.dispenser.Val())
 	if err != nil {
-		return fmt.Errorf("invalid %s: %v", fieldName, err)
+		return fmt.Errorf("invalid %s: %w", fieldName, err)
 	}
 	*field = val
 	return nil
@@ -638,7 +639,7 @@ func (p *caddyfileParser) parseIntFieldToInt(field *int, fieldName string) error
 	p.dispenser.Next()
 	val, err := strconv.Atoi(p.dispenser.Val())
 	if err != nil {
-		return fmt.Errorf("invalid %s: %v", fieldName, err)
+		return fmt.Errorf("invalid %s: %w", fieldName, err)
 	}
 	*field = val
 	return nil
@@ -648,7 +649,7 @@ func (p *caddyfileParser) parseInt64Field(field *int64, fieldName string) error 
 	p.dispenser.Next()
 	val, err := strconv.Atoi(p.dispenser.Val())
 	if err != nil {
-		return fmt.Errorf("invalid %s: %v", fieldName, err)
+		return fmt.Errorf("invalid %s: %w", fieldName, err)
 	}
 	*field = int64(val)
 	return nil
@@ -656,11 +657,12 @@ func (p *caddyfileParser) parseInt64Field(field *int64, fieldName string) error 
 
 func (p *caddyfileParser) parseUint64Field(field *uint64, fieldName string) error {
 	p.dispenser.Next()
-	val, err := strconv.Atoi(p.dispenser.Val())
+	val, err := strconv.ParseUint(p.dispenser.Val(), 10, 64)
 	if err != nil {
 		return p.dispenser.Errf("Error converting string to int: %v", err)
 	}
-	*field = uint64(val)
+	*field = val
+
 	return nil
 }
 
@@ -668,7 +670,7 @@ func (p *caddyfileParser) parseBoolField(field *bool, fieldName string) error {
 	p.dispenser.Next()
 	val, err := strconv.ParseBool(p.dispenser.Val())
 	if err != nil {
-		return fmt.Errorf("invalid %s: %v", fieldName, err)
+		return fmt.Errorf("invalid %s: %w", fieldName, err)
 	}
 	*field = val
 	return nil
@@ -680,14 +682,10 @@ func (p *caddyfileParser) parseSecretKey(hexKey string) ([]byte, error) {
 }
 
 func (p *caddyfileParser) parseSecretKeyFromFile(filename string) ([]byte, error) {
-	// Try os.ReadFile first (modern Go), fall back to ioutil if needed
-	hexKeyBytes, err := os.ReadFile(filename)
+
+	hexKeyBytes, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
-		// Fallback to ioutil for compatibility
-		hexKeyBytes, err = ioutil.ReadFile(filename)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	hexKey := string(hexKeyBytes)
 	return p.parseSecretKey(hexKey)

--- a/modules/consts.go
+++ b/modules/consts.go
@@ -50,7 +50,7 @@ const (
 	DefaultRequestAttemptCount     = 5
 	DefaultArchiveEnabled          = false
 	// Registry constants
-	DefaultRegistryBlockCheckIntervalSec = uint64(60)
+	DefaultRegistryBlockCheckIntervalSec = int64(60)
 	DefaultRegistryBlockEpoch            = uint64(2000)
 	DefaultRegistryPriority              = 0
 	DefaultPort                          = "8000"

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -2,6 +2,8 @@ package modules
 
 import (
 	"bytes"
+	"container/list"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,12 +12,6 @@ import (
 	"sync"
 	"time"
 
-	dinHttp "github.com/DIN-center/din-caddy-plugins/lib/http"
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
-	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
-	"github.com/DIN-center/din-caddy-plugins/lib/web3"
 	"github.com/DIN-center/din-sc/apps/din-go/lib/din"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -24,11 +20,13 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"container/list"
-
-	"encoding/json"
-
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
+	dinHttp "github.com/DIN-center/din-caddy-plugins/lib/http"
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
+	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
+	"github.com/DIN-center/din-caddy-plugins/lib/web3"
 )
 
 var (
@@ -38,6 +36,7 @@ var (
 	// Din Middleware Module
 	_ caddy.Module                = (*DinMiddleware)(nil)
 	_ caddy.Provisioner           = (*DinMiddleware)(nil)
+	_ caddy.CleanerUpper          = (*DinMiddleware)(nil)
 	_ caddyhttp.MiddlewareHandler = (*DinMiddleware)(nil)
 	_ caddyfile.Unmarshaler       = (*DinMiddleware)(nil)
 	// _ caddy.Validator			= (*mod.DinMiddleware)(nil)
@@ -80,7 +79,7 @@ type DinMiddleware struct {
 	// The flag to enable or disable the din registry
 	RegistryEnabled bool
 	// The interval in seconds to check the latest block number from the registry
-	RegistryBlockCheckIntervalSec uint64
+	RegistryBlockCheckIntervalSec int64
 	// The epoch in blocks to check the latest block number from the registry.
 	// For example, if the epoch is 10, then the din registry will be synced every 10 blocks.
 	RegistryBlockEpoch uint64
@@ -107,15 +106,15 @@ func (*DinMiddleware) CaddyModule() caddy.ModuleInfo {
 
 // Provision() is called by Caddy to prepare the middleware for use.
 // It is called only once, when the server is starting.
-func (d *DinMiddleware) Provision(context caddy.Context) error {
+func (d *DinMiddleware) Provision(ctx caddy.Context) error {
 	if len(d.Networks) == 0 && !d.RegistryEnabled {
 		return fmt.Errorf("expected at least 1 network or registry to be defined")
 	}
 
 	// set the initialize the dinMiddlewareObject
-	err := d.initialize(context)
+	err := d.initialize(ctx)
 	if err != nil {
-		return fmt.Errorf("error initializing middleware: %v", err)
+		return fmt.Errorf("error initializing middleware: %w", err)
 	}
 
 	d.logger.Info("Din middleware provisioned")
@@ -204,7 +203,7 @@ func (d *DinMiddleware) initializeDinRegistryClient() error {
 
 		client, err := din.NewDinClient(d.logger.Logger, d.RegistryEndpointUrl, d.RegistryContractAddress)
 		if err != nil {
-			return fmt.Errorf("error initializing DIN client: %v", err)
+			return fmt.Errorf("error initializing DIN client: %w", err)
 		}
 		d.DingoClient = client
 	}
@@ -308,7 +307,7 @@ func (d *DinMiddleware) initializeNetworkServices(networkName string, networkObj
 	// Initialize providers
 	for _, provider := range networkObj.Providers {
 		if err := d.initializeProvider(networkName, provider, httpClient, d.logger); err != nil {
-			return fmt.Errorf("error initializing provider: %v", err)
+			return fmt.Errorf("error initializing provider: %w", err)
 		}
 	}
 	return nil
@@ -340,7 +339,7 @@ func (d *DinMiddleware) validateNetworkConfiguration(networkName string, network
 func (d *DinMiddleware) startBackgroundServices() error {
 	// Start health checks
 	if err := d.startHealthChecks(); err != nil {
-		return fmt.Errorf("error starting healthchecks: %v", err)
+		return fmt.Errorf("error starting healthchecks: %w", err)
 	}
 
 	// Start registry sync if enabled
@@ -360,7 +359,7 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 		d.logger.Error("Error parsing provider URL",
 			zap.String("http_url", provider.HttpUrl),
 			zap.Error(err))
-		return fmt.Errorf("error parsing provider URL: %v", err)
+		return fmt.Errorf("error parsing provider URL: %w", err)
 	}
 
 	dialHost := parsedUrl.Host
@@ -460,7 +459,8 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 		d.logger.Error("Handler failed to process request", zap.String("network", networkPath), zap.Error(err))
 
 		// Check if it's an HTTPError with specific status code
-		if httpErr, ok := err.(*networklib.HTTPError); ok {
+		httpErr := &networklib.HTTPError{}
+		if errors.As(err, &httpErr) {
 			rw.WriteHeader(httpErr.StatusCode)
 			rw.Write([]byte(httpErr.Message + "\n"))
 		} else {
@@ -789,11 +789,17 @@ func (d *DinMiddleware) startRegistrySync() {
 	}()
 }
 
-func (d *DinMiddleware) closeAll() {
+// Cleanup implements caddy.CleanerUpper.
+func (d *DinMiddleware) Cleanup() error {
 	for _, network := range d.Networks {
 		network.close()
+		d.logger.Logger.Sugar().Infof("DIN nework closed: %s", network.Name)
 	}
+
 	d.close()
+	d.logger.Info("DIN middleware deprovisioned")
+
+	return nil
 }
 
 func (d *DinMiddleware) close() {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"container/list"
 	"encoding/json"
+	stdliberrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -413,8 +414,7 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 
 // ServeHTTP is the main handler for the middleware that is ran for every request.
 // It checks if the network path is defined in the networks map and sets the provider in the context.
-func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
-
+func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error { //nolint:gocyclo
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -426,26 +426,30 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	pathSegments := strings.Split(fullPath, "/")
 	networkPath := pathSegments[0] // Get the first segment as network name
 
+	// If the network path is empty, return an empty JSON object with a 200.
+	if networkPath == "" {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte("{}"))
+
+		return err
+	}
+
 	networkObj, ok := d.Networks[networkPath]
 	if !ok {
-		// If the network is not defined, return a 404. If the network path is empty, return an empty JSON object with a 200
-		if networkPath == "" {
-			rw.WriteHeader(200)
-			rw.Write([]byte("{}"))
-			return nil
-		}
+		// If the network is not defined, return a 404.
+		rw.WriteHeader(http.StatusNotFound)
+		_, err := rw.Write([]byte("Not Found\n"))
 
-		rw.WriteHeader(404)
-		rw.Write([]byte("Not Found\n"))
-		return fmt.Errorf("network undefined")
+		return fmt.Errorf("network undefined: %w", err)
 	}
 
 	// Ensure handler is available
 	if networkObj.handler == nil {
 		d.logger.Error("No handler available for network", zap.String("network", networkPath))
 		rw.WriteHeader(http.StatusInternalServerError)
-		rw.Write([]byte("Internal Server Error\n"))
-		return fmt.Errorf("no handler available for network %s", networkPath)
+		_, err := rw.Write([]byte("Internal Server Error\n"))
+
+		return fmt.Errorf("no handler available for network %s: %w", networkPath, err)
 	}
 
 	// Store network object in replacer for later use
@@ -458,16 +462,25 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	if err := networkObj.handler.ProcessRequest(r); err != nil {
 		d.logger.Error("Handler failed to process request", zap.String("network", networkPath), zap.Error(err))
 
+		var (
+			statusCode int
+			body       string
+		)
+
 		// Check if it's an HTTPError with specific status code
 		httpErr := &networklib.HTTPError{}
 		if errors.As(err, &httpErr) {
-			rw.WriteHeader(httpErr.StatusCode)
-			rw.Write([]byte(httpErr.Message + "\n"))
+			statusCode = httpErr.StatusCode
+			body = httpErr.Message + "\n"
 		} else {
-			rw.WriteHeader(http.StatusBadRequest)
-			rw.Write([]byte("Bad Request\n"))
+			statusCode = http.StatusBadRequest
+			body = "Bad Request\n"
 		}
-		return fmt.Errorf("handler failed to process request: %w", err)
+
+		rw.WriteHeader(statusCode)
+		_, writeErr := rw.Write([]byte(body))
+
+		return stdliberrors.Join(fmt.Errorf("handler failed to process request: %w", err), writeErr)
 	}
 
 	// Read request body and save in context
@@ -483,7 +496,11 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	if (len(bodyBytes) / 1024) > int(networkObj.MaxRequestPayloadSizeKB) {
 		// If the request payload is too large, return an error
 		rw.WriteHeader(http.StatusRequestEntityTooLarge)
-		rw.Write([]byte("Request payload too large\n"))
+		_, err := rw.Write([]byte("Request payload too large\n"))
+		if err != nil {
+			return errors.Wrap(err, "request payload too large")
+		}
+
 		return fmt.Errorf("request payload too large")
 	}
 
@@ -493,7 +510,10 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 		// if the request body is empty for JSON-RPC, do not increment the prometheus metric, return an error
 		// this is specifically for OPTIONS requests and invalid JSON-RPC payload bodies
 		rw.WriteHeader(http.StatusBadRequest)
-		rw.Write([]byte("Request body is empty\n"))
+		_, err := rw.Write([]byte("Request body is empty\n"))
+		if err != nil {
+			return fmt.Errorf("error writing response: %w", err)
+		}
 		return fmt.Errorf("request body is empty")
 	}
 
@@ -742,15 +762,6 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	return nil
 }
 
-// getNetworkNames returns a slice of available network names for debugging
-func (d *DinMiddleware) getNetworkNames() []string {
-	names := make([]string, 0, len(d.Networks))
-	for name := range d.Networks {
-		names = append(names, name)
-	}
-	return names
-}
-
 // StartHealthchecks starts a background goroutine to monitor all of the networks' overall health and the health of its providers
 func (d *DinMiddleware) startHealthChecks() error {
 	d.logger.Info("Starting healthchecks")
@@ -804,11 +815,4 @@ func (d *DinMiddleware) Cleanup() error {
 
 func (d *DinMiddleware) close() {
 	close(d.quit)
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -98,7 +98,7 @@ type DinMiddleware struct {
 }
 
 // CaddyModule returns the Caddy module information.
-func (DinMiddleware) CaddyModule() caddy.ModuleInfo {
+func (*DinMiddleware) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.handlers.din",
 		New: func() caddy.Module { return new(DinMiddleware) },

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -8,11 +8,12 @@ import (
 
 	"encoding/json"
 
+	"github.com/DIN-center/din-sc/apps/din-go/lib/din"
+	"go.uber.org/zap"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/web3"
-	"github.com/DIN-center/din-sc/apps/din-go/lib/din"
-	"go.uber.org/zap"
 )
 
 // syncRegistryWithLatestBlock checks the latest block number from the linea network and updates the middleware object with the latest registry data if the block number difference is greater than or equal to the epoch
@@ -568,7 +569,7 @@ func (d *DinMiddleware) processHCMethodResponseAsync(networkObj *network, networ
 	blockNumber, _, processingError := networkObj.processBlockNumberResponse(respBody, &respStatus)
 	if processingError != nil {
 		// Extract method directly from GenericRequestContext - completely generic
-		var method string = "unknown"
+		var method = "unknown"
 		if genericContext != nil {
 			method = genericContext.Method
 		}
@@ -613,7 +614,7 @@ func (d *DinMiddleware) processHCMethodResponseAsync(networkObj *network, networ
 		}
 
 		// Extract method and params directly from getBlockByNumber GenericRequestContext for logging
-		var getBlockMethodName string = "unknown"
+		var getBlockMethodName = "unknown"
 		var getBlockParams json.RawMessage
 		if getBlockGenericContext != nil {
 			getBlockMethodName = getBlockGenericContext.Method

--- a/modules/din_middleware_helpers_test.go
+++ b/modules/din_middleware_helpers_test.go
@@ -7,14 +7,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	din "github.com/DIN-center/din-sc/apps/din-go/lib/din"
 	"github.com/pkg/errors"
 
+	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"go.uber.org/zap"
@@ -219,7 +221,7 @@ func TestAddNetworkWithRegistryData(t *testing.T) {
 			}
 
 			// Call the function being tested
-			dinMiddleware.addNetworkWithRegistryData(tt.regNetwork)
+			require.NoError(t, dinMiddleware.addNetworkWithRegistryData(tt.regNetwork))
 
 			// Verify the network is added
 			network, ok := dinMiddleware.Networks[tt.regNetwork.ProxyName]
@@ -347,7 +349,7 @@ func TestUpdateNetworkWithRegistryData(t *testing.T) {
 			}
 
 			// Call the function being tested
-			dinMiddleware.updateNetworkWithRegistryData(tt.regNetwork, tt.newNetwork)
+			require.NoError(t, dinMiddleware.updateNetworkWithRegistryData(tt.regNetwork, tt.newNetwork))
 
 			// Assert the number of providers after the update
 			assert.Equal(t, tt.expectedProviderCount, len(tt.newNetwork.Providers))

--- a/modules/din_middleware_test.go
+++ b/modules/din_middleware_test.go
@@ -14,21 +14,23 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
 	"github.com/DIN-center/din-caddy-plugins/lib/utils"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestMiddlewareCaddyModule(t *testing.T) {
@@ -115,7 +117,7 @@ func TestMiddlewareServeHTTP(t *testing.T) {
 			hasErr: false,
 		},
 		{
-			name: "unsuccesful request, payload too large",
+			name: "unsuccessful request, payload too large",
 			request: func() *http.Request {
 				req := httptest.NewRequest("POST", "http://localhost:8000/eth", strings.NewReader(largePayload))
 				req.Header.Set("Content-Type", "application/json")
@@ -498,10 +500,12 @@ func TestProcessHCMethodResponseAsync(t *testing.T) {
 
 		f()
 
-		w.Close()
+		require.NoError(t, w.Close())
 		os.Stdout = oldStdout
 		var buf bytes.Buffer
-		io.Copy(&buf, r)
+		_, err := io.Copy(&buf, r)
+		require.NoError(t, err)
+
 		return buf.String()
 	}
 
@@ -692,9 +696,10 @@ func TestProcessHCMethodResponseAsync(t *testing.T) {
 			} else {
 				assert.Contains(t, actualLogOutput, "Goroutine: Processing response for HCMethod", "Expected 'Processing response for HCMethod' log for case: "+tt.name+"; Log: "+actualLogOutput)
 
-				if tt.name == "Successful processing" {
+				switch tt.name {
+				case "Successful processing":
 					assert.Contains(t, actualLogOutput, "successfully processed block number and added to network history", "Expected 'successfully processed block number' log for successful case; Log: "+actualLogOutput)
-				} else if tt.name == "Error from processBlockNumberResponse - malformed respBody" || tt.name == "Error from processBlockNumberResponse - http error status" {
+				case "Error from processBlockNumberResponse - malformed respBody", "Error from processBlockNumberResponse - http error status":
 					assert.Contains(t, actualLogOutput, "error processing block number from response using processBlockNumberResponse", "Expected 'error processing block number' log for error cases; Log: "+actualLogOutput)
 				}
 			}

--- a/modules/din_select.go
+++ b/modules/din_select.go
@@ -38,7 +38,10 @@ func (d *DinSelect) Provision(context caddy.Context) error {
 	d.logger = context.Logger(d)
 
 	selector := &reverseproxy.HeaderHashSelection{Field: "Din-Session-Id"}
-	selector.Provision(context)
+	if err := selector.Provision(context); err != nil {
+		return err
+	}
+
 	d.selector = selector
 	return nil
 }

--- a/modules/din_upstreams_test.go
+++ b/modules/din_upstreams_test.go
@@ -314,7 +314,7 @@ func TestGetDinUpstreams(t *testing.T) {
 			output: []*reverseproxy.Upstream{},
 		},
 		{
-			name: "TestGetDinUpstreams succesful, no priorities",
+			name: "TestGetDinUpstreams successful, no priorities",
 			request: &http.Request{
 				URL: &url.URL{Path: "/ethereum/eth_blockNumber"},
 			},

--- a/modules/handler_set_test.go
+++ b/modules/handler_set_test.go
@@ -3,14 +3,15 @@ package modules
 import (
 	"testing"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 )
 
 // TestHandlerSetOnce verifies that handlers are only set once during the entire flow

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -11,12 +11,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/caddyserver/caddy/v2"
+	"go.uber.org/zap"
+
 	dinHttp "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
 	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
-	"github.com/caddyserver/caddy/v2"
-	"go.uber.org/zap"
 )
 
 // checkForJSONRPCError checks if a response body contains a JSON-RPC error
@@ -517,17 +518,17 @@ func createGetBlockByNumberRequestContext(networkName, providerHost, method stri
 	return repl, genericContext, payload
 }
 
-// checkRequestContext checks if the request context has been cancelled or exceeded deadline
+// checkRequestContext checks if the request context has been canceled or exceeded deadline
 // Returns an error if the context is done, nil if the context is still active
 func checkRequestContext(l *logger.LoggerClient, r *http.Request, networkPath string, attempt int) error {
 	select {
 	case <-r.Context().Done():
 		switch r.Context().Err() {
 		case context.Canceled:
-			l.Debug("Request cancelled by client",
+			l.Debug("Request canceled by client",
 				zap.String("network", networkPath),
 				zap.Int("attempt", attempt+1))
-			return fmt.Errorf("request cancelled by client")
+			return fmt.Errorf("request canceled by client")
 		case context.DeadlineExceeded:
 			l.Debug("Request deadline exceeded",
 				zap.String("network", networkPath),
@@ -556,9 +557,9 @@ func handleContextCancellation(l *logger.LoggerClient, promClient *prom.Promethe
 	var responseBody string
 
 	switch {
-	case strings.Contains(err.Error(), "cancelled by client"):
+	case strings.Contains(err.Error(), "canceled by client"):
 		statusCode = http.StatusRequestTimeout // 408
-		responseBody = `{"error": "Request cancelled by client", "code": 408}`
+		responseBody = `{"error": "Request canceled by client", "code": 408}`
 	case strings.Contains(err.Error(), "deadline exceeded"):
 		statusCode = http.StatusGatewayTimeout // 504
 		responseBody = `{"error": "Request timeout exceeded", "code": 504}`
@@ -594,7 +595,9 @@ func handleContextCancellation(l *logger.LoggerClient, promClient *prom.Promethe
 	// Set appropriate headers and write response
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(statusCode)
-	rw.Write([]byte(responseBody))
+	if _, err := rw.Write([]byte(responseBody)); err != nil {
+		l.Error("Failed to write response", zap.Error(err), zap.String("network", networkPath))
+	}
 
 	// Collect Prometheus metrics for context cancellation
 	if promClient != nil {

--- a/modules/helpers_test.go
+++ b/modules/helpers_test.go
@@ -444,7 +444,7 @@ func TestCheckRequestContext(t *testing.T) {
 			expectMsg:   "",
 		},
 		{
-			name: "Cancelled context should return client cancellation error",
+			name: "Canceled context should return client cancellation error",
 			setupCtx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel() // Cancel immediately
@@ -453,7 +453,7 @@ func TestCheckRequestContext(t *testing.T) {
 			networkPath: "ethereum-mainnet",
 			attempt:     1,
 			expectError: true,
-			expectMsg:   "request cancelled by client",
+			expectMsg:   "request canceled by client",
 		},
 		{
 			name: "Deadline exceeded context should return timeout error",
@@ -527,7 +527,7 @@ func TestHandleContextCancellation(t *testing.T) {
 	}{
 		{
 			name:        "Client cancellation should return 408",
-			errorMsg:    "request cancelled by client",
+			errorMsg:    "request canceled by client",
 			networkPath: "ethereum-mainnet",
 			attempt:     1,
 			setupReplacer: func(repl *caddy.Replacer) {
@@ -537,7 +537,7 @@ func TestHandleContextCancellation(t *testing.T) {
 			expectedStatusCode: http.StatusRequestTimeout,
 			expectedLogLevel:   zapcore.ErrorLevel,
 			expectedLogMsg:     "Request attempt failed",
-			expectedResponse:   `{"error": "Request cancelled by client", "code": 408}`,
+			expectedResponse:   `{"error": "Request canceled by client", "code": 408}`,
 		},
 		{
 			name:        "Deadline exceeded should return 504",
@@ -569,7 +569,7 @@ func TestHandleContextCancellation(t *testing.T) {
 		},
 		{
 			name:        "Long request body should be truncated in logs",
-			errorMsg:    "request cancelled by client",
+			errorMsg:    "request canceled by client",
 			networkPath: "ethereum-mainnet",
 			attempt:     0,
 			setupReplacer: func(repl *caddy.Replacer) {
@@ -582,7 +582,7 @@ func TestHandleContextCancellation(t *testing.T) {
 			expectedStatusCode: http.StatusRequestTimeout,
 			expectedLogLevel:   zapcore.ErrorLevel,
 			expectedLogMsg:     "Request attempt failed",
-			expectedResponse:   `{"error": "Request cancelled by client", "code": 408}`,
+			expectedResponse:   `{"error": "Request canceled by client", "code": 408}`,
 		},
 		{
 			name:        "Missing request body and provider should handle gracefully",
@@ -865,7 +865,7 @@ func TestLogFailedAttempt(t *testing.T) {
 			}
 
 			// Extract method and params directly from JSONRPCRequest for the new logging structure
-			var method string = "unknown"
+			var method = "unknown"
 			var params json.RawMessage
 			if tt.parsedReqBody != nil {
 				method = tt.parsedReqBody.Method

--- a/modules/network.go
+++ b/modules/network.go
@@ -2,11 +2,15 @@ package modules
 
 import (
 	"container/list"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
@@ -14,9 +18,9 @@ import (
 	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
 	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
 	"github.com/DIN-center/din-caddy-plugins/lib/utils"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
+
+var _ json.Unmarshaler = (*network)(nil)
 
 type network struct {
 	Name             string
@@ -68,6 +72,7 @@ func NewNetwork(name string, handlerType HandlerType, environment utils.Environm
 	n := &network{
 		Name:        name,
 		HandlerType: handlerType, // Used for handler selection
+		quit:        make(chan struct{}),
 		// Default health check values, to be overridden if specified in the Caddyfile
 		HCThreshold:              DefaultHCThreshold,
 		HCTimeout:                DefaultHCTimeout,
@@ -121,6 +126,23 @@ func (n *network) SetHandler(handler networklib.NetworkHandler) error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
+func (n *network) UnmarshalJSON(data []byte) error {
+	type Alias network
+	alias := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(n),
+	}
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	n.quit = make(chan struct{})
+
+	return nil
+}
+
 func (n *network) startHealthcheck() {
 	n.healthCheck()
 	ticker := time.NewTicker(time.Second * time.Duration(n.HCInterval))
@@ -154,7 +176,7 @@ func (n *network) healthCheck() {
 	for _, provider := range n.Providers {
 
 		// Get latest block and initial health status
-		var healthStatus HealthStatus = Healthy
+		var healthStatus = Healthy
 		latestBlockResult, err := n.getLatestBlockNumber(provider.HttpUrl, provider.Headers, provider.AuthClient(), provider.host)
 		if err != nil {
 			n.logProviderWarning("Health check failed after all attempts for provider", provider,
@@ -712,13 +734,13 @@ func (n *network) checkSelfLoopbackHealth() (*getLatestBlockNumberResult, error)
 	result, err := n.handler.GetLatestBlockNumber(loopbackURL, headers, n.HttpClient, nil, 1)
 	if err != nil {
 		// Extract method directly from GenericRequestContext - completely generic
-		var method string = "unknown"
+		var method = "unknown"
 		if genericContext != nil {
 			method = genericContext.Method
 		}
 
 		// Set default values for when result is nil
-		var statusCode int = 0
+		var statusCode = 0
 		if result != nil {
 			statusCode = result.ResponseStatus
 		}

--- a/modules/network_evaluate_health_test.go
+++ b/modules/network_evaluate_health_test.go
@@ -3,13 +3,14 @@ package modules
 import (
 	"testing"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 )
 
 // TestEvaluateProviderHealth tests the provider health evaluation logic

--- a/modules/network_get_block_test.go
+++ b/modules/network_get_block_test.go
@@ -4,14 +4,15 @@ import (
 	"net/http"
 	"testing"
 
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
+
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 )
 
 // TestGetBlockByNumber tests the getBlockByNumber functionality

--- a/modules/network_loopback_test.go
+++ b/modules/network_loopback_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
-	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
+
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
+	prom "github.com/DIN-center/din-caddy-plugins/lib/prometheus"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 )
 
 // TestLoopbackHealthCheck tests the loopback health check functionality

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -4,15 +4,16 @@ import (
 	"strings"
 	"testing"
 
-	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
-	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
-	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
+
+	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	"github.com/DIN-center/din-caddy-plugins/lib/logger"
+	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
+	"github.com/DIN-center/din-caddy-plugins/lib/utils"
 )
 
 func TestHandleErrorWithGracePeriod(t *testing.T) {
@@ -340,7 +341,7 @@ func TestProcessBlockNumberResponse(t *testing.T) {
 				Type:    string(EVMHandler),
 				ChainID: "1",
 			}
-			n.SetHandler(networklib.NewEVMHandler(config))
+			require.NoError(t, n.SetHandler(networklib.NewEVMHandler(config)))
 
 			var sc *int
 			if !tt.passNilStatusCode {
@@ -472,9 +473,9 @@ func TestArchiveModeCheck(t *testing.T) {
 				ChainID: "test-chain",
 			}
 			if networkType == string(EVMHandler) {
-				n.SetHandler(networklib.NewEVMHandler(config))
+				require.NoError(t, n.SetHandler(networklib.NewEVMHandler(config)))
 			} else {
-				n.SetHandler(networklib.NewStarknetHandler(config))
+				require.NoError(t, n.SetHandler(networklib.NewStarknetHandler(config)))
 			}
 
 			err = n.handler.PerformArchiveCheck("http://test.com", map[string]string{}, n.HttpClient, nil, n.RequestAttemptCount, tt.quarterBlock)
@@ -679,13 +680,6 @@ func TestBlockJumpBehavior(t *testing.T) {
 }
 
 func TestGetLatestBlockNumber(t *testing.T) {
-	type mockPostResponse struct {
-		resBytes          []byte
-		statusCodeVal     int
-		passNilStatusCode bool
-		err               error
-	}
-
 	tests := []struct {
 		name                 string
 		networkName          string
@@ -793,7 +787,9 @@ func TestGetLatestBlockNumber(t *testing.T) {
 	}
 }
 
-func newTestNetwork(name string, historySize int) *network {
+func newTestNetwork(t *testing.T, name string, historySize int) *network {
+	t.Helper()
+
 	n, _ := NewNetwork(name, EVMHandler, utils.Environment("test"), "8000")
 	n.NetworkBlockHistorySize = historySize
 	// Initialize logger to prevent panic
@@ -806,7 +802,8 @@ func newTestNetwork(name string, historySize int) *network {
 		Logger: n.logger,
 	}
 	handler := networklib.NewEVMHandler(config)
-	n.SetHandler(handler)
+	require.NoError(t, n.SetHandler(handler))
+
 	return n
 }
 
@@ -905,7 +902,7 @@ func TestAddNetworkBlockEntry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := newTestNetwork("test", tt.networkHistorySize)
+			n := newTestNetwork(t, "test", tt.networkHistorySize)
 
 			// Add initial entries
 			for _, blockNum := range tt.initialEntries {
@@ -960,7 +957,7 @@ func TestGetLatestBlockEntry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := newTestNetwork("test", 5)
+			n := newTestNetwork(t, "test", 5)
 
 			// Add entries
 			for _, blockNum := range tt.blockNumbers {
@@ -1229,7 +1226,7 @@ func TestNetwork_processBlockNumberResponse(t *testing.T) {
 				Type:    string(EVMHandler),
 				ChainID: "1",
 			}
-			n.SetHandler(networklib.NewEVMHandler(config))
+			require.NoError(t, n.SetHandler(networklib.NewEVMHandler(config)))
 
 			blockNumber, healthStatus, err := n.processBlockNumberResponse(tt.resBytes, tt.statusCode)
 
@@ -1490,20 +1487,6 @@ func TestDetermineNetworkTypeFromNetworkName(t *testing.T) {
 			assert.Equal(t, HandlerType(tt.expectedType), n.HandlerType)
 		})
 	}
-}
-
-func createMockProviderWithStatus(host string, entries []blockHistoryEntry) *provider {
-	p, err := NewProvider("http://" + host + ".com")
-	if err != nil {
-		panic(err) // This should not happen in tests
-	}
-
-	// Add entries using the proper AddBlockEntry method
-	for _, entry := range entries {
-		p.AddBlockEntry(entry.blockNumber, entry.healthStatus, 10)
-	}
-
-	return p
 }
 
 func TestNetworkSetHandler(t *testing.T) {

--- a/modules/provider.go
+++ b/modules/provider.go
@@ -8,11 +8,12 @@ import (
 
 	"errors"
 
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
+
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/oidc"
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 )
 
 type provider struct {

--- a/modules/rest_middleware_flow_test.go
+++ b/modules/rest_middleware_flow_test.go
@@ -194,12 +194,16 @@ func TestRESTAPIMiddlewareIntegration(t *testing.T) {
 					}
 				} else {
 					w.WriteHeader(tt.expectedStatusCode)
-					if tt.expectedStatusCode >= 200 && tt.expectedStatusCode < 300 {
-						w.Write([]byte(`{"status":"ok"}`))
-					} else if tt.expectedStatusCode == 404 {
-						w.Write([]byte(`{"error":"not found"}`))
-					} else if tt.expectedStatusCode >= 500 {
-						w.Write([]byte(`{"error":"internal server error"}`))
+
+					body := `{"error":"internal server error"}`
+					if tt.expectedStatusCode >= http.StatusOK && tt.expectedStatusCode < http.StatusMultipleChoices {
+						body = `{"status":"ok"}`
+					} else if tt.expectedStatusCode == http.StatusNotFound {
+						body = `{"error":"not found"}`
+					}
+
+					if _, err := w.Write([]byte(body)); err != nil {
+						t.Logf("Error writing response body: %v", err)
 					}
 				}
 


### PR DESCRIPTION
When `make check` is executed, both `vet` and `golangci-lint` fail.  This PR is mostly style clean-ups to satisfy the existing checks with the intention that these checks can provider stronger gatekeeping via GitHub Actions.


## Code changes recommeded by `go vet`

The `go vet` check reported a (false positive) concurrency issue as shown below:

```sh
go vet ./...
# github.com/DIN-center/din-caddy-plugins/modules
# [github.com/DIN-center/din-caddy-plugins/modules]
modules/din_middleware.go:101:7: CaddyModule passes lock by value: github.com/DIN-center/din-caddy-plugins/modules.DinMiddleware contains sync.RWMutex
```

This is a false positive because the mutex is unused, but is still easy to fix as completed in 9d9be79.

```go
func (DinMiddleware) CaddyModule() caddy.ModuleInfo {
	return caddy.ModuleInfo{
		ID:  "http.handlers.din",
		New: func() caddy.Module { return new(DinMiddleware) },
	}
}
```

## Style changes recommended by `golangci-lint`

The `golangci-lint` check reports 77 issue (I fixed some in previous PRs) as shown below:

```sh
golangci-lint run ./...
WARN [runner] Changes related to "staticcheck" are skipped for the file "/home/smoyer1/git/din/din-caddy-plugins/lib/network/starknet_handler.go": conflicting edits from staticcheck and staticcheck on /home/smoyer1/git/din/din-caddy-plugins/lib/network/starknet_handler.go
first edits:
--- base
+++ staticcheck
@@ -152,9 +152,7 @@
 
        // Check if all characters are valid hex
        for _, char := range hexDigits {
-               if !((char >= '0' && char <= '9') ||
-                       (char >= 'a' && char <= 'f') ||
-                       (char >= 'A' && char <= 'F')) {
+               if ((char < '0' || char > '9') && (char < 'a' || char > 'f') && (char < 'A' || char > 'F')) {
                        return fmt.Errorf("invalid hex character in Starknet chain ID: %s", chainID)
                }
        }

second edits:
--- base
+++ staticcheck
@@ -152,9 +152,9 @@
 
        // Check if all characters are valid hex
        for _, char := range hexDigits {
-               if !((char >= '0' && char <= '9') ||
-                       (char >= 'a' && char <= 'f') ||
-                       (char >= 'A' && char <= 'F')) {
+               if ((char < '0' || char > '9') &&
+       (char < 'a' || char > 'f') &&
+       (char < 'A' || char > 'F')) {
                        return fmt.Errorf("invalid hex character in Starknet chain ID: %s", chainID)
                }
        } 
cmd/siwe-token/main.go:51:39: Error return value of `(*github.com/DIN-center/din-caddy-plugins/lib/auth/siwe.SIWESignerClient).GenPrivKey` is not checked (errcheck)
        (&siwe.SIWESignerClient{}).GenPrivKey(signer)
                                             ^
cmd/siwe-token/main.go:54:23: Error return value of `os.Stderr.WriteString` is not checked (errcheck)
        os.Stderr.WriteString("Your signing address: ")
                             ^
cmd/siwe-token/main.go:55:23: Error return value of `os.Stderr.WriteString` is not checked (errcheck)
        os.Stderr.WriteString(signer.Address)
                             ^
cmd/siwe-token/main.go:56:23: Error return value of `os.Stderr.WriteString` is not checked (errcheck)
        os.Stderr.WriteString("\n")
                             ^
cmd/siwe-token/main.go:62:14: Error return value of `client.Start` is not checked (errcheck)
        client.Start(zap.NewNop())
                    ^
cmd/siwe-token/main.go:73:23: Error return value of `os.Stderr.WriteString` is not checked (errcheck)
        os.Stderr.WriteString("Add to CURL:\n-H '")
                             ^
cmd/siwe-token/main.go:74:23: Error return value of `os.Stdout.WriteString` is not checked (errcheck)
        os.Stdout.WriteString(strings.Join(result, " "))
                             ^
cmd/siwe-token/main.go:75:23: Error return value of `os.Stderr.WriteString` is not checked (errcheck)
        os.Stderr.WriteString("'\n")
                             ^
lib/auth/oidc/client.go:320:23: Error return value of `resp.Body.Close` is not checked (errcheck)
        defer resp.Body.Close()
                             ^
lib/auth/oidc/client_test.go:34:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                json.NewEncoder(w).Encode(map[string]interface{}{
                                         ^
lib/auth/oidc/client_test.go:167:13: Error return value of `w.Write` is not checked (errcheck)
                                        w.Write([]byte(str))
                                               ^
lib/auth/oidc/client_test.go:169:31: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                                        json.NewEncoder(w).Encode(tt.responseBody)
                                                                 ^
lib/auth/oidc/client_test.go:291:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                json.NewEncoder(w).Encode(map[string]interface{}{
                                         ^
lib/auth/oidc/client_test.go:332:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                json.NewEncoder(w).Encode(map[string]interface{}{
                                         ^
lib/auth/oidc/client_test.go:370:11: Error return value of `w.Write` is not checked (errcheck)
                        w.Write([]byte("Internal Server Error"))
                               ^
lib/auth/oidc/client_test.go:376:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                json.NewEncoder(w).Encode(map[string]interface{}{
                                         ^
lib/auth/oidc/client_test.go:431:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                json.NewEncoder(w).Encode(map[string]interface{}{
                                         ^
lib/auth/oidc/client_test.go:594:30: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                                json.NewEncoder(w).Encode(map[string]interface{}{
                                                         ^
lib/auth/oidc/client_test.go:695:30: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                                json.NewEncoder(w).Encode(map[string]interface{}{
                                                         ^
lib/auth/siwe/client.go:46:15: Error return value of `s.GenPrivKey` is not checked (errcheck)
                s.GenPrivKey(sc)
                            ^
lib/auth/siwe/client_test.go:25:14: Error return value of `fmt.Fprintf` is not checked (errcheck)
                fmt.Fprintf(w, `{"headers": {"x-api-key": "%v"}}`, counter)
                           ^
lib/auth/siwe/client_test.go:35:25: Error return value of `signerClient.GenPrivKey` is not checked (errcheck)
        signerClient.GenPrivKey(signer)
                               ^
lib/auth/siwe/server.go:41:13: Error return value of `fmt.Fprintf` is not checked (errcheck)
        fmt.Fprintf(rw, `{"error": "%v"}`, err.Error())
                   ^
lib/auth/siwe/server.go:42:10: Error return value of `rw.Write` is not checked (errcheck)
        rw.Write([]byte("\n"))
                ^
lib/auth/siwe/server.go:113:10: Error return value of `rw.Write` is not checked (errcheck)
        rw.Write(data)
                ^
lib/auth/siwe/server.go:114:10: Error return value of `rw.Write` is not checked (errcheck)
        rw.Write([]byte("\n"))
                ^
lib/http/http.go:30:25: Error return value of `gzipReader.Close` is not checked (errcheck)
                defer gzipReader.Close()
                                      ^
lib/http/http.go:81:22: Error return value of `res.Body.Close` is not checked (errcheck)
        defer res.Body.Close()
                            ^
lib/http/http.go:118:22: Error return value of `res.Body.Close` is not checked (errcheck)
        defer res.Body.Close()
                            ^
lib/http/http_test.go:92:12: Error return value of `w.Write` is not checked (errcheck)
                                w.Write([]byte(tc.serverResponse))
                                       ^
modules/din_middleware.go:438:12: Error return value of `rw.Write` is not checked (errcheck)
                        rw.Write([]byte("{}"))
                                ^
modules/din_middleware.go:443:11: Error return value of `rw.Write` is not checked (errcheck)
                rw.Write([]byte("Not Found\n"))
                        ^
modules/din_middleware.go:451:11: Error return value of `rw.Write` is not checked (errcheck)
                rw.Write([]byte("Internal Server Error\n"))
                        ^
modules/din_middleware.go:469:12: Error return value of `rw.Write` is not checked (errcheck)
                        rw.Write([]byte(httpErr.Message + "\n"))
                                ^
modules/din_middleware.go:472:12: Error return value of `rw.Write` is not checked (errcheck)
                        rw.Write([]byte("Bad Request\n"))
                                ^
modules/din_middleware.go:490:11: Error return value of `rw.Write` is not checked (errcheck)
                rw.Write([]byte("Request payload too large\n"))
                        ^
modules/din_middleware.go:500:11: Error return value of `rw.Write` is not checked (errcheck)
                rw.Write([]byte("Request body is empty\n"))
                        ^
modules/din_middleware_helpers_test.go:223:44: Error return value of `dinMiddleware.addNetworkWithRegistryData` is not checked (errcheck)
                        dinMiddleware.addNetworkWithRegistryData(tt.regNetwork)
                                                                ^
modules/din_middleware_helpers_test.go:351:47: Error return value of `dinMiddleware.updateNetworkWithRegistryData` is not checked (errcheck)
                        dinMiddleware.updateNetworkWithRegistryData(tt.regNetwork, tt.newNetwork)
                                                                   ^
modules/din_middleware_test.go:502:10: Error return value of `w.Close` is not checked (errcheck)
                w.Close()
                       ^
modules/din_middleware_test.go:505:10: Error return value of `io.Copy` is not checked (errcheck)
                io.Copy(&buf, r)
                       ^
modules/din_select.go:41:20: Error return value of `selector.Provision` is not checked (errcheck)
        selector.Provision(context)
                          ^
modules/helpers.go:598:10: Error return value of `rw.Write` is not checked (errcheck)
        rw.Write([]byte(responseBody))
                ^
modules/network_test.go:344:16: Error return value of `n.SetHandler` is not checked (errcheck)
                        n.SetHandler(networklib.NewEVMHandler(config))
                                    ^
modules/network_test.go:476:17: Error return value of `n.SetHandler` is not checked (errcheck)
                                n.SetHandler(networklib.NewEVMHandler(config))
                                            ^
modules/network_test.go:478:17: Error return value of `n.SetHandler` is not checked (errcheck)
                                n.SetHandler(networklib.NewStarknetHandler(config))
                                            ^
modules/network_test.go:810:14: Error return value of `n.SetHandler` is not checked (errcheck)
        n.SetHandler(handler)
                    ^
modules/network_test.go:1233:16: Error return value of `n.SetHandler` is not checked (errcheck)
                        n.SetHandler(networklib.NewEVMHandler(config))
                                    ^
modules/rest_middleware_flow_test.go:198:14: Error return value of `w.Write` is not checked (errcheck)
                                                w.Write([]byte(`{"status":"ok"}`))
                                                       ^
modules/rest_middleware_flow_test.go:200:14: Error return value of `w.Write` is not checked (errcheck)
                                                w.Write([]byte(`{"error":"not found"}`))
                                                       ^
modules/rest_middleware_flow_test.go:202:14: Error return value of `w.Write` is not checked (errcheck)
                                                w.Write([]byte(`{"error":"internal server error"}`))
                                                       ^
modules/din_middleware.go:420:1: cyclomatic complexity 42 of func `(*DinMiddleware).ServeHTTP` is high (> 30) (gocyclo)
func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
^
cmd/siwe-token/main.go:32:22: G304: Potential file inclusion via variable (gosec)
        hexKeyBytes, err := os.ReadFile(privateKeyFile)
                            ^
lib/auth/siwe/client.go:281:2: G104: Errors unhandled (gosec)
        hasher.Write([]byte(s))       // Hash the string
        ^
lib/auth/siwe/server.go:170:20: G304: Potential file inclusion via variable (gosec)
                                secret, err := ioutil.ReadFile(secretFilePath)
                                               ^
modules/caddy_unmarshaller.go:664:17: G115: integer overflow conversion int -> uint64 (gosec)
        *field = uint64(val)
                       ^
modules/caddy_unmarshaller.go:685:22: G304: Potential file inclusion via variable (gosec)
        hexKeyBytes, err := os.ReadFile(filename)
                            ^
modules/caddy_unmarshaller.go:688:22: G304: Potential file inclusion via variable (gosec)
                hexKeyBytes, err = ioutil.ReadFile(filename)
                                   ^
lib/auth/oidc/client.go:8:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
lib/auth/siwe/client.go:10:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
lib/auth/siwe/server.go:9:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
lib/network/beacon_handler.go:138:13: ST1005: error strings should not be capitalized (staticcheck)
                apiErr := fmt.Errorf("Beacon Chain API error: %v", errorField)
                          ^
lib/network/beacon_handler.go:237:14: ST1005: error strings should not be capitalized (staticcheck)
        return nil, fmt.Errorf("Beacon Chain uses REST API, not JSON-RPC block requests")
                    ^
lib/network/beacon_handler.go:279:14: ST1005: error strings should not be capitalized (staticcheck)
        return nil, fmt.Errorf("Beacon Chain does not support archive mode")
                    ^
lib/network/beacon_handler.go:283:9: ST1005: error strings should not be capitalized (staticcheck)
        return fmt.Errorf("Beacon Chain does not support archive mode")
               ^
lib/network/bitcoin_esplora_handler.go:175:14: ST1005: error strings should not be capitalized (staticcheck)
        return nil, fmt.Errorf("Bitcoin Esplora uses REST API, not JSON-RPC")
                    ^
lib/network/evm_handler.go:201:2: S1017: should replace this if statement with an unconditional strings.TrimPrefix (staticcheck)
        if strings.HasPrefix(chainIDNum, "0x") {
        ^
lib/network/solana_handler.go:12:2: ST1019: package "github.com/DIN-center/din-caddy-plugins/lib/http" is being imported more than once (staticcheck)
        dinHttp "github.com/DIN-center/din-caddy-plugins/lib/http"
        ^
lib/network/solana_handler.go:13:2: ST1019(related information): other import of "github.com/DIN-center/din-caddy-plugins/lib/http" (staticcheck)
        din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
        ^
lib/network/solana_handler.go:110:10: ST1005: error strings should not be capitalized (staticcheck)
                return fmt.Errorf("Solana JSON-RPC requires POST method, got %s", req.Method)
                       ^
lib/network/solana_handler.go:253:14: ST1005: error strings should not be capitalized (staticcheck)
        return nil, fmt.Errorf("Solana does not support archive mode")
                    ^
lib/network/solana_handler.go:257:9: ST1005: error strings should not be capitalized (staticcheck)
        return fmt.Errorf("Solana does not support archive mode")
               ^
lib/network/starknet_handler.go:109:10: ST1005: error strings should not be capitalized (staticcheck)
                return fmt.Errorf("Starknet JSON-RPC requires POST method, got %s", req.Method)
                       ^
modules/caddy_unmarshaller.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
modules/din_middleware.go:750:25: func (*DinMiddleware).getNetworkNames is unused (unused)
func (d *DinMiddleware) getNetworkNames() []string {
                        ^
modules/din_middleware.go:810:6: func min is unused (unused)
func min(a, b int) int {
     ^
modules/network_test.go:683:7: type mockPostResponse is unused (unused)
        type mockPostResponse struct {
             ^
77 issues:
* errcheck: 51
* gocyclo: 1
* gosec: 6
* staticcheck: 16
* unused: 3
```

The changes required to remove these issues are, in general, non-functional changes but in some cases, the order of logic is rearranged to improve how the logic "flows".  There are more improvements that could be made but, for now, the linter is not reporting issues.

One remaining issue is the cyclomatic complexity of `modules.(*DinMiddleware).ServeHTTP`.  I've added a `nolint` directive to this method as refactoring it would require more testing effort than the remainder of the reported linter issues combined.

## Clean shutdown of DIN middleware and networks

The one functional change in this PR is to cleanly shut down the DIN middleware and each of the provisioned networks.  This change can most easily be reviewed by inspecting the relevant commit - 53a29db.

## Testing

The changes in this PR were tested as follows:

1. `make check` passes all checks.
2. `make run` runs the caddy server and, after initialization, continues to show logs in the same fashion as before the changes were made.
3. Running `make run` before and after the clean shutdown code was added shows that the associated "close" functions are called.

Before:

```sh
2025/08/29 14:27:02.966 DEBUG   http.handlers.din       Successfully parsed block response      {"networkName": "bsc-mainnet", "machine_id": "@xps-15-7:866716", "environment": "dev"}
2025/08/29 14:27:02.966 DEBUG   http.handlers.din       Goroutine: HCMethod matched, successfully processed block number and added to network history        {"block_number": 59305722, "network": "bsc-mainnet", "machine_id": "@xps-15-7:866716", "environment": "dev"}
2025/08/29 14:27:02.967 INFO    admin   stopped previous server {"address": ":2019"}
2025/08/29 14:27:02.968 INFO    shutdown complete       {"signal": "SIGINT", "exit_code": 0}
```

After:

```sh
2025/08/29 15:48:30.837 DEBUG   http.handlers.din       Latest block metric data        {"network": "zksync-mainnet", "provider": "nd-455-933-745.p2pify.com", "health_status": "Warning", "environment": "dev", "machine_id": "@xps-15-7:926947", "environment": "dev"}
2025/08/29 15:48:30.874 DEBUG   http.handlers.din       Handler GetLatestBlockNumber succeeded  {"block_number": 64350001, "health_status": "healthy", "network": "zksync-mainnet", "provider": "zksync01.mainnet.rpc.northwestnodes.com", "machine_id": "@xps-15-7:926947", "environment": "dev"}
^C2025/08/29 15:48:30.940       INFO    shutting down   {"signal": "SIGINT"}
2025/08/29 15:48:30.941 WARN    exiting; byeee!! 👋     {"signal": "SIGINT"}
2025/08/29 11:48:30 [INFO] SIGINT: Shutting down
2025/08/29 15:48:30.941 DEBUG   events  event   {"name": "stopping", "id": "f663c8c5-3291-4acb-ad31-c5a3b81ef4d8", "origin": "", "data": null}
2025/08/29 15:48:30.941 INFO    http    servers shutting down with eternal grace period
2025/08/29 15:48:30.941 INFO    http.handlers.din       DIN nework closed: zksync-mainnet
2025/08/29 15:48:30.941 INFO    http.handlers.din       DIN nework closed: bsc-mainnet
2025/08/29 15:48:30.941 INFO    http.handlers.din       DIN nework closed: starknet-mainnet
2025/08/29 15:48:30.941 INFO    http.handlers.din       DIN middleware deprovisioned    {"machine_id": "@xps-15-7:926947", "environment": "dev"}
2025/08/29 15:48:30.942 INFO    admin   stopped previous server {"address": ":2019"}
2025/08/29 15:48:30.942 INFO    shutdown complete       {"signal": "SIGINT", "exit_code": 0}
```