### PR TITLE
Allow post requests in esplora

### DIFF
--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -116,19 +116,7 @@ func (h *BitcoinEsploraHandler) NormalizeEndpoint(path string) string {
 }
 
 func (h *BitcoinEsploraHandler) ValidateRequest(req *http.Request) error {
-	// Block POST requests and return 405 Method Not Allowed
-	if req.Method == "POST" {
-		return &HTTPError{
-			StatusCode: http.StatusMethodNotAllowed,
-			Message:    "POST method not allowed for Bitcoin Esplora API",
-		}
-	}
-
-	// Check for valid HTTP methods - Bitcoin Esplora REST API now only supports GET
-	if req.Method != "GET" {
-		return fmt.Errorf("unsupported HTTP method for Bitcoin Esplora REST API: %s", req.Method)
-	}
-
+	// For now we let everything through
 	return nil
 }
 

--- a/lib/network/bitcoin_esplora_handler_test.go
+++ b/lib/network/bitcoin_esplora_handler_test.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"errors"
 	"net/http"
 	"testing"
 
@@ -53,26 +52,6 @@ func TestBitcoinEsploraHandler_ValidateRequest(t *testing.T) {
 			path:      "/blocks/tip/height",
 			expectErr: false,
 		},
-		{
-			name:      "blocked POST request for tx broadcast",
-			method:    "POST",
-			path:      "/tx",
-			headers:   map[string]string{"Content-Type": "text/plain"},
-			expectErr: true,
-		},
-		{
-			name:      "invalid method PUT",
-			method:    "PUT",
-			path:      "/blocks/tip/height",
-			expectErr: true,
-		},
-		{
-			name:      "blocked POST request with invalid content type",
-			method:    "POST",
-			path:      "/tx",
-			headers:   map[string]string{"Content-Type": "application/json"},
-			expectErr: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -97,19 +76,12 @@ func TestBitcoinEsploraHandler_ValidateRequest(t *testing.T) {
 func TestBitcoinEsploraHandler_ValidateRequest_HTTPError(t *testing.T) {
 	handler := NewBitcoinEsploraHandler(&NetworkConfig{})
 
-	// Test that POST requests return HTTPError with 405 status code
+	// Test that POST requests no longer return HTTPError with 405 status code
 	req, err := http.NewRequest("POST", "https://example.com/tx", nil)
 	require.NoError(t, err)
 
 	err = handler.ValidateRequest(req)
-	require.Error(t, err)
-
-	// Check that it's an HTTPError with the correct status code
-	httpErr := &HTTPError{}
-	ok := errors.As(err, &httpErr)
-	require.True(t, ok, "Expected HTTPError type")
-	assert.Equal(t, http.StatusMethodNotAllowed, httpErr.StatusCode)
-	assert.Equal(t, "POST method not allowed for Bitcoin Esplora API", httpErr.Message)
+	require.NoError(t, err)
 }
 
 func TestBitcoinEsploraHandler_NormalizeEndpoint(t *testing.T) {


### PR DESCRIPTION
Now that we have providers that implement OFAC compliance we can allow POST requests.