### PR TITLE
[FIX]  Network initialization and registration after DIN Registry sync

### DIFF
--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -194,8 +194,9 @@ func (d *DinMiddleware) addNetworkWithRegistryData(regNetwork *din.Network) erro
 	// Add the network to the middleware object
 	d.Networks[network.Name] = network
 
-	// Register network in global registry for DinUpstreams access
-	RegisterNetwork(network.Name, network)
+	// We should initialize the network and register it in global registry for DinUpstreams access
+	d.logger.Info("Initializing network and registering in global registry", zap.String("network", network.Name))
+	d.initializeNetwork(network.Name)
 
 	// Start the healthcheck for the network if the middleware is not in test mode
 	if !d.testMode {


### PR DESCRIPTION
Fix how the network handlers are initialized after the DIN Router fetches data from the DIN Registry.  

**For testing**, this requires enabling the DIN Registry with the following:
```
din_registry {
  registry_enabled true
  registry_endpoint_url https://linea-sepolia.infura.io/v3/*******************
  registry_contract_address 0x9368f7261dc241a760b07fc568bbd8ef6445f8c7
  registry_block_check_interval_sec 5
  registry_block_epoch 2
  }
```