### PR TITLE
Refactor: Centralize retry logic and eliminate redundant retries

### DIFF
--- a/docs/retry-system.md
+++ b/docs/retry-system.md
@@ -1,0 +1,467 @@
+# Retry System Documentation
+
+## Overview
+
+The DIN Caddy Plugins use a centralized retry system built on top of the battle-tested [`github.com/cenkalti/backoff/v5`](https://github.com/cenkalti/backoff) package. This system provides automatic retry logic with exponential backoff for transient failures while offering comprehensive logging for observability.
+
+## Architecture
+
+### Core Components
+
+1. **`lib/network/retry.go`** - Central retry implementation
+2. **Exponential Backoff** - Automatically increases delay between retries
+3. **Enhanced Logging** - Structured logs with timing and context information
+4. **Conditional Retry Logic** - Support for retryable vs non-retryable errors
+
+### Key Features
+
+- **Exponential backoff** with jitter to prevent thundering herd
+- **Context-aware** - Respects context cancellation
+- **Comprehensive logging** for SRE observability
+- **Configurable max attempts** per operation
+- **Support for permanent (non-retryable) errors
+- **Structured logging fields** for easy querying
+
+## API Reference
+
+### `Retry` Function
+
+Simple retry mechanism for operations that should retry on any error.
+
+```go
+func Retry(
+    ctx context.Context,
+    logger Logger,
+    operationName string,
+    maxAttempts int,
+    operation func() error,
+    fields ...zap.Field,
+) error
+```
+
+**Parameters:**
+- `ctx` - Context for cancellation
+- `logger` - Logger interface (supports both zap.Logger and LoggerClient)
+- `operationName` - Descriptive name for the operation (used in logs)
+- `maxAttempts` - Maximum number of attempts before giving up
+- `operation` - The function to retry
+- `fields` - Additional structured logging fields
+
+**Example:**
+```go
+err := networklib.Retry(
+    context.Background(),
+    logger,
+    "get_registry_data",
+    3,
+    func() error {
+        return client.GetRegistryData()
+    },
+    zap.String("registry", "din"),
+    zap.String("endpoint", "https://api.example.com"),
+)
+```
+
+### `RetryWithChecker` Function
+
+Advanced retry mechanism with custom retry logic based on error type.
+
+```go
+func RetryWithChecker(
+    ctx context.Context,
+    logger Logger,
+    operationName string,
+    maxAttempts int,
+    isRetryable func(error) bool,
+    operation func() error,
+    fields ...zap.Field,
+) error
+```
+
+**Parameters:**
+- `ctx` - Context for cancellation
+- `logger` - Logger interface
+- `operationName` - Descriptive name for the operation
+- `maxAttempts` - Maximum number of attempts
+- `isRetryable` - Function to determine if an error should trigger a retry
+- `operation` - The function to retry
+- `fields` - Additional structured logging fields
+
+**Example:**
+```go
+err := networklib.RetryWithChecker(
+    context.Background(),
+    logger,
+    "chain_id_check",
+    5,
+    func(err error) bool {
+        // Only retry on network errors, not on validation errors
+        return IsNetworkError(err)
+    },
+    func() error {
+        return validateChainID()
+    },
+    zap.String("provider", "infura"),
+    zap.String("network", "ethereum"),
+)
+```
+
+## Retry Behavior
+
+### Exponential Backoff Strategy
+
+The retry system uses exponential backoff with the following characteristics:
+
+1. **Initial Interval**: 500ms (default)
+2. **Multiplier**: 1.5x (default)
+3. **Randomization Factor**: ±50% jitter
+4. **Max Interval**: 60 seconds (default)
+
+Example backoff sequence:
+```
+Attempt 1: Immediate
+Attempt 2: ~500ms delay (250-750ms with jitter)
+Attempt 3: ~750ms delay (375-1125ms with jitter)
+Attempt 4: ~1.125s delay (562-1687ms with jitter)
+...continues exponentially...
+```
+
+### Non-Retryable Errors
+
+When using `RetryWithChecker`, if the `isRetryable` function returns `false`, the retry loop stops immediately and returns the error. This is useful for:
+
+- **Business logic errors** (e.g., invalid credentials)
+- **Client errors** (e.g., 400 Bad Request)
+- **Permanent failures** (e.g., resource not found)
+
+## Logging Structure
+
+### Log Levels
+
+- **Debug**: Individual attempt results
+- **Info**: Retry notifications and final outcomes
+- **Warn/Error**: Used by calling code for business-specific issues
+
+### Structured Fields
+
+Every log entry includes these base fields:
+- `operation` - The operation name
+- `max_attempts` - Maximum configured attempts
+- Custom fields passed via the `fields` parameter
+
+#### Per-Attempt Fields
+- `attempt` - Current attempt number
+- `attempt_duration` - Duration of this attempt
+- `total_elapsed` - Total time since first attempt
+- `error` - The error that occurred (if any)
+- `retryable` - Whether the error is retryable (RetryWithChecker only)
+
+#### Backoff Notification Fields
+- `backoff_duration` - Time until next retry
+- `total_elapsed` - Total elapsed time
+
+#### Final Result Fields
+- `total_attempts` - Number of attempts made
+- `total_duration` - Total time taken
+- `permanent_error` - Whether failure was due to non-retryable error
+
+### Example Log Output
+
+```json
+{
+  "level": "debug",
+  "msg": "Retryable error encountered, will retry",
+  "operation": "chain_id_check",
+  "max_attempts": 3,
+  "provider": "infura",
+  "network": "ethereum",
+  "error": "connection timeout",
+  "retryable": true,
+  "attempt": 1,
+  "attempt_duration": "5.2s",
+  "total_elapsed": "5.2s"
+}
+
+{
+  "level": "info",
+  "msg": "Retrying operation after backoff",
+  "operation": "chain_id_check",
+  "max_attempts": 3,
+  "provider": "infura",
+  "network": "ethereum",
+  "attempt": 1,
+  "backoff_duration": "750ms",
+  "total_elapsed": "5.2s"
+}
+
+{
+  "level": "debug",
+  "msg": "Operation succeeded",
+  "operation": "chain_id_check",
+  "max_attempts": 3,
+  "provider": "infura",
+  "network": "ethereum",
+  "attempt": 2,
+  "attempt_duration": "1.3s",
+  "total_duration": "7.25s"
+}
+```
+
+## Usage Patterns
+
+### Pattern 1: Simple Retry for Registry Calls
+
+```go
+err := networklib.Retry(
+    ctx,
+    d.logger,
+    "get_registry_data",
+    d.Registry.RetryMaxAttempts+1,
+    func() error {
+        data, err = d.DingoClient.GetRegistryData()
+        return err
+    },
+    zap.String("registry_endpoint", d.Registry.EndpointUrl),
+)
+```
+
+### Pattern 2: Conditional Retry for Network Operations
+
+```go
+err := networklib.RetryWithChecker(
+    ctx,
+    n.logger,
+    "get_latest_block_number",
+    n.RequestAttemptCount,
+    func(err error) bool {
+        statusCode := 0
+        if lastResult != nil {
+            statusCode = lastResult.ResponseStatus
+        }
+        return n.handler.IsRetryableError(err, statusCode)
+    },
+    func() error {
+        res, err := n.handler.GetLatestBlockNumber(...)
+        // Process result
+        return err
+    },
+    zap.String("provider", providerHost),
+    zap.String("network", n.Name),
+)
+```
+
+### Pattern 3: Archive Mode Check with Retry
+
+```go
+return networklib.RetryWithChecker(
+    ctx,
+    n.logger,
+    "archive_check",
+    n.RequestAttemptCount,
+    func(err error) bool {
+        return n.handler.IsRetryableError(err, 0)
+    },
+    func() error {
+        return n.handler.PerformArchiveCheck(...)
+    },
+    zap.String("provider", provider.host),
+    zap.String("block_height", blockHeightString),
+)
+```
+
+## Configuration
+
+### Setting Max Attempts
+
+Max attempts are typically configured at the network or middleware level:
+
+```go
+// In network configuration
+n.RequestAttemptCount = 3  // Will retry up to 3 times
+
+// In middleware configuration
+d.Registry.RetryMaxAttempts = 2  // Will retry up to 3 times (0-indexed)
+```
+
+### Context with Timeout
+
+Use context with timeout to set an overall time limit:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+err := networklib.Retry(ctx, logger, "operation", 5, func() error {
+    // Operation that might take time
+    return performOperation()
+})
+```
+
+## Best Practices
+
+### 1. Choose the Right Retry Function
+
+- Use `Retry` for operations that should retry on any error
+- Use `RetryWithChecker` when you need to distinguish between retryable and non-retryable errors
+
+### 2. Set Appropriate Max Attempts
+
+- Network operations: 3-5 attempts
+- Registry/configuration fetches: 2-3 attempts
+- Critical operations: Consider higher attempts with longer timeouts
+
+### 3. Add Meaningful Context Fields
+
+Always include relevant context in the fields parameter:
+```go
+// Good - includes context
+networklib.Retry(ctx, logger, "fetch_block", 3, operation,
+    zap.String("provider", provider),
+    zap.String("network", network),
+    zap.Int64("block_number", blockNum),
+)
+
+// Bad - missing context
+networklib.Retry(ctx, logger, "fetch_block", 3, operation)
+```
+
+### 4. Handle Non-Retryable Errors Appropriately
+
+```go
+func isRetryable(err error) bool {
+    // Don't retry on client errors
+    if httpErr, ok := err.(HTTPError); ok {
+        if httpErr.StatusCode >= 400 && httpErr.StatusCode < 500 {
+            return false  // Client error, don't retry
+        }
+    }
+
+    // Don't retry on context cancellation
+    if errors.Is(err, context.Canceled) {
+        return false
+    }
+
+    // Retry on other errors (network, server errors, etc.)
+    return true
+}
+```
+
+### 5. Monitor Retry Metrics
+
+Use the structured logs to monitor:
+- Retry rates per operation
+- Average number of attempts
+- Total time spent in retries
+- Success rates after retries
+
+## Troubleshooting
+
+### High Retry Rates
+
+If seeing high retry rates:
+1. Check `retryable` field in logs to understand error types
+2. Review `attempt_duration` to identify slow operations
+3. Look at `backoff_duration` to ensure proper backoff
+4. Consider adjusting `max_attempts` or timeout values
+
+### Debugging Failed Operations
+
+Look for these log patterns:
+1. `"msg": "Non-retryable error encountered"` - Permanent failure
+2. `"msg": "Operation failed on final attempt"` - Exhausted retries
+3. `"error": "context canceled"` - Operation was cancelled
+4. Check `total_duration` vs individual `attempt_duration` to identify delays
+
+### Performance Optimization
+
+- Reduce `max_attempts` for non-critical operations
+- Implement circuit breakers for frequently failing endpoints
+- Use shorter timeouts for fast-fail scenarios
+- Consider implementing fallback mechanisms
+
+## Migration Guide
+
+### From Direct backoff Usage
+
+Before:
+```go
+b := backoff.NewExponentialBackOff()
+_, err := backoff.Retry(ctx, operation,
+    backoff.WithBackOff(b),
+    backoff.WithMaxTries(3),
+)
+```
+
+After:
+```go
+err := networklib.Retry(ctx, logger, "operation_name", 3, operation,
+    zap.String("context", "value"),
+)
+```
+
+### From Manual Retry Loops
+
+Before:
+```go
+for attempt := 0; attempt < maxAttempts; attempt++ {
+    err := operation()
+    if err == nil {
+        return nil
+    }
+    if !isRetryable(err) {
+        return err
+    }
+    time.Sleep(backoffDuration(attempt))
+}
+```
+
+After:
+```go
+err := networklib.RetryWithChecker(
+    ctx, logger, "operation_name", maxAttempts,
+    isRetryable, operation,
+    zap.String("context", "value"),
+)
+```
+
+## Testing
+
+### Unit Testing with Retry
+
+```go
+func TestWithRetry(t *testing.T) {
+    logger := zaptest.NewLogger(t)
+    attempts := 0
+
+    err := networklib.Retry(
+        context.Background(),
+        logger,
+        "test_operation",
+        3,
+        func() error {
+            attempts++
+            if attempts < 2 {
+                return errors.New("temporary error")
+            }
+            return nil
+        },
+    )
+
+    assert.NoError(t, err)
+    assert.Equal(t, 2, attempts)
+}
+```
+
+### Mocking for Tests
+
+When testing code that uses retry, you can:
+1. Set `maxAttempts` to 1 to disable retries
+2. Use a cancelled context to skip retries
+3. Mock the operation to succeed immediately
+
+## Related Documentation
+
+- [Exponential Backoff Algorithm](https://en.wikipedia.org/wiki/Exponential_backoff)
+- [cenkalti/backoff Documentation](https://github.com/cenkalti/backoff)
+- [Structured Logging Best Practices](https://www.datadoghq.com/blog/go-logging/)
+- [Circuit Breaker Pattern](https://martinfowler.com/bliki/CircuitBreaker.html)

--- a/lib/network/beacon_handler.go
+++ b/lib/network/beacon_handler.go
@@ -486,160 +486,150 @@ func (h *BeaconChainHandler) ParseChainIDResponse(body []byte, statusCode int) (
 // For beacon chain, we can either return the configured chain ID directly
 // or make a REST API call to get the network configuration
 func (h *BeaconChainHandler) GetChainID(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (string, error) {
-	var lastErr error
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Make GET request to config/spec endpoint
-		configURL, err := url.JoinPath(httpUrl, h.GetChainIDMethod())
-		if err != nil {
-			lastErr = fmt.Errorf("failed to construct config URL: %w", err)
-			continue
-		}
-		resBytes, statusCode, err := httpClient.Get(configURL, headers, authClient)
-		if err != nil {
-			lastErr = fmt.Errorf("error sending HTTP request: %w", err)
-			continue
-		}
-
-		// Parse the response to extract chain ID
-		chainID, err := h.ParseChainIDResponse(resBytes, *statusCode)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		// Success!
-		return chainID, nil
+	// Single attempt - let middleware handle retries
+	configURL, err := url.JoinPath(httpUrl, h.GetChainIDMethod())
+	if err != nil {
+		return "", fmt.Errorf("failed to construct config URL: %w", err)
+	}
+	resBytes, statusCode, err := httpClient.Get(configURL, headers, authClient)
+	if err != nil {
+		return "", fmt.Errorf("error sending HTTP request: %w", err)
 	}
 
-	return "", fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+	// Parse the response to extract chain ID
+	chainID, err := h.ParseChainIDResponse(resBytes, *statusCode)
+	if err != nil {
+		return "", err
+	}
+
+	return chainID, nil
 }
 
 // GetLatestBlockNumber retrieves the latest block number (slot) for beacon chain
 // Uses the REST API endpoint /eth/v2/beacon/blocks/head to get the latest slot
 func (h *BeaconChainHandler) GetLatestBlockNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (*LatestBlockResult, error) {
-	var lastErr error
-	var lastResponseStatus int
-	var lastHealthStatus = Unhealthy
-
-	// Use the block info endpoint to get latest slot
+	// Single attempt - let middleware handle retries
 	blockInfoMethod := h.GetBlockInfoMethod()
 
 	h.logger.Debug("Starting beacon chain latest block number request",
 		zap.String("endpoint", blockInfoMethod),
-		zap.String("base_url", httpUrl),
-		zap.Int("max_attempts", requestAttempts))
+		zap.String("base_url", httpUrl))
 
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Make GET request to beacon headers/head endpoint
-		blockInfoURL, err := url.JoinPath(httpUrl, blockInfoMethod)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to construct block info URL: %w", err)
-			lastHealthStatus = Unhealthy
-			continue
-		}
-
-		h.logger.Debug("Making GET request for latest block number",
-			zap.String("url", blockInfoURL),
-			zap.String("network", "beacon"),
-			zap.Int("attempt", attempt+1))
-
-		resBytes, statusCode, err := httpClient.Get(blockInfoURL, headers, authClient)
-		if statusCode != nil {
-			lastResponseStatus = *statusCode
-		}
-
-		if err != nil {
-			lastErr = fmt.Errorf("error sending HTTP request: %w", err)
-			// Check if it's a retryable error based on status code
-			if lastResponseStatus >= 500 || lastResponseStatus == 429 {
-				lastHealthStatus = Warning
-			} else {
-				lastHealthStatus = Unhealthy
-			}
-			h.logger.Debug("HTTP request failed",
-				zap.Error(err),
-				zap.Int("status_code", lastResponseStatus),
-				zap.Int("attempt", attempt+1))
-			continue
-		}
-
-		// Check HTTP status code
-		if lastResponseStatus >= 400 {
-			if lastResponseStatus == 429 {
-				lastErr = fmt.Errorf("rate limit error (status code: %d)", lastResponseStatus)
-				lastHealthStatus = Warning
-			} else {
-				lastErr = fmt.Errorf("error status code: %d", lastResponseStatus)
-				lastHealthStatus = Unhealthy
-			}
-			h.logger.Debug("HTTP request returned error status",
-				zap.Int("status_code", lastResponseStatus),
-				zap.String("response_body", string(resBytes)),
-				zap.Int("attempt", attempt+1))
-			continue
-		}
-
-		h.logger.Debug("Received successful response from beacon API",
-			zap.Int("status_code", lastResponseStatus),
-			zap.Int("response_size", len(resBytes)),
-			zap.String("response_preview", string(resBytes[:min(len(resBytes), 200)])))
-
-		// Parse the beacon chain response to get block info
-		blockInfo, err := h.ParseHealthCheckResponse(resBytes)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to parse beacon chain response: %w", err)
-			lastHealthStatus = Unhealthy
-			h.logger.Debug("Failed to parse beacon response",
-				zap.Error(err),
-				zap.String("response_snippet", string(resBytes[:min(len(resBytes), 500)])),
-				zap.Int("attempt", attempt+1))
-			continue
-		}
-
-		if blockInfo == nil {
-			lastErr = fmt.Errorf("beacon chain response parsing returned nil block info")
-			lastHealthStatus = Unhealthy
-			h.logger.Debug("Received nil block info from parser",
-				zap.Int("attempt", attempt+1))
-			continue
-		}
-
-		// Success! Use slot as block number for consistency with other networks
-		h.logger.Debug("Successfully retrieved latest block number",
-			zap.Int64("slot", blockInfo.Number), // Number field contains slot for beacon chain
-			zap.Int64("block_number", blockInfo.Number),
-			zap.Int64("epoch", getInt64FromMetadata(blockInfo.Metadata, "epoch")),
-			zap.String("hash", blockInfo.Hash),
-			zap.Bool("execution_optimistic", getBoolFromMetadata(blockInfo.Metadata, "execution_optimistic")),
-			zap.Bool("finalized", getBoolFromMetadata(blockInfo.Metadata, "finalized")))
-
+	// Make GET request to beacon headers/head endpoint
+	blockInfoURL, err := url.JoinPath(httpUrl, blockInfoMethod)
+	if err != nil {
 		return &LatestBlockResult{
-			BlockNumber:    blockInfo.Number, // This will be the slot number
-			HealthStatus:   Healthy,
-			ResponseStatus: lastResponseStatus,
-			Metadata: map[string]interface{}{
-				"slot":      blockInfo.Number, // Number field contains slot for beacon chain
-				"epoch":     getInt64FromMetadata(blockInfo.Metadata, "epoch"),
-				"hash":      blockInfo.Hash,
-				"timestamp": blockInfo.Timestamp,
-				"endpoint":  blockInfoMethod,
-			},
-		}, nil
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: 0,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("failed to construct block info URL: %w", err)
 	}
 
-	// All attempts failed
-	h.logger.Warn("All attempts to get latest block number failed",
-		zap.Error(lastErr),
-		zap.Int("attempts", requestAttempts),
-		zap.String("health_status", lastHealthStatus.String()),
-		zap.String("endpoint", blockInfoMethod))
+	h.logger.Debug("Making GET request for latest block number",
+		zap.String("url", blockInfoURL),
+		zap.String("network", "beacon"))
+
+	resBytes, statusCode, err := httpClient.Get(blockInfoURL, headers, authClient)
+	var responseStatus int
+	if statusCode != nil {
+		responseStatus = *statusCode
+	}
+
+	if err != nil {
+		// Check if it's a retryable error based on status code
+		var healthStatus HealthStatus
+		if responseStatus >= 500 || responseStatus == 429 {
+			healthStatus = Warning
+		} else {
+			healthStatus = Unhealthy
+		}
+		h.logger.Debug("HTTP request failed",
+			zap.Error(err),
+			zap.Int("status_code", responseStatus))
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   healthStatus,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("error sending HTTP request: %w", err)
+	}
+
+	// Check HTTP status code
+	if responseStatus >= 400 {
+		var healthStatus HealthStatus
+		var errMsg string
+		if responseStatus == 429 {
+			errMsg = fmt.Sprintf("rate limit error (status code: %d)", responseStatus)
+			healthStatus = Warning
+		} else if responseStatus >= 500 {
+			errMsg = fmt.Sprintf("server error (status code: %d)", responseStatus)
+			healthStatus = Warning
+		} else {
+			errMsg = fmt.Sprintf("error status code: %d", responseStatus)
+			healthStatus = Unhealthy
+		}
+		h.logger.Debug("HTTP request returned error status",
+			zap.Int("status_code", responseStatus),
+			zap.String("response_body", string(resBytes)))
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   healthStatus,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("%s", errMsg)
+	}
+
+	h.logger.Debug("Received successful response from beacon API",
+		zap.Int("status_code", responseStatus),
+		zap.Int("response_size", len(resBytes)),
+		zap.String("response_preview", string(resBytes[:min(len(resBytes), 200)])))
+
+	// Parse the beacon chain response to get block info
+	blockInfo, err := h.ParseHealthCheckResponse(resBytes)
+	if err != nil {
+		h.logger.Debug("Failed to parse beacon response",
+			zap.Error(err),
+			zap.String("response_snippet", string(resBytes[:min(len(resBytes), 500)])))
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("failed to parse beacon chain response: %w", err)
+	}
+
+	if blockInfo == nil {
+		h.logger.Debug("Received nil block info from parser")
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("beacon chain response parsing returned nil block info")
+	}
+
+	// Success! Use slot as block number for consistency with other networks
+	h.logger.Debug("Successfully retrieved latest block number",
+		zap.Int64("slot", blockInfo.Number), // Number field contains slot for beacon chain
+		zap.Int64("block_number", blockInfo.Number),
+		zap.Int64("epoch", getInt64FromMetadata(blockInfo.Metadata, "epoch")),
+		zap.String("hash", blockInfo.Hash),
+		zap.Bool("execution_optimistic", getBoolFromMetadata(blockInfo.Metadata, "execution_optimistic")),
+		zap.Bool("finalized", getBoolFromMetadata(blockInfo.Metadata, "finalized")))
 
 	return &LatestBlockResult{
-		BlockNumber:    0,
-		HealthStatus:   lastHealthStatus,
-		ResponseStatus: lastResponseStatus,
-		Metadata:       make(map[string]interface{}),
-	}, fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+		BlockNumber:    blockInfo.Number, // This will be the slot number
+		HealthStatus:   Healthy,
+		ResponseStatus: responseStatus,
+		Metadata: map[string]interface{}{
+			"slot":      blockInfo.Number, // Number field contains slot for beacon chain
+			"epoch":     getInt64FromMetadata(blockInfo.Metadata, "epoch"),
+			"hash":      blockInfo.Hash,
+			"timestamp": blockInfo.Timestamp,
+			"endpoint":  blockInfoMethod,
+		},
+	}, nil
 }
 
 // PerformArchiveCheck for beacon chain - stubbed out (archive mode disabled)
@@ -759,4 +749,12 @@ func getBoolFromMetadata(metadata map[string]interface{}, key string) bool {
 		}
 	}
 	return false
+}
+
+// Helper function to get minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/lib/network/beacon_handler.go
+++ b/lib/network/beacon_handler.go
@@ -751,10 +751,3 @@ func getBoolFromMetadata(metadata map[string]interface{}, key string) bool {
 	return false
 }
 
-// Helper function to get minimum of two integers
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -282,44 +282,59 @@ func (h *BitcoinEsploraHandler) ParseHealthCheckResponse(body []byte) (*BlockInf
 func (h *BitcoinEsploraHandler) GetLatestBlockNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (*LatestBlockResult, error) {
 	endpoint := httpUrl + h.healthCheckEndpoint
 
-	// Execute request with retries
-	var resp []byte
-	var lastErr error
-	var statusCode int
+	// Single attempt - let middleware handle retries
+	respBytes, status, err := httpClient.Get(endpoint, headers, authClient)
 
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		respBytes, status, err := httpClient.Get(endpoint, headers, authClient)
-		if err != nil {
-			lastErr = err
-			if status != nil {
-				statusCode = *status
-			}
-			continue
-		}
-		if status != nil {
-			statusCode = *status
-		}
-		if statusCode >= 200 && statusCode < 300 {
-			resp = respBytes
-			break
-		}
-		lastErr = fmt.Errorf("HTTP error %d", statusCode)
+	var statusCode int
+	if status != nil {
+		statusCode = *status
 	}
 
-	if resp == nil {
-		return nil, lastErr
+	if err != nil {
+		var healthStatus HealthStatus
+		if statusCode >= 500 || statusCode == 429 {
+			healthStatus = Warning
+		} else {
+			healthStatus = Unhealthy
+		}
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   healthStatus,
+			ResponseStatus: statusCode,
+			Metadata:       make(map[string]interface{}),
+		}, err
+	}
+
+	if statusCode < 200 || statusCode >= 300 {
+		var healthStatus HealthStatus
+		if statusCode >= 500 || statusCode == 429 {
+			healthStatus = Warning
+		} else {
+			healthStatus = Unhealthy
+		}
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   healthStatus,
+			ResponseStatus: statusCode,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("HTTP error %d", statusCode)
 	}
 
 	// Parse response
-	blockInfo, err := h.ParseHealthCheckResponse(resp)
+	blockInfo, err := h.ParseHealthCheckResponse(respBytes)
 	if err != nil {
-		return nil, err
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: statusCode,
+			Metadata:       make(map[string]interface{}),
+		}, err
 	}
 
 	return &LatestBlockResult{
 		BlockNumber:    blockInfo.Number,
 		HealthStatus:   Healthy,
-		ResponseStatus: 200,
+		ResponseStatus: statusCode,
 		Metadata:       make(map[string]interface{}),
 	}, nil
 }
@@ -391,39 +406,27 @@ func (h *BitcoinEsploraHandler) PerformArchiveCheck(httpUrl string, headers map[
 
 // PerformGetBlockByNumber performs the complete get block by number operation
 func (h *BitcoinEsploraHandler) PerformGetBlockByNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (interface{}, error) {
+	// Single attempt - let middleware handle retries
 	// First get block hash by height
 	endpoint := fmt.Sprintf("%s/block-height/%d", httpUrl, blockNumber)
 
 	// Execute request to get block hash
-	var resp []byte
-	var lastErr error
-	var statusCode int
-
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		respBytes, status, err := httpClient.Get(endpoint, headers, authClient)
-		if err != nil {
-			lastErr = err
-			if status != nil {
-				statusCode = *status
-			}
-			continue
-		}
-		if status != nil {
-			statusCode = *status
-		}
-		if statusCode >= 200 && statusCode < 300 {
-			resp = respBytes
-			break
-		}
-		lastErr = fmt.Errorf("HTTP error %d", statusCode)
+	respBytes, status, err := httpClient.Get(endpoint, headers, authClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get block hash: %w", err)
 	}
 
-	if resp == nil {
-		return nil, fmt.Errorf("failed to get block hash: %w", lastErr)
+	var statusCode int
+	if status != nil {
+		statusCode = *status
+	}
+
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, fmt.Errorf("HTTP error %d getting block hash", statusCode)
 	}
 
 	var blockHash string
-	if err := json.Unmarshal(resp, &blockHash); err != nil {
+	if err := json.Unmarshal(respBytes, &blockHash); err != nil {
 		return nil, fmt.Errorf("failed to parse block hash: %w", err)
 	}
 
@@ -431,31 +434,18 @@ func (h *BitcoinEsploraHandler) PerformGetBlockByNumber(httpUrl string, headers 
 	blockEndpoint := fmt.Sprintf("%s/block/%s", httpUrl, blockHash)
 
 	// Execute request to get block data
-	var blockResp []byte
-	lastErr = nil
-
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		respBytes, status, err := httpClient.Get(blockEndpoint, headers, authClient)
-		if err != nil {
-			lastErr = err
-			if status != nil {
-				statusCode = *status
-			}
-			continue
-		}
-		if status != nil {
-			statusCode = *status
-		}
-		if statusCode >= 200 && statusCode < 300 {
-			blockResp = respBytes
-			break
-		}
-		lastErr = fmt.Errorf("HTTP error %d", statusCode)
+	blockRespBytes, blockStatus, err := httpClient.Get(blockEndpoint, headers, authClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get block data: %w", err)
 	}
 
-	if blockResp == nil {
-		return nil, fmt.Errorf("failed to get block data: %w", lastErr)
+	if blockStatus != nil {
+		statusCode = *blockStatus
 	}
 
-	return h.ParseBlockResponse(blockResp)
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, fmt.Errorf("HTTP error %d getting block data", statusCode)
+	}
+
+	return h.ParseBlockResponse(blockRespBytes)
 }

--- a/lib/network/bitcoin_handler.go
+++ b/lib/network/bitcoin_handler.go
@@ -444,80 +444,63 @@ func (h *BitcoinHandler) PerformArchiveCheck(httpUrl string, headers map[string]
 // PerformGetBlockByNumber performs get block by number operation for Bitcoin chains using JSON-RPC
 // This implements the two-step process: getblockhash -> getblock
 func (h *BitcoinHandler) PerformGetBlockByNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (interface{}, error) {
-	var lastErr error
-
+	// Single attempt - let middleware handle retries
 	// Step 1: Get block hash from block number
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Create getblockhash request
-		hashPayload, err := h.CreateBlockRequest("getblockhash", blockNumber, false)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to create getblockhash request: %w", err)
-			continue
-		}
-
-		// Make POST request for block hash
-		hashResBytes, statusCode, err := httpClient.Post(httpUrl, headers, hashPayload, authClient)
-		if err != nil {
-			lastErr = fmt.Errorf("error sending getblockhash request: %w", err)
-			continue
-		}
-
-		// Check HTTP status
-		if statusCode != nil && *statusCode >= 400 {
-			lastErr = fmt.Errorf("HTTP error for getblockhash: %d", *statusCode)
-			continue
-		}
-
-		// Parse response to get block hash
-		var hashResponse JSONRPCResponse
-		if err := json.Unmarshal(hashResBytes, &hashResponse); err != nil {
-			lastErr = fmt.Errorf("failed to parse getblockhash response: %w", err)
-			continue
-		}
-
-		// Check for JSON-RPC error
-		if hashResponse.Error != nil {
-			lastErr = fmt.Errorf("getblockhash error %d: %s", hashResponse.Error.Code, hashResponse.Error.Message)
-			continue
-		}
-
-		// Extract block hash from result
-		var blockHash string
-		if err := json.Unmarshal(hashResponse.Result, &blockHash); err != nil {
-			lastErr = fmt.Errorf("failed to extract block hash: %w", err)
-			continue
-		}
-
-		// Step 2: Get block details using the hash
-		blockPayload, err := h.CreateBlockRequestWithHash(blockHash, false)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to create getblock request: %w", err)
-			continue
-		}
-
-		// Make POST request for block details
-		blockResBytes, statusCode, err := httpClient.Post(httpUrl, headers, blockPayload, authClient)
-		if err != nil {
-			lastErr = fmt.Errorf("error sending getblock request: %w", err)
-			continue
-		}
-
-		// Check HTTP status
-		if statusCode != nil && *statusCode >= 400 {
-			lastErr = fmt.Errorf("HTTP error for getblock: %d", *statusCode)
-			continue
-		}
-
-		// Parse block response
-		blockData, err := h.ParseBlockResponse(blockResBytes)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		// Success!
-		return blockData, nil
+	hashPayload, err := h.CreateBlockRequest("getblockhash", blockNumber, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create getblockhash request: %w", err)
 	}
 
-	return nil, fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+	// Make POST request for block hash
+	hashResBytes, statusCode, err := httpClient.Post(httpUrl, headers, hashPayload, authClient)
+	if err != nil {
+		return nil, fmt.Errorf("error sending getblockhash request: %w", err)
+	}
+
+	// Check HTTP status
+	if statusCode != nil && *statusCode >= 400 {
+		return nil, fmt.Errorf("HTTP error for getblockhash: %d", *statusCode)
+	}
+
+	// Parse response to get block hash
+	var hashResponse JSONRPCResponse
+	if err := json.Unmarshal(hashResBytes, &hashResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse getblockhash response: %w", err)
+	}
+
+	// Check for JSON-RPC error
+	if hashResponse.Error != nil {
+		return nil, fmt.Errorf("getblockhash error %d: %s", hashResponse.Error.Code, hashResponse.Error.Message)
+	}
+
+	// Extract block hash from result
+	var blockHash string
+	if err := json.Unmarshal(hashResponse.Result, &blockHash); err != nil {
+		return nil, fmt.Errorf("failed to extract block hash: %w", err)
+	}
+
+	// Step 2: Get block details using the hash
+	blockPayload, err := h.CreateBlockRequestWithHash(blockHash, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create getblock request: %w", err)
+	}
+
+	// Make POST request for block details
+	blockResBytes, statusCode, err := httpClient.Post(httpUrl, headers, blockPayload, authClient)
+	if err != nil {
+		return nil, fmt.Errorf("error sending getblock request: %w", err)
+	}
+
+	// Check HTTP status
+	if statusCode != nil && *statusCode >= 400 {
+		return nil, fmt.Errorf("HTTP error for getblock: %d", *statusCode)
+	}
+
+	// Parse block response
+	blockData, err := h.ParseBlockResponse(blockResBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return blockData, nil
 }

--- a/lib/network/json_rpc_client.go
+++ b/lib/network/json_rpc_client.go
@@ -17,171 +17,170 @@ import (
 // GetChainIDViaJSONRPC performs a JSON-RPC chain ID request
 // This is shared logic for JSON-RPC based handlers (EVM, Starknet, Solana)
 func GetChainIDViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, chainIDMethod string, parseFunc func([]byte, int) (string, error)) (string, error) {
-
+	// Single attempt - let middleware handle retries
 	// Create JSON-RPC payload for chain ID request
 	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"%s","params":[],"id":1}`, chainIDMethod))
 
-	var lastErr error
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Make POST request with payload
-		resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
-		if err != nil {
-			lastErr = fmt.Errorf("error sending HTTP request: %w", err)
-			continue
-		}
-
-		// Use the provided parse function to extract chain ID
-		chainID, err := parseFunc(resBytes, *statusCode)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		// Success!
-		return chainID, nil
+	// Make POST request with payload
+	resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
+	if err != nil {
+		return "", fmt.Errorf("error sending HTTP request: %w", err)
 	}
 
-	return "", fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+	// Use the provided parse function to extract chain ID
+	chainID, err := parseFunc(resBytes, *statusCode)
+	if err != nil {
+		return "", err
+	}
+
+	return chainID, nil
 }
 
 // GetLatestBlockNumberViaJSONRPC performs a JSON-RPC latest block number request
 // This is shared logic for JSON-RPC based handlers (EVM, Starknet, Solana)
 func GetLatestBlockNumberViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumberMethod string, parseFunc func(json.RawMessage) (int64, error)) (*LatestBlockResult, error) {
+	// Single attempt - let middleware handle retries
 	// Create JSON-RPC payload for latest block number request
 	payload := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"%s","params":[],"id":1}`, blockNumberMethod))
 
-	var lastErr error
-	var lastResponseStatus int
-	var lastHealthStatus = Unhealthy
-
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Make POST request with payload
-		resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
-		if statusCode != nil {
-			lastResponseStatus = *statusCode
-		}
-
-		if err != nil {
-			lastErr = fmt.Errorf("error sending HTTP request: %w", err)
-			// HTTP connection errors are considered unhealthy (matches original test expectations)
-			lastHealthStatus = Unhealthy
-			continue
-		}
-
-		// Check HTTP status code for rate limiting first
-		if lastResponseStatus == 429 {
-			lastErr = fmt.Errorf("rate limit error (status code: %d)", lastResponseStatus)
-			lastHealthStatus = Warning
-			continue
-		}
-
-		// Check for other HTTP error status codes
-		if lastResponseStatus >= 400 {
-			lastErr = fmt.Errorf("error status code: %d", lastResponseStatus)
-			// All HTTP error status codes are considered unhealthy (matches original test expectations)
-			lastHealthStatus = Unhealthy
-			continue
-		}
-
-		// Parse JSON-RPC response structure
-		var response JSONRPCResponse
-		if err := json.Unmarshal(resBytes, &response); err != nil {
-			lastErr = fmt.Errorf("failed to parse JSON-RPC response: %w", err)
-			lastHealthStatus = Unhealthy
-			continue
-		}
-
-		// Check for JSON-RPC error
-		if response.Error != nil {
-			lastErr = fmt.Errorf("JSON-RPC error %d: %s", response.Error.Code, response.Error.Message)
-			// Classify JSON-RPC errors based on their nature
-			if IsRetryableJSONRPCError(lastErr, lastResponseStatus) {
-				lastHealthStatus = Warning
-			} else {
-				lastHealthStatus = Unhealthy
-			}
-			continue
-		}
-
-		// Use the provided parse function to extract block number
-		blockNumber, err := parseFunc(response.Result)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to parse block number from result: %w", err)
-			lastHealthStatus = Unhealthy
-			continue
-		}
-
-		// Success!
-		return &LatestBlockResult{
-			BlockNumber:    blockNumber,
-			HealthStatus:   Healthy,
-			ResponseStatus: lastResponseStatus,
-			Metadata:       make(map[string]interface{}),
-		}, nil
+	// Make POST request with payload
+	resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
+	var responseStatus int
+	if statusCode != nil {
+		responseStatus = *statusCode
 	}
 
-	// All attempts failed
+	if err != nil {
+		// HTTP connection errors are considered unhealthy
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("error sending HTTP request: %w", err)
+	}
+
+	// Check HTTP status code for rate limiting first
+	if responseStatus == 429 {
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Warning,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("rate limit error (status code: %d)", responseStatus)
+	}
+
+	// Check for server errors (5xx)
+	if responseStatus >= 500 {
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Warning,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("server error (status code: %d)", responseStatus)
+	}
+
+	// Check for other HTTP error status codes
+	if responseStatus >= 400 {
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("error status code: %d", responseStatus)
+	}
+
+	// Parse JSON-RPC response structure
+	var response JSONRPCResponse
+	if err := json.Unmarshal(resBytes, &response); err != nil {
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("failed to parse JSON-RPC response: %w", err)
+	}
+
+	// Check for JSON-RPC error
+	if response.Error != nil {
+		var healthStatus HealthStatus
+		// Classify JSON-RPC errors based on their nature
+		if IsRetryableJSONRPCError(fmt.Errorf("JSON-RPC error %d: %s", response.Error.Code, response.Error.Message), responseStatus) {
+			healthStatus = Warning
+		} else {
+			healthStatus = Unhealthy
+		}
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   healthStatus,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("JSON-RPC error %d: %s", response.Error.Code, response.Error.Message)
+	}
+
+	// Use the provided parse function to extract block number
+	blockNumber, err := parseFunc(response.Result)
+	if err != nil {
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: responseStatus,
+			Metadata:       make(map[string]interface{}),
+		}, fmt.Errorf("failed to parse block number from result: %w", err)
+	}
+
+	// Success!
 	return &LatestBlockResult{
-		BlockNumber:    0,
-		HealthStatus:   lastHealthStatus,
-		ResponseStatus: lastResponseStatus,
+		BlockNumber:    blockNumber,
+		HealthStatus:   Healthy,
+		ResponseStatus: responseStatus,
 		Metadata:       make(map[string]interface{}),
-	}, fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+	}, nil
 }
 
 // PerformArchiveCheckViaJSONRPC performs a JSON-RPC archive mode check request
 // This is shared logic for JSON-RPC based handlers (EVM, Starknet, Solana)
 func PerformArchiveCheckViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, archiveMethod string, blockHeight string, createPayloadFunc func(string, string) ([]byte, error), parseResponseFunc func([]byte) error) error {
-	var lastErr error
-	var lastResponseStatus int
-
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Use the provided function to create archive payload
-		payload, err := createPayloadFunc(archiveMethod, blockHeight)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to create archive payload: %w", err)
-			continue
-		}
-
-		// Make POST request with payload
-		resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
-		if statusCode != nil {
-			lastResponseStatus = *statusCode
-		}
-
-		if err != nil {
-			lastErr = fmt.Errorf("error sending HTTP request: %w", err)
-			continue
-		}
-
-		// Check for specific HTTP error status codes
-		if lastResponseStatus >= 400 {
-			if lastResponseStatus == 503 || lastResponseStatus == 502 {
-				lastErr = fmt.Errorf("network unavailable (status code: %d)", lastResponseStatus)
-			} else {
-				lastErr = fmt.Errorf("error status code: %d", lastResponseStatus)
-			}
-			continue
-		}
-
-		// Use the provided parse function to validate archive response
-		err = parseResponseFunc(resBytes)
-		if err != nil {
-			lastErr = fmt.Errorf("archive mode check failed: %w", err)
-			continue
-		}
-
-		// Success!
-		return nil
+	// Single attempt - let middleware handle retries
+	// Use the provided function to create archive payload
+	payload, err := createPayloadFunc(archiveMethod, blockHeight)
+	if err != nil {
+		return fmt.Errorf("failed to create archive payload: %w", err)
 	}
 
-	// All attempts failed
-	return fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+	// Make POST request with payload
+	resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
+	if err != nil {
+		return fmt.Errorf("error sending HTTP request: %w", err)
+	}
+
+	var responseStatus int
+	if statusCode != nil {
+		responseStatus = *statusCode
+	}
+
+	// Check for specific HTTP error status codes
+	if responseStatus >= 400 {
+		if responseStatus == 503 || responseStatus == 502 {
+			return fmt.Errorf("network unavailable (status code: %d)", responseStatus)
+		} else {
+			return fmt.Errorf("error status code: %d", responseStatus)
+		}
+	}
+
+	// Use the provided parse function to validate archive response
+	err = parseResponseFunc(resBytes)
+	if err != nil {
+		return fmt.Errorf("archive mode check failed: %w", err)
+	}
+
+	return nil
 }
 
 // PerformGetBlockByNumberViaJSONRPC performs a JSON-RPC get block by number request
 // This is shared logic for JSON-RPC based handlers (EVM, Starknet, Solana)
 func PerformGetBlockByNumberViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64, getSupportedMethodsFunc func() []string, createBlockRequestFunc func(string, int64, bool) ([]byte, error), parseBlockResponseFunc func([]byte) (interface{}, error)) (interface{}, error) {
+	// Single attempt - let middleware handle retries
 	// Find the appropriate get block by number method
 	supportedMethods := getSupportedMethodsFunc()
 	if len(supportedMethods) == 0 {
@@ -202,39 +201,28 @@ func PerformGetBlockByNumberViaJSONRPC(httpUrl string, headers map[string]string
 		return nil, fmt.Errorf("no getBlockByNumber method found")
 	}
 
-	var lastErr error
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Use the provided function to create block request payload
-		payload, err := createBlockRequestFunc(getBlockMethod, blockNumber, false)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to create block request: %w", err)
-			continue
-		}
-
-		// Make POST request with payload
-		resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
-		if err != nil {
-			lastErr = fmt.Errorf("error sending HTTP request: %w", err)
-			continue
-		}
-
-		// Check HTTP status code
-		if statusCode != nil && *statusCode != 200 {
-			lastErr = fmt.Errorf("error status code: %d", *statusCode)
-			continue
-		}
-
-		// Use the provided parse function to parse block response
-		blockData, err := parseBlockResponseFunc(resBytes)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to parse block response: %w", err)
-			continue
-		}
-
-		// Success!
-		return blockData, nil
+	// Use the provided function to create block request payload
+	payload, err := createBlockRequestFunc(getBlockMethod, blockNumber, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create block request: %w", err)
 	}
 
-	// All attempts failed
-	return nil, fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+	// Make POST request with payload
+	resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
+	if err != nil {
+		return nil, fmt.Errorf("error sending HTTP request: %w", err)
+	}
+
+	// Check HTTP status code
+	if statusCode != nil && *statusCode != 200 {
+		return nil, fmt.Errorf("error status code: %d", *statusCode)
+	}
+
+	// Use the provided parse function to parse block response
+	blockData, err := parseBlockResponseFunc(resBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse block response: %w", err)
+	}
+
+	return blockData, nil
 }

--- a/lib/network/retry.go
+++ b/lib/network/retry.go
@@ -3,44 +3,120 @@ package network
 import (
 	"context"
 	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"go.uber.org/zap"
 )
 
-// Retry performs an operation with exponential backoff up to maxAttempts times.
-// It will retry on any error. Use RetryWithChecker for custom retry logic.
-func Retry(ctx context.Context, maxAttempts int, operation func() error) error {
-	var lastErr error
+// Logger interface that can be satisfied by both zap.Logger and LoggerClient
+type Logger interface {
+	Debug(msg string, fields ...zap.Field)
+	Info(msg string, fields ...zap.Field)
+}
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		// Check context cancellation
+// Retry performs an operation with exponential backoff and comprehensive logging.
+// It will retry on any error up to maxAttempts times.
+func Retry(
+	ctx context.Context,
+	logger Logger,
+	operationName string,
+	maxAttempts int,
+	operation func() error,
+	fields ...zap.Field,
+) error {
+	attemptCount := 0
+	startTime := time.Now()
+
+	// Create exponential backoff
+	b := backoff.NewExponentialBackOff()
+
+	// Create base fields for logging
+	baseFields := append([]zap.Field{
+		zap.String("operation", operationName),
+		zap.Int("max_attempts", maxAttempts),
+	}, fields...)
+
+	// Wrap the operation to add logging
+	wrappedOperation := func() (interface{}, error) {
+		// Check context before attempting operation
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
+
+		attemptCount++
+		attemptStart := time.Now()
 
 		err := operation()
-		if err == nil {
-			return nil // Success!
+		attemptDuration := time.Since(attemptStart)
+
+		if err != nil {
+			// Log the error with all context
+			logFields := append(baseFields,
+				zap.Error(err),
+				zap.Int("attempt", attemptCount),
+				zap.Duration("attempt_duration", attemptDuration),
+				zap.Duration("total_elapsed", time.Since(startTime)),
+			)
+
+			if attemptCount < maxAttempts {
+				logger.Debug("Operation failed, will retry", logFields...)
+			} else {
+				logger.Debug("Operation failed on final attempt", logFields...)
+			}
+			return nil, err
 		}
 
-		lastErr = err
-
-		// Don't sleep after the last attempt
-		if attempt < maxAttempts-1 {
-			// Simple exponential backoff: 100ms, 200ms, 400ms, 800ms...
-			delay := time.Duration(100<<attempt) * time.Millisecond
-			if delay > 5*time.Second {
-				delay = 5 * time.Second // Cap at 5 seconds
-			}
-
-			select {
-			case <-time.After(delay):
-				// Continue to next attempt
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
+		// Log success
+		logger.Debug("Operation succeeded",
+			append(baseFields,
+				zap.Int("attempt", attemptCount),
+				zap.Duration("attempt_duration", attemptDuration),
+				zap.Duration("total_duration", time.Since(startTime)),
+			)...,
+		)
+		return nil, nil
 	}
 
-	return lastErr
+	// Create notify function for retry attempts
+	notifyFunc := func(err error, duration time.Duration) {
+		logger.Info("Retrying operation after backoff",
+			append(baseFields,
+				zap.Error(err),
+				zap.Int("attempt", attemptCount),
+				zap.Duration("backoff_duration", duration),
+				zap.Duration("total_elapsed", time.Since(startTime)),
+			)...,
+		)
+	}
+
+	// Perform the retry
+	_, err := backoff.Retry(
+		ctx,
+		wrappedOperation,
+		backoff.WithBackOff(b),
+		backoff.WithMaxTries(uint(maxAttempts)),
+		backoff.WithNotify(notifyFunc),
+	)
+
+	// Log final result
+	if err != nil {
+		logger.Info("Retry sequence failed",
+			append(baseFields,
+				zap.Error(err),
+				zap.Int("total_attempts", attemptCount),
+				zap.Duration("total_duration", time.Since(startTime)),
+			)...,
+		)
+	} else {
+		logger.Debug("Retry sequence completed successfully",
+			append(baseFields,
+				zap.Int("total_attempts", attemptCount),
+				zap.Duration("total_duration", time.Since(startTime)),
+			)...,
+		)
+	}
+
+	return err
 }
 
 // RetryWithChecker performs an operation with exponential backoff and custom retry logic.
@@ -48,43 +124,119 @@ func Retry(ctx context.Context, maxAttempts int, operation func() error) error {
 // If isRetryable returns false, the operation stops immediately with that error.
 func RetryWithChecker(
 	ctx context.Context,
+	logger Logger,
+	operationName string,
 	maxAttempts int,
 	isRetryable func(error) bool,
 	operation func() error,
+	fields ...zap.Field,
 ) error {
-	var lastErr error
+	attemptCount := 0
+	startTime := time.Now()
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	// Create exponential backoff
+	b := backoff.NewExponentialBackOff()
+
+	// Create base fields for logging
+	baseFields := append([]zap.Field{
+		zap.String("operation", operationName),
+		zap.Int("max_attempts", maxAttempts),
+	}, fields...)
+
+	// Wrap the operation to add logging and retry logic
+	wrappedOperation := func() (interface{}, error) {
+		// Check context before attempting operation
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
+
+		attemptCount++
+		attemptStart := time.Now()
 
 		err := operation()
-		if err == nil {
-			return nil
-		}
+		attemptDuration := time.Since(attemptStart)
 
-		lastErr = err
+		if err != nil {
+			// Check if error is retryable
+			retryable := isRetryable(err)
 
-		// Check if we should retry
-		if !isRetryable(err) {
-			return err // Non-retryable error, stop immediately
-		}
+			// Log the error with all context including retryability
+			logFields := append(baseFields,
+				zap.Error(err),
+				zap.Bool("retryable", retryable),
+				zap.Int("attempt", attemptCount),
+				zap.Duration("attempt_duration", attemptDuration),
+				zap.Duration("total_elapsed", time.Since(startTime)),
+			)
 
-		// Same backoff logic
-		if attempt < maxAttempts-1 {
-			delay := time.Duration(100<<attempt) * time.Millisecond
-			if delay > 5*time.Second {
-				delay = 5 * time.Second
+			if !retryable {
+				logger.Debug("Non-retryable error encountered", logFields...)
+				return nil, backoff.Permanent(err)
 			}
 
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				return ctx.Err()
+			if attemptCount < maxAttempts {
+				logger.Debug("Retryable error encountered, will retry", logFields...)
+			} else {
+				logger.Debug("Retryable error on final attempt", logFields...)
 			}
+			return nil, err
 		}
+
+		// Log success
+		logger.Debug("Operation succeeded",
+			append(baseFields,
+				zap.Int("attempt", attemptCount),
+				zap.Duration("attempt_duration", attemptDuration),
+				zap.Duration("total_duration", time.Since(startTime)),
+			)...,
+		)
+		return nil, nil
 	}
 
-	return lastErr
+	// Create notify function for retry attempts
+	notifyFunc := func(err error, duration time.Duration) {
+		logger.Info("Retrying operation after backoff",
+			append(baseFields,
+				zap.Error(err),
+				zap.Int("attempt", attemptCount),
+				zap.Duration("backoff_duration", duration),
+				zap.Duration("total_elapsed", time.Since(startTime)),
+			)...,
+		)
+	}
+
+	// Perform the retry
+	_, err := backoff.Retry(
+		ctx,
+		wrappedOperation,
+		backoff.WithBackOff(b),
+		backoff.WithMaxTries(uint(maxAttempts)),
+		backoff.WithNotify(notifyFunc),
+	)
+
+	// Log final result
+	if err != nil {
+		// Unwrap permanent errors for logging
+		if permanentErr, ok := err.(*backoff.PermanentError); ok {
+			err = permanentErr.Unwrap()
+		}
+
+		logger.Info("Retry sequence failed",
+			append(baseFields,
+				zap.Error(err),
+				zap.Int("total_attempts", attemptCount),
+				zap.Duration("total_duration", time.Since(startTime)),
+				zap.Bool("permanent_error", !isRetryable(err)),
+			)...,
+		)
+	} else {
+		logger.Debug("Retry sequence completed successfully",
+			append(baseFields,
+				zap.Int("total_attempts", attemptCount),
+				zap.Duration("total_duration", time.Since(startTime)),
+			)...,
+		)
+	}
+
+	return err
 }

--- a/lib/network/retry.go
+++ b/lib/network/retry.go
@@ -1,0 +1,90 @@
+package network
+
+import (
+	"context"
+	"time"
+)
+
+// Retry performs an operation with exponential backoff up to maxAttempts times.
+// It will retry on any error. Use RetryWithChecker for custom retry logic.
+func Retry(ctx context.Context, maxAttempts int, operation func() error) error {
+	var lastErr error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		// Check context cancellation
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		err := operation()
+		if err == nil {
+			return nil // Success!
+		}
+
+		lastErr = err
+
+		// Don't sleep after the last attempt
+		if attempt < maxAttempts-1 {
+			// Simple exponential backoff: 100ms, 200ms, 400ms, 800ms...
+			delay := time.Duration(100<<attempt) * time.Millisecond
+			if delay > 5*time.Second {
+				delay = 5 * time.Second // Cap at 5 seconds
+			}
+
+			select {
+			case <-time.After(delay):
+				// Continue to next attempt
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	return lastErr
+}
+
+// RetryWithChecker performs an operation with exponential backoff and custom retry logic.
+// The isRetryable function determines whether an error should trigger a retry.
+// If isRetryable returns false, the operation stops immediately with that error.
+func RetryWithChecker(
+	ctx context.Context,
+	maxAttempts int,
+	isRetryable func(error) bool,
+	operation func() error,
+) error {
+	var lastErr error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		err := operation()
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		// Check if we should retry
+		if !isRetryable(err) {
+			return err // Non-retryable error, stop immediately
+		}
+
+		// Same backoff logic
+		if attempt < maxAttempts-1 {
+			delay := time.Duration(100<<attempt) * time.Millisecond
+			if delay > 5*time.Second {
+				delay = 5 * time.Second
+			}
+
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	return lastErr
+}

--- a/lib/network/retry_test.go
+++ b/lib/network/retry_test.go
@@ -1,0 +1,208 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetry(t *testing.T) {
+	tests := []struct {
+		name            string
+		maxAttempts     int
+		operation       func(attempts *int) func() error
+		expectedAttempts int
+		expectError     bool
+	}{
+		{
+			name:        "successful on first attempt",
+			maxAttempts: 3,
+			operation: func(attempts *int) func() error {
+				return func() error {
+					*attempts++
+					return nil
+				}
+			},
+			expectedAttempts: 1,
+			expectError:     false,
+		},
+		{
+			name:        "successful on third attempt",
+			maxAttempts: 5,
+			operation: func(attempts *int) func() error {
+				return func() error {
+					*attempts++
+					if *attempts < 3 {
+						return errors.New("temporary error")
+					}
+					return nil
+				}
+			},
+			expectedAttempts: 3,
+			expectError:     false,
+		},
+		{
+			name:        "all attempts fail",
+			maxAttempts: 3,
+			operation: func(attempts *int) func() error {
+				return func() error {
+					*attempts++
+					return errors.New("persistent error")
+				}
+			},
+			expectedAttempts: 3,
+			expectError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := 0
+			err := Retry(context.Background(), tt.maxAttempts, tt.operation(&attempts))
+
+			assert.Equal(t, tt.expectedAttempts, attempts)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRetryWithChecker(t *testing.T) {
+	tests := []struct {
+		name            string
+		maxAttempts     int
+		operation       func(attempts *int) func() error
+		isRetryable     func(error) bool
+		expectedAttempts int
+		expectError     bool
+	}{
+		{
+			name:        "non-retryable error stops immediately",
+			maxAttempts: 5,
+			operation: func(attempts *int) func() error {
+				return func() error {
+					*attempts++
+					return errors.New("non-retryable")
+				}
+			},
+			isRetryable: func(err error) bool {
+				return err.Error() != "non-retryable"
+			},
+			expectedAttempts: 1,
+			expectError:     true,
+		},
+		{
+			name:        "retryable errors continue until success",
+			maxAttempts: 5,
+			operation: func(attempts *int) func() error {
+				return func() error {
+					*attempts++
+					if *attempts < 3 {
+						return errors.New("retryable")
+					}
+					return nil
+				}
+			},
+			isRetryable: func(err error) bool {
+				return err.Error() == "retryable"
+			},
+			expectedAttempts: 3,
+			expectError:     false,
+		},
+		{
+			name:        "mix of retryable and non-retryable",
+			maxAttempts: 5,
+			operation: func(attempts *int) func() error {
+				return func() error {
+					*attempts++
+					if *attempts == 1 {
+						return errors.New("retryable")
+					}
+					return errors.New("non-retryable")
+				}
+			},
+			isRetryable: func(err error) bool {
+				return err.Error() == "retryable"
+			},
+			expectedAttempts: 2,
+			expectError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := 0
+			err := RetryWithChecker(
+				context.Background(),
+				tt.maxAttempts,
+				tt.isRetryable,
+				tt.operation(&attempts),
+			)
+
+			assert.Equal(t, tt.expectedAttempts, attempts)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRetryContextCancellation(t *testing.T) {
+	t.Run("context cancelled before operation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		attempts := 0
+		err := Retry(ctx, 3, func() error {
+			attempts++
+			return errors.New("should not be called")
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+		assert.Equal(t, 0, attempts)
+	})
+
+	t.Run("context cancelled during retry delay", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		attempts := 0
+		err := Retry(ctx, 5, func() error {
+			attempts++
+			return errors.New("always fails")
+		})
+
+		assert.Error(t, err)
+		// Should have attempted at least once but not all 5 times
+		assert.GreaterOrEqual(t, attempts, 1)
+		assert.Less(t, attempts, 5)
+	})
+}
+
+func TestRetryBackoff(t *testing.T) {
+	t.Run("exponential backoff timing", func(t *testing.T) {
+		start := time.Now()
+		attempts := 0
+
+		_ = Retry(context.Background(), 3, func() error {
+			attempts++
+			return errors.New("always fails")
+		})
+
+		elapsed := time.Since(start)
+		// Should have delays of 100ms and 200ms = 300ms total
+		// Allow some tolerance for execution time
+		assert.Greater(t, elapsed, 250*time.Millisecond)
+		assert.Less(t, elapsed, 400*time.Millisecond)
+		assert.Equal(t, 3, attempts)
+	})
+}

--- a/lib/network/retry_test.go
+++ b/lib/network/retry_test.go
@@ -7,15 +7,19 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestRetry(t *testing.T) {
 	tests := []struct {
-		name            string
-		maxAttempts     int
-		operation       func(attempts *int) func() error
+		name             string
+		maxAttempts      int
+		operation        func(attempts *int) func() error
 		expectedAttempts int
-		expectError     bool
+		expectError      bool
+		expectedLogs     map[string]int // expected log messages and their counts
 	}{
 		{
 			name:        "successful on first attempt",
@@ -27,7 +31,11 @@ func TestRetry(t *testing.T) {
 				}
 			},
 			expectedAttempts: 1,
-			expectError:     false,
+			expectError:      false,
+			expectedLogs: map[string]int{
+				"Operation succeeded":               1,
+				"Retry sequence completed successfully": 1,
+			},
 		},
 		{
 			name:        "successful on third attempt",
@@ -42,7 +50,13 @@ func TestRetry(t *testing.T) {
 				}
 			},
 			expectedAttempts: 3,
-			expectError:     false,
+			expectError:      false,
+			expectedLogs: map[string]int{
+				"Operation failed, will retry":      2,
+				"Retrying operation after backoff":  2,
+				"Operation succeeded":                1,
+				"Retry sequence completed successfully": 1,
+			},
 		},
 		{
 			name:        "all attempts fail",
@@ -54,20 +68,61 @@ func TestRetry(t *testing.T) {
 				}
 			},
 			expectedAttempts: 3,
-			expectError:     true,
+			expectError:      true,
+			expectedLogs: map[string]int{
+				"Operation failed, will retry":     2,
+				"Operation failed on final attempt": 1,
+				"Retrying operation after backoff": 2,
+				"Retry sequence failed":            1,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attempts := 0
-			err := Retry(context.Background(), tt.maxAttempts, tt.operation(&attempts))
+			// Create observer to capture logs
+			core, observed := observer.New(zap.DebugLevel)
+			logger := zap.New(core)
 
+			attempts := 0
+			err := Retry(
+				context.Background(),
+				logger,
+				"test_operation",
+				tt.maxAttempts,
+				tt.operation(&attempts),
+				zap.String("test_field", "test_value"),
+			)
+
+			// Check results
 			assert.Equal(t, tt.expectedAttempts, attempts)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			// Check logs
+			logs := observed.All()
+			logMessages := make(map[string]int)
+			for _, log := range logs {
+				logMessages[log.Message]++
+			}
+
+			for expectedMsg, expectedCount := range tt.expectedLogs {
+				actualCount := logMessages[expectedMsg]
+				assert.Equal(t, expectedCount, actualCount,
+					"Expected %d log entries for '%s', got %d", expectedCount, expectedMsg, actualCount)
+			}
+
+			// Verify common fields are present
+			for _, log := range logs {
+				assert.Contains(t, log.ContextMap(), "operation")
+				assert.Equal(t, "test_operation", log.ContextMap()["operation"])
+				assert.Contains(t, log.ContextMap(), "max_attempts")
+				assert.Equal(t, int64(tt.maxAttempts), log.ContextMap()["max_attempts"])
+				assert.Contains(t, log.ContextMap(), "test_field")
+				assert.Equal(t, "test_value", log.ContextMap()["test_field"])
 			}
 		})
 	}
@@ -75,12 +130,13 @@ func TestRetry(t *testing.T) {
 
 func TestRetryWithChecker(t *testing.T) {
 	tests := []struct {
-		name            string
-		maxAttempts     int
-		operation       func(attempts *int) func() error
-		isRetryable     func(error) bool
+		name             string
+		maxAttempts      int
+		operation        func(attempts *int) func() error
+		isRetryable      func(error) bool
 		expectedAttempts int
-		expectError     bool
+		expectError      bool
+		expectedLogs     map[string]int
 	}{
 		{
 			name:        "non-retryable error stops immediately",
@@ -95,7 +151,11 @@ func TestRetryWithChecker(t *testing.T) {
 				return err.Error() != "non-retryable"
 			},
 			expectedAttempts: 1,
-			expectError:     true,
+			expectError:      true,
+			expectedLogs: map[string]int{
+				"Non-retryable error encountered": 1,
+				"Retry sequence failed":           1,
+			},
 		},
 		{
 			name:        "retryable errors continue until success",
@@ -113,7 +173,13 @@ func TestRetryWithChecker(t *testing.T) {
 				return err.Error() == "retryable"
 			},
 			expectedAttempts: 3,
-			expectError:     false,
+			expectError:      false,
+			expectedLogs: map[string]int{
+				"Retryable error encountered, will retry": 2,
+				"Retrying operation after backoff":        2,
+				"Operation succeeded":                      1,
+				"Retry sequence completed successfully":   1,
+			},
 		},
 		{
 			name:        "mix of retryable and non-retryable",
@@ -131,25 +197,61 @@ func TestRetryWithChecker(t *testing.T) {
 				return err.Error() == "retryable"
 			},
 			expectedAttempts: 2,
-			expectError:     true,
+			expectError:      true,
+			expectedLogs: map[string]int{
+				"Retryable error encountered, will retry": 1,
+				"Retrying operation after backoff":        1,
+				"Non-retryable error encountered":         1,
+				"Retry sequence failed":                   1,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Create observer to capture logs
+			core, observed := observer.New(zap.DebugLevel)
+			logger := zap.New(core)
+
 			attempts := 0
 			err := RetryWithChecker(
 				context.Background(),
+				logger,
+				"test_operation",
 				tt.maxAttempts,
 				tt.isRetryable,
 				tt.operation(&attempts),
+				zap.String("test_field", "test_value"),
 			)
 
+			// Check results
 			assert.Equal(t, tt.expectedAttempts, attempts)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			// Check logs
+			logs := observed.All()
+			logMessages := make(map[string]int)
+			for _, log := range logs {
+				logMessages[log.Message]++
+			}
+
+			for expectedMsg, expectedCount := range tt.expectedLogs {
+				actualCount := logMessages[expectedMsg]
+				assert.Equal(t, expectedCount, actualCount,
+					"Expected %d log entries for '%s', got %d", expectedCount, expectedMsg, actualCount)
+			}
+
+			// Check retryability field in error logs
+			for _, log := range logs {
+				if log.Message == "Retryable error encountered, will retry" ||
+				   log.Message == "Non-retryable error encountered" ||
+				   log.Message == "Retryable error on final attempt" {
+					assert.Contains(t, log.ContextMap(), "retryable")
+				}
 			}
 		})
 	}
@@ -157,26 +259,28 @@ func TestRetryWithChecker(t *testing.T) {
 
 func TestRetryContextCancellation(t *testing.T) {
 	t.Run("context cancelled before operation", func(t *testing.T) {
+		logger := zaptest.NewLogger(t)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
 
 		attempts := 0
-		err := Retry(ctx, 3, func() error {
+		err := Retry(ctx, logger, "test_operation", 3, func() error {
 			attempts++
 			return errors.New("should not be called")
 		})
 
 		assert.Error(t, err)
 		assert.Equal(t, context.Canceled, err)
-		assert.Equal(t, 0, attempts)
+		assert.Equal(t, 0, attempts, "Should not execute operation when context is already cancelled")
 	})
 
 	t.Run("context cancelled during retry delay", func(t *testing.T) {
+		logger := zaptest.NewLogger(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
 
 		attempts := 0
-		err := Retry(ctx, 5, func() error {
+		err := Retry(ctx, logger, "test_operation", 5, func() error {
 			attempts++
 			return errors.New("always fails")
 		})
@@ -188,21 +292,116 @@ func TestRetryContextCancellation(t *testing.T) {
 	})
 }
 
-func TestRetryBackoff(t *testing.T) {
+func TestRetryBackoffTiming(t *testing.T) {
 	t.Run("exponential backoff timing", func(t *testing.T) {
+		logger := zaptest.NewLogger(t)
 		start := time.Now()
 		attempts := 0
 
-		_ = Retry(context.Background(), 3, func() error {
+		_ = Retry(context.Background(), logger, "test_operation", 3, func() error {
 			attempts++
 			return errors.New("always fails")
 		})
 
 		elapsed := time.Since(start)
-		// Should have delays of 100ms and 200ms = 300ms total
+		// Should have exponential delays between attempts
+		// First retry after ~500ms, second after ~750ms = ~1.25s total minimum
 		// Allow some tolerance for execution time
-		assert.Greater(t, elapsed, 250*time.Millisecond)
-		assert.Less(t, elapsed, 400*time.Millisecond)
+		assert.Greater(t, elapsed, 1*time.Second)
+		assert.Less(t, elapsed, 3*time.Second)
 		assert.Equal(t, 3, attempts)
+	})
+}
+
+func TestRetryLoggingFields(t *testing.T) {
+	t.Run("verify all logging fields are present", func(t *testing.T) {
+		core, observed := observer.New(zap.DebugLevel)
+		logger := zap.New(core)
+
+		attempts := 0
+		err := RetryWithChecker(
+			context.Background(),
+			logger,
+			"complex_operation",
+			3,
+			func(err error) bool { return true },
+			func() error {
+				attempts++
+				if attempts < 2 {
+					return errors.New("will succeed next time")
+				}
+				return nil
+			},
+			zap.String("provider", "test-provider"),
+			zap.String("network", "test-network"),
+			zap.Int("custom_field", 42),
+		)
+
+		assert.NoError(t, err)
+
+		// Check that custom fields are present in all logs
+		logs := observed.All()
+		for _, log := range logs {
+			assert.Contains(t, log.ContextMap(), "operation")
+			assert.Equal(t, "complex_operation", log.ContextMap()["operation"])
+			assert.Contains(t, log.ContextMap(), "provider")
+			assert.Equal(t, "test-provider", log.ContextMap()["provider"])
+			assert.Contains(t, log.ContextMap(), "network")
+			assert.Equal(t, "test-network", log.ContextMap()["network"])
+			assert.Contains(t, log.ContextMap(), "custom_field")
+			assert.Equal(t, int64(42), log.ContextMap()["custom_field"])
+		}
+
+		// Check specific logs have timing information
+		for _, log := range logs {
+			if log.Message == "Retryable error encountered, will retry" {
+				assert.Contains(t, log.ContextMap(), "attempt")
+				assert.Contains(t, log.ContextMap(), "attempt_duration")
+				assert.Contains(t, log.ContextMap(), "total_elapsed")
+			}
+			if log.Message == "Operation succeeded" {
+				assert.Contains(t, log.ContextMap(), "attempt")
+				assert.Contains(t, log.ContextMap(), "attempt_duration")
+				// Success log uses total_duration, not total_elapsed
+				assert.Contains(t, log.ContextMap(), "total_duration")
+			}
+			if log.Message == "Retrying operation after backoff" {
+				assert.Contains(t, log.ContextMap(), "backoff_duration")
+				assert.Contains(t, log.ContextMap(), "total_elapsed")
+			}
+		}
+	})
+}
+
+func TestRetryPermanentError(t *testing.T) {
+	t.Run("permanent error is unwrapped in final log", func(t *testing.T) {
+		core, observed := observer.New(zap.DebugLevel)
+		logger := zap.New(core)
+
+		err := RetryWithChecker(
+			context.Background(),
+			logger,
+			"test_operation",
+			3,
+			func(err error) bool { return false }, // All errors are non-retryable
+			func() error {
+				return errors.New("permanent failure")
+			},
+		)
+
+		assert.Error(t, err)
+		assert.Equal(t, "permanent failure", err.Error())
+
+		// Find the final failure log
+		logs := observed.All()
+		var foundFinalLog bool
+		for _, log := range logs {
+			if log.Message == "Retry sequence failed" {
+				foundFinalLog = true
+				assert.Contains(t, log.ContextMap(), "permanent_error")
+				assert.Equal(t, true, log.ContextMap()["permanent_error"])
+			}
+		}
+		assert.True(t, foundFinalLog, "Should have logged final failure")
 	})
 }

--- a/lib/network/tron_handler.go
+++ b/lib/network/tron_handler.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -17,7 +16,6 @@ import (
 	"github.com/DIN-center/din-caddy-plugins/lib/auth"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
-	"github.com/cenkalti/backoff/v5"
 )
 
 const (
@@ -362,46 +360,52 @@ func (h *TronHandler) GetBlockByNumberMethod() string {
 
 // GetLatestBlockNumber implements the Handler interface.
 func (h *TronHandler) GetLatestBlockNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (*LatestBlockResult, error) {
-	if requestAttempts < 0 {
-		return nil, fmt.Errorf("%w: %d", ErrUnderflow, requestAttempts)
-	}
-
-	tries := uint(requestAttempts)
-
-	op := func() (*LatestBlockResult, error) {
-		body, statusCode, err := httpClient.Post(httpUrl+h.GetBlockByNumberMethod(), headers, []byte{}, authClient)
-		if err != nil {
-			return nil, err
-		}
-
-		if *statusCode >= http.StatusBadRequest && *statusCode < http.StatusInternalServerError && *statusCode != http.StatusTooManyRequests {
-			return nil, &backoff.PermanentError{
-				Err: fmt.Errorf("%w: (Client error) %d", ErrUnexpectedStatusCode, *statusCode),
-			}
-		}
-
-		if *statusCode <= http.StatusOK && *statusCode >= http.StatusMultipleChoices {
-			return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, *statusCode)
-		}
-
-		block, err := h.parseBlockResponse(body)
-		if err != nil {
-			return nil, err
-		}
-
+	// Single attempt - let middleware handle retries
+	body, statusCode, err := httpClient.Post(httpUrl+h.GetBlockByNumberMethod(), headers, []byte{}, authClient)
+	if err != nil {
 		return &LatestBlockResult{
-			BlockNumber:    block.BlockHeader.RawData.Number,
-			HealthStatus:   Healthy,
-			ResponseStatus: *statusCode,
-		}, nil
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: 0,
+		}, err
 	}
 
-	return backoff.Retry(
-		context.Background(),
-		op,
-		backoff.WithBackOff(backoff.NewExponentialBackOff()),
-		backoff.WithMaxTries(tries),
-	)
+	if *statusCode >= http.StatusBadRequest {
+		if *statusCode == http.StatusTooManyRequests {
+			return &LatestBlockResult{
+				BlockNumber:    0,
+				HealthStatus:   Warning,
+				ResponseStatus: *statusCode,
+			}, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, *statusCode)
+		}
+		if *statusCode >= http.StatusInternalServerError {
+			return &LatestBlockResult{
+				BlockNumber:    0,
+				HealthStatus:   Warning,
+				ResponseStatus: *statusCode,
+			}, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, *statusCode)
+		}
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: *statusCode,
+		}, fmt.Errorf("%w: (Client error) %d", ErrUnexpectedStatusCode, *statusCode)
+	}
+
+	block, err := h.parseBlockResponse(body)
+	if err != nil {
+		return &LatestBlockResult{
+			BlockNumber:    0,
+			HealthStatus:   Unhealthy,
+			ResponseStatus: *statusCode,
+		}, err
+	}
+
+	return &LatestBlockResult{
+		BlockNumber:    block.BlockHeader.RawData.Number,
+		HealthStatus:   Healthy,
+		ResponseStatus: *statusCode,
+	}, nil
 }
 
 // RequiresSeparateBlockInfoCall implements the Handler interface.
@@ -430,42 +434,22 @@ func (h *TronHandler) ParseBlockNumberResponse(body []byte, statusCode int) (int
 
 // PerformGetBlockByNumber implements the Handler interface.
 func (h *TronHandler) PerformGetBlockByNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (interface{}, error) {
-	if requestAttempts < 0 {
-		return nil, fmt.Errorf("%w: %d", ErrUnderflow, requestAttempts)
+	// Single attempt - let middleware handle retries
+	reqBody, err := h.CreateBlockRequest("", blockNumber, false)
+	if err != nil {
+		return nil, err
 	}
 
-	tries := uint(requestAttempts)
-
-	op := func() (*TronBlock, error) {
-		reqBody, err := h.CreateBlockRequest("", blockNumber, false)
-		if err != nil {
-			return nil, err
-		}
-
-		respBody, statusCode, err := httpClient.Post(httpUrl+h.GetBlockByNumberMethod(), headers, reqBody, authClient)
-		if err != nil {
-			return nil, err
-		}
-
-		if *statusCode >= http.StatusBadRequest && *statusCode < http.StatusInternalServerError && *statusCode != http.StatusTooManyRequests {
-			return nil, &backoff.PermanentError{
-				Err: fmt.Errorf("%w: (Client error) %d", ErrUnexpectedStatusCode, *statusCode),
-			}
-		}
-
-		if *statusCode != http.StatusOK {
-			return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, *statusCode)
-		}
-
-		return h.parseBlockResponse(respBody)
+	respBody, statusCode, err := httpClient.Post(httpUrl+h.GetBlockByNumberMethod(), headers, reqBody, authClient)
+	if err != nil {
+		return nil, err
 	}
 
-	return backoff.Retry(
-		context.Background(),
-		op,
-		backoff.WithBackOff(backoff.NewExponentialBackOff()),
-		backoff.WithMaxTries(tries),
-	)
+	if *statusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, *statusCode)
+	}
+
+	return h.parseBlockResponse(respBody)
 }
 
 //
@@ -559,38 +543,18 @@ func (h *TronHandler) ValidateChainID(chainID string) error {
 
 // GetChainID implements the Handler interface.
 func (h *TronHandler) GetChainID(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (string, error) {
-	if requestAttempts < 0 {
-		return "", fmt.Errorf("%w: %d", ErrUnderflow, requestAttempts)
+	// Single attempt - let middleware handle retries
+	reqBody, err := h.CreateBlockRequest("", 0, false)
+	if err != nil {
+		return "", err
 	}
 
-	tries := uint(requestAttempts)
-
-	op := func() (string, error) {
-		reqBody, err := h.CreateBlockRequest("", 0, false)
-		if err != nil {
-			return "", err
-		}
-
-		respBody, statusCode, err := httpClient.Post(httpUrl+h.GetChainIDMethod(), headers, reqBody, authClient)
-		if err != nil {
-			return "", err
-		}
-
-		if *statusCode >= http.StatusBadRequest && *statusCode < http.StatusInternalServerError && *statusCode != http.StatusTooManyRequests {
-			return "", &backoff.PermanentError{
-				Err: fmt.Errorf("%w: (Client error) %d", ErrUnexpectedStatusCode, *statusCode),
-			}
-		}
-
-		return h.ParseChainIDResponse(respBody, *statusCode)
+	respBody, statusCode, err := httpClient.Post(httpUrl+h.GetChainIDMethod(), headers, reqBody, authClient)
+	if err != nil {
+		return "", err
 	}
 
-	return backoff.Retry(
-		context.Background(),
-		op,
-		backoff.WithBackOff(backoff.NewExponentialBackOff()),
-		backoff.WithMaxTries(tries),
-	)
+	return h.ParseChainIDResponse(respBody, *statusCode)
 }
 
 //

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -24,16 +24,15 @@ func (d *DinMiddleware) getRegistryData() (*din.DinRegistryData, error) {
 
 	err := networklib.Retry(
 		context.Background(),
+		d.logger,
+		"get_registry_data",
 		d.Registry.RetryMaxAttempts+1, // +1 because config is 0-indexed for retries
 		func() error {
 			var err error
 			data, err = d.DingoClient.GetRegistryData()
-			if err != nil {
-				d.logger.Warn("Registry call failed, will retry",
-					zap.Error(err))
-			}
 			return err
 		},
+		zap.String("registry_endpoint", d.Registry.EndpointUrl),
 	)
 
 	if err != nil {
@@ -51,16 +50,16 @@ func (d *DinMiddleware) syncRegistryWithLatestBlock(web3Client web3.Web3Client) 
 
 	err := networklib.Retry(
 		context.Background(),
+		d.logger,
+		"get_latest_block_number",
 		d.Registry.RetryMaxAttempts+1,
 		func() error {
 			var err error
 			latestBlockNumber, err = web3Client.LatestBlockNumber()
-			if err != nil {
-				d.logger.Warn("Failed to get latest block number, will retry",
-					zap.Error(err))
-			}
 			return err
 		},
+		zap.String("network", "linea"),
+		zap.String("registry_endpoint", d.Registry.EndpointUrl),
 	)
 
 	if err != nil {

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -13,56 +14,59 @@ import (
 
 	"github.com/DIN-center/din-caddy-plugins/lib/auth/siwe"
 	din_http "github.com/DIN-center/din-caddy-plugins/lib/http"
+	networklib "github.com/DIN-center/din-caddy-plugins/lib/network"
 	"github.com/DIN-center/din-caddy-plugins/lib/web3"
 )
 
 // getRegistryData retrieves registry data with retry logic
 func (d *DinMiddleware) getRegistryData() (*din.DinRegistryData, error) {
-	var lastErr error
+	var data *din.DinRegistryData
 
-	for attempt := 0; attempt <= d.Registry.RetryMaxAttempts; attempt++ {
-		data, err := d.DingoClient.GetRegistryData()
-		if err == nil {
-			return data, nil
-		}
-		lastErr = err
+	err := networklib.Retry(
+		context.Background(),
+		d.Registry.RetryMaxAttempts+1, // +1 because config is 0-indexed for retries
+		func() error {
+			var err error
+			data, err = d.DingoClient.GetRegistryData()
+			if err != nil {
+				d.logger.Warn("Registry call failed, will retry",
+					zap.Error(err))
+			}
+			return err
+		},
+	)
 
-		if attempt < d.Registry.RetryMaxAttempts {
-			d.logger.Warn("Registry call failed, retrying",
-				zap.Int("attempt", attempt+1),
-				zap.Int("max_attempts", d.Registry.RetryMaxAttempts),
-				zap.Error(err))
-			time.Sleep(d.Registry.RetryDelay) // Fixed delay, no backoff
-		}
+	if err != nil {
+		return nil, fmt.Errorf("registry call failed after %d attempts: %w",
+			d.Registry.RetryMaxAttempts+1, err)
 	}
 
-	return nil, fmt.Errorf("registry call failed after %d attempts: %w",
-		d.Registry.RetryMaxAttempts, lastErr)
+	return data, nil
 }
 
 // syncRegistryWithLatestBlock checks the latest block number from the linea network and updates the middleware object with the latest registry data if the block number difference is greater than or equal to the epoch
 func (d *DinMiddleware) syncRegistryWithLatestBlock(web3Client web3.Web3Client) {
 	// Get latest block number with retry
 	var latestBlockNumber uint64
-	var err error
 
-	for attempt := 0; attempt <= d.Registry.RetryMaxAttempts; attempt++ {
-		latestBlockNumber, err = web3Client.LatestBlockNumber()
-		if err == nil {
-			break
-		}
-		if attempt < d.Registry.RetryMaxAttempts {
-			d.logger.Warn("Failed to get latest block number, retrying",
-				zap.Int("attempt", attempt+1),
-				zap.Error(err))
-			time.Sleep(d.Registry.RetryDelay)
-		}
-	}
+	err := networklib.Retry(
+		context.Background(),
+		d.Registry.RetryMaxAttempts+1,
+		func() error {
+			var err error
+			latestBlockNumber, err = web3Client.LatestBlockNumber()
+			if err != nil {
+				d.logger.Warn("Failed to get latest block number, will retry",
+					zap.Error(err))
+			}
+			return err
+		},
+	)
 
 	if err != nil {
 		d.logger.Error("Failed to get latest block number after retries",
 			zap.Error(err),
-			zap.Int("max_retries", d.Registry.RetryMaxAttempts))
+			zap.Int("max_retries", d.Registry.RetryMaxAttempts+1))
 		return
 	}
 

--- a/modules/network.go
+++ b/modules/network.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"container/list"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -388,50 +389,50 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 	// chainId check health check
 	// Use handler's GetChainID method for all network types
 	if n.handler != nil {
-		// Add retry logic since handlers no longer retry internally
 		var chainId string
-		var lastErr error
-		for attempt := 0; attempt < n.RequestAttemptCount; attempt++ {
-			var err error
-			chainId, err = n.handler.GetChainID(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), 1)
-			if err != nil {
-				lastErr = err
-				// Check if error is retryable
-				if !n.handler.IsRetryableError(err, 0) {
+
+		err := networklib.RetryWithChecker(
+			context.Background(),
+			n.RequestAttemptCount,
+			func(err error) bool {
+				retryable := n.handler.IsRetryableError(err, 0)
+				if !retryable {
 					n.logProviderWarning("Non-retryable error getting chain ID", provider,
 						zap.String("expected_chain_id", n.ChainId),
 						zap.String("health_status", Unhealthy.String()),
+						zap.Error(err))
+				} else {
+					n.logger.Debug("Retryable error getting chain ID, will retry",
 						zap.Error(err),
-						zap.Int("attempt", attempt+1))
-					return Unhealthy
+						zap.String("provider", provider.host))
 				}
-				n.logger.Debug("Retryable error getting chain ID, will retry",
-					zap.Error(err),
-					zap.String("provider", provider.host),
-					zap.Int("attempt", attempt+1),
-					zap.Int("max_attempts", n.RequestAttemptCount))
-				continue
-			}
+				return retryable
+			},
+			func() error {
+				var err error
+				chainId, err = n.handler.GetChainID(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), 1)
+				if err != nil {
+					return err
+				}
 
-			// Success - validate the chain ID
-			if err := n.handler.ValidateChainID(chainId); err != nil {
-				n.logProviderWarning("Provider has incorrect chain ID", provider,
-					zap.String("chain_id", chainId),
-					zap.String("expected_chain_id", n.ChainId),
-					zap.String("validation_error", err.Error()),
-					zap.String("health_status", Unhealthy.String()))
-				return Unhealthy
-			}
-			// Chain ID is valid, break out of retry loop
-			break
-		}
+				// Success - validate the chain ID
+				if err := n.handler.ValidateChainID(chainId); err != nil {
+					n.logProviderWarning("Provider has incorrect chain ID", provider,
+						zap.String("chain_id", chainId),
+						zap.String("expected_chain_id", n.ChainId),
+						zap.String("validation_error", err.Error()),
+						zap.String("health_status", Unhealthy.String()))
+					return fmt.Errorf("chain ID validation failed: %w", err)
+				}
+				return nil
+			},
+		)
 
-		// If we exhausted all retries with errors
-		if lastErr != nil {
-			n.logProviderWarning("Error getting chain ID after all retries", provider,
+		if err != nil {
+			n.logProviderWarning("Error getting/validating chain ID after all retries", provider,
 				zap.String("expected_chain_id", n.ChainId),
 				zap.String("health_status", Unhealthy.String()),
-				zap.Error(lastErr),
+				zap.Error(err),
 				zap.Int("total_attempts", n.RequestAttemptCount))
 			return Unhealthy
 		}
@@ -471,32 +472,26 @@ func (n *network) performArchiveCheck(provider *provider, currentBlock int64) er
 	// Use handler method to format block height directly
 	quarterBlockHeightString := n.handler.FormatBlockHeight(quarterBlockHeight)
 
-	// Add retry logic since handlers no longer retry internally
-	var lastErr error
-	for attempt := 0; attempt < n.RequestAttemptCount; attempt++ {
-		err := n.handler.PerformArchiveCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), 1, quarterBlockHeightString)
-		if err != nil {
-			lastErr = err
-			// Check if error is retryable
-			if !n.handler.IsRetryableError(err, 0) {
+	return networklib.RetryWithChecker(
+		context.Background(),
+		n.RequestAttemptCount,
+		func(err error) bool {
+			retryable := n.handler.IsRetryableError(err, 0)
+			if !retryable {
 				n.logger.Debug("Non-retryable error in archive check",
 					zap.Error(err),
-					zap.String("provider", provider.host),
-					zap.Int("attempt", attempt+1))
-				return err
+					zap.String("provider", provider.host))
+			} else {
+				n.logger.Debug("Retryable error in archive check, will retry",
+					zap.Error(err),
+					zap.String("provider", provider.host))
 			}
-			n.logger.Debug("Retryable error in archive check, will retry",
-				zap.Error(err),
-				zap.String("provider", provider.host),
-				zap.Int("attempt", attempt+1),
-				zap.Int("max_attempts", n.RequestAttemptCount))
-			continue
-		}
-		// Success
-		return nil
-	}
-	// All attempts failed
-	return lastErr
+			return retryable
+		},
+		func() error {
+			return n.handler.PerformArchiveCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), 1, quarterBlockHeightString)
+		},
+	)
 }
 
 // isStalled checks if provider's block numbers haven't changed
@@ -586,79 +581,72 @@ type getLatestBlockNumberResult struct {
 }
 
 func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string, ac auth.IAuthClient, providerHost string) (*getLatestBlockNumberResult, error) {
-	// Add retry logic since handlers no longer retry internally
-	var lastErr error
+	var result *getLatestBlockNumberResult
 	var lastResult *networklib.LatestBlockResult
 
-	for attempt := 0; attempt < n.RequestAttemptCount; attempt++ {
-		// Call handler's GetLatestBlockNumber method (single attempt)
-		result, err := n.handler.GetLatestBlockNumber(httpUrl, headers, n.HttpClient, ac, 1)
-		if err != nil {
-			lastErr = err
-			lastResult = result
-
+	err := networklib.RetryWithChecker(
+		context.Background(),
+		n.RequestAttemptCount,
+		func(err error) bool {
 			// Check if the error is retryable
-			var statusCode int
-			if result != nil {
-				statusCode = result.ResponseStatus
+			statusCode := 0
+			if lastResult != nil {
+				statusCode = lastResult.ResponseStatus
 			}
-
-			// Use handler's IsRetryableError to determine if we should retry
-			if !n.handler.IsRetryableError(err, statusCode) {
+			retryable := n.handler.IsRetryableError(err, statusCode)
+			if !retryable {
 				n.logger.Debug("Non-retryable error in GetLatestBlockNumber",
 					zap.Error(err),
 					zap.String("network", n.Name),
-					zap.String("provider", providerHost),
-					zap.Int("attempt", attempt+1))
-				break // Non-retryable error, stop trying
+					zap.String("provider", providerHost))
+			} else {
+				n.logger.Debug("Retryable error in GetLatestBlockNumber",
+					zap.Error(err),
+					zap.String("network", n.Name),
+					zap.String("provider", providerHost))
 			}
+			return retryable
+		},
+		func() error {
+			res, err := n.handler.GetLatestBlockNumber(httpUrl, headers, n.HttpClient, ac, 1)
+			lastResult = res
+			if res != nil {
+				result = &getLatestBlockNumberResult{
+					blockNumber:    res.BlockNumber,
+					healthStatus:   HealthStatus(res.HealthStatus),
+					responseStatus: res.ResponseStatus,
+				}
+			}
+			if err == nil {
+				n.logger.Debug("Handler GetLatestBlockNumber succeeded",
+					zap.Int64("block_number", res.BlockNumber),
+					zap.String("health_status", res.HealthStatus.String()),
+					zap.String("network", n.Name),
+					zap.String("provider", providerHost))
+			}
+			return err
+		},
+	)
 
-			n.logger.Debug("Retryable error in GetLatestBlockNumber",
-				zap.Error(err),
-				zap.String("network", n.Name),
-				zap.String("provider", providerHost),
-				zap.Int("attempt", attempt+1),
-				zap.Int("max_attempts", n.RequestAttemptCount))
-			continue
-		}
-
-		// Success!
-		n.logger.Debug("Handler GetLatestBlockNumber succeeded",
-			zap.Int64("block_number", result.BlockNumber),
-			zap.String("health_status", result.HealthStatus.String()),
+	if err != nil {
+		n.logger.Debug("Handler GetLatestBlockNumber failed after all attempts",
+			zap.Error(err),
 			zap.String("network", n.Name),
 			zap.String("provider", providerHost),
-			zap.Int("attempt", attempt+1))
+			zap.Int("total_attempts", n.RequestAttemptCount))
 
+		if result != nil {
+			return result, err
+		}
+		// Return a default unhealthy result when result is nil
 		return &getLatestBlockNumberResult{
-			blockNumber:    result.BlockNumber,
-			healthStatus:   HealthStatus(result.HealthStatus),
-			responseStatus: result.ResponseStatus,
-		}, nil
+			blockNumber:    0,
+			healthStatus:   Unhealthy,
+			responseStatus: 0,
+		}, err
 	}
 
-	// All attempts failed
-	n.logger.Debug("Handler GetLatestBlockNumber failed after all attempts",
-		zap.Error(lastErr),
-		zap.String("network", n.Name),
-		zap.String("provider", providerHost),
-		zap.Int("total_attempts", n.RequestAttemptCount))
-
-	// Return the last result if available
-	if lastResult != nil {
-		return &getLatestBlockNumberResult{
-			blockNumber:    lastResult.BlockNumber,
-			healthStatus:   HealthStatus(lastResult.HealthStatus),
-			responseStatus: lastResult.ResponseStatus,
-		}, lastErr
-	}
-
-	// Return a default unhealthy result when result is nil
-	return &getLatestBlockNumberResult{
-		blockNumber:    0,
-		healthStatus:   Unhealthy,
-		responseStatus: 0,
-	}, lastErr
+	return result, nil
 }
 
 // Layer 3: Process response

--- a/modules/network.go
+++ b/modules/network.go
@@ -388,21 +388,51 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 	// chainId check health check
 	// Use handler's GetChainID method for all network types
 	if n.handler != nil {
-		chainId, err := n.handler.GetChainID(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), n.RequestAttemptCount)
-		if err != nil {
-			n.logProviderWarning("Error getting chain ID", provider,
-				zap.String("expected_chain_id", n.ChainId),
-				zap.String("health_status", Unhealthy.String()),
-				zap.Error(err))
-			return Unhealthy
+		// Add retry logic since handlers no longer retry internally
+		var chainId string
+		var lastErr error
+		for attempt := 0; attempt < n.RequestAttemptCount; attempt++ {
+			var err error
+			chainId, err = n.handler.GetChainID(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), 1)
+			if err != nil {
+				lastErr = err
+				// Check if error is retryable
+				if !n.handler.IsRetryableError(err, 0) {
+					n.logProviderWarning("Non-retryable error getting chain ID", provider,
+						zap.String("expected_chain_id", n.ChainId),
+						zap.String("health_status", Unhealthy.String()),
+						zap.Error(err),
+						zap.Int("attempt", attempt+1))
+					return Unhealthy
+				}
+				n.logger.Debug("Retryable error getting chain ID, will retry",
+					zap.Error(err),
+					zap.String("provider", provider.host),
+					zap.Int("attempt", attempt+1),
+					zap.Int("max_attempts", n.RequestAttemptCount))
+				continue
+			}
+
+			// Success - validate the chain ID
+			if err := n.handler.ValidateChainID(chainId); err != nil {
+				n.logProviderWarning("Provider has incorrect chain ID", provider,
+					zap.String("chain_id", chainId),
+					zap.String("expected_chain_id", n.ChainId),
+					zap.String("validation_error", err.Error()),
+					zap.String("health_status", Unhealthy.String()))
+				return Unhealthy
+			}
+			// Chain ID is valid, break out of retry loop
+			break
 		}
 
-		if err := n.handler.ValidateChainID(chainId); err != nil {
-			n.logProviderWarning("Provider has incorrect chain ID", provider,
-				zap.String("chain_id", chainId),
+		// If we exhausted all retries with errors
+		if lastErr != nil {
+			n.logProviderWarning("Error getting chain ID after all retries", provider,
 				zap.String("expected_chain_id", n.ChainId),
-				zap.String("validation_error", err.Error()),
-				zap.String("health_status", Unhealthy.String()))
+				zap.String("health_status", Unhealthy.String()),
+				zap.Error(lastErr),
+				zap.Int("total_attempts", n.RequestAttemptCount))
 			return Unhealthy
 		}
 	}
@@ -441,7 +471,32 @@ func (n *network) performArchiveCheck(provider *provider, currentBlock int64) er
 	// Use handler method to format block height directly
 	quarterBlockHeightString := n.handler.FormatBlockHeight(quarterBlockHeight)
 
-	return n.handler.PerformArchiveCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), n.RequestAttemptCount, quarterBlockHeightString)
+	// Add retry logic since handlers no longer retry internally
+	var lastErr error
+	for attempt := 0; attempt < n.RequestAttemptCount; attempt++ {
+		err := n.handler.PerformArchiveCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), 1, quarterBlockHeightString)
+		if err != nil {
+			lastErr = err
+			// Check if error is retryable
+			if !n.handler.IsRetryableError(err, 0) {
+				n.logger.Debug("Non-retryable error in archive check",
+					zap.Error(err),
+					zap.String("provider", provider.host),
+					zap.Int("attempt", attempt+1))
+				return err
+			}
+			n.logger.Debug("Retryable error in archive check, will retry",
+				zap.Error(err),
+				zap.String("provider", provider.host),
+				zap.Int("attempt", attempt+1),
+				zap.Int("max_attempts", n.RequestAttemptCount))
+			continue
+		}
+		// Success
+		return nil
+	}
+	// All attempts failed
+	return lastErr
 }
 
 // isStalled checks if provider's block numbers haven't changed
@@ -531,43 +586,79 @@ type getLatestBlockNumberResult struct {
 }
 
 func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string, ac auth.IAuthClient, providerHost string) (*getLatestBlockNumberResult, error) {
-	// Delegate to handler's GetLatestBlockNumber method
-	result, err := n.handler.GetLatestBlockNumber(httpUrl, headers, n.HttpClient, ac, n.RequestAttemptCount)
-	if err != nil {
-		n.logger.Debug("Handler GetLatestBlockNumber failed",
-			zap.Error(err),
-			zap.String("network", n.Name),
-			zap.String("provider", providerHost))
+	// Add retry logic since handlers no longer retry internally
+	var lastErr error
+	var lastResult *networklib.LatestBlockResult
 
-		// If there's an error, result might be nil or partially populated
-		if result != nil {
-			return &getLatestBlockNumberResult{
-				blockNumber:    result.BlockNumber,
-				healthStatus:   HealthStatus(result.HealthStatus), // Convert networklib.HealthStatus to modules.HealthStatus
-				responseStatus: result.ResponseStatus,
-			}, err
-		} else {
-			// Return a default unhealthy result when result is nil
-			return &getLatestBlockNumberResult{
-				blockNumber:    0,
-				healthStatus:   Unhealthy,
-				responseStatus: 0,
-			}, err
+	for attempt := 0; attempt < n.RequestAttemptCount; attempt++ {
+		// Call handler's GetLatestBlockNumber method (single attempt)
+		result, err := n.handler.GetLatestBlockNumber(httpUrl, headers, n.HttpClient, ac, 1)
+		if err != nil {
+			lastErr = err
+			lastResult = result
+
+			// Check if the error is retryable
+			var statusCode int
+			if result != nil {
+				statusCode = result.ResponseStatus
+			}
+
+			// Use handler's IsRetryableError to determine if we should retry
+			if !n.handler.IsRetryableError(err, statusCode) {
+				n.logger.Debug("Non-retryable error in GetLatestBlockNumber",
+					zap.Error(err),
+					zap.String("network", n.Name),
+					zap.String("provider", providerHost),
+					zap.Int("attempt", attempt+1))
+				break // Non-retryable error, stop trying
+			}
+
+			n.logger.Debug("Retryable error in GetLatestBlockNumber",
+				zap.Error(err),
+				zap.String("network", n.Name),
+				zap.String("provider", providerHost),
+				zap.Int("attempt", attempt+1),
+				zap.Int("max_attempts", n.RequestAttemptCount))
+			continue
 		}
+
+		// Success!
+		n.logger.Debug("Handler GetLatestBlockNumber succeeded",
+			zap.Int64("block_number", result.BlockNumber),
+			zap.String("health_status", result.HealthStatus.String()),
+			zap.String("network", n.Name),
+			zap.String("provider", providerHost),
+			zap.Int("attempt", attempt+1))
+
+		return &getLatestBlockNumberResult{
+			blockNumber:    result.BlockNumber,
+			healthStatus:   HealthStatus(result.HealthStatus),
+			responseStatus: result.ResponseStatus,
+		}, nil
 	}
 
-	// Success!
-	n.logger.Debug("Handler GetLatestBlockNumber succeeded",
-		zap.Int64("block_number", result.BlockNumber),
-		zap.String("health_status", result.HealthStatus.String()),
+	// All attempts failed
+	n.logger.Debug("Handler GetLatestBlockNumber failed after all attempts",
+		zap.Error(lastErr),
 		zap.String("network", n.Name),
-		zap.String("provider", providerHost))
+		zap.String("provider", providerHost),
+		zap.Int("total_attempts", n.RequestAttemptCount))
 
+	// Return the last result if available
+	if lastResult != nil {
+		return &getLatestBlockNumberResult{
+			blockNumber:    lastResult.BlockNumber,
+			healthStatus:   HealthStatus(lastResult.HealthStatus),
+			responseStatus: lastResult.ResponseStatus,
+		}, lastErr
+	}
+
+	// Return a default unhealthy result when result is nil
 	return &getLatestBlockNumberResult{
-		blockNumber:    result.BlockNumber,
-		healthStatus:   HealthStatus(result.HealthStatus), // Convert networklib.HealthStatus to modules.HealthStatus
-		responseStatus: result.ResponseStatus,
-	}, nil
+		blockNumber:    0,
+		healthStatus:   Unhealthy,
+		responseStatus: 0,
+	}, lastErr
 }
 
 // Layer 3: Process response
@@ -752,7 +843,8 @@ func (n *network) checkSelfLoopbackHealth() (*getLatestBlockNumberResult, error)
 		"Content-Type": "application/json",
 	}
 
-	// Use handler's GetLatestBlockNumber method but maintain detailed logging
+	// Use handler's GetLatestBlockNumber method with single attempt
+	// Loopback already goes through middleware which has retries, so no need for retry here
 	result, err := n.handler.GetLatestBlockNumber(loopbackURL, headers, n.HttpClient, nil, 1)
 	if err != nil {
 		// Extract method directly from GenericRequestContext - completely generic

--- a/modules/network.go
+++ b/modules/network.go
@@ -393,20 +393,11 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 
 		err := networklib.RetryWithChecker(
 			context.Background(),
+			n.logger,
+			"chain_id_check",
 			n.RequestAttemptCount,
 			func(err error) bool {
-				retryable := n.handler.IsRetryableError(err, 0)
-				if !retryable {
-					n.logProviderWarning("Non-retryable error getting chain ID", provider,
-						zap.String("expected_chain_id", n.ChainId),
-						zap.String("health_status", Unhealthy.String()),
-						zap.Error(err))
-				} else {
-					n.logger.Debug("Retryable error getting chain ID, will retry",
-						zap.Error(err),
-						zap.String("provider", provider.host))
-				}
-				return retryable
+				return n.handler.IsRetryableError(err, 0)
 			},
 			func() error {
 				var err error
@@ -426,6 +417,9 @@ func (n *network) evaluateProviderHealth(provider *provider, currentBlock int64,
 				}
 				return nil
 			},
+			zap.String("provider", provider.host),
+			zap.String("network", n.Name),
+			zap.String("expected_chain_id", n.ChainId),
 		)
 
 		if err != nil {
@@ -474,23 +468,19 @@ func (n *network) performArchiveCheck(provider *provider, currentBlock int64) er
 
 	return networklib.RetryWithChecker(
 		context.Background(),
+		n.logger,
+		"archive_check",
 		n.RequestAttemptCount,
 		func(err error) bool {
-			retryable := n.handler.IsRetryableError(err, 0)
-			if !retryable {
-				n.logger.Debug("Non-retryable error in archive check",
-					zap.Error(err),
-					zap.String("provider", provider.host))
-			} else {
-				n.logger.Debug("Retryable error in archive check, will retry",
-					zap.Error(err),
-					zap.String("provider", provider.host))
-			}
-			return retryable
+			return n.handler.IsRetryableError(err, 0)
 		},
 		func() error {
 			return n.handler.PerformArchiveCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), 1, quarterBlockHeightString)
 		},
+		zap.String("provider", provider.host),
+		zap.String("network", n.Name),
+		zap.String("block_height", quarterBlockHeightString),
+		zap.Int64("current_block", currentBlock),
 	)
 }
 
@@ -586,6 +576,8 @@ func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string
 
 	err := networklib.RetryWithChecker(
 		context.Background(),
+		n.logger,
+		"get_latest_block_number",
 		n.RequestAttemptCount,
 		func(err error) bool {
 			// Check if the error is retryable
@@ -593,19 +585,7 @@ func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string
 			if lastResult != nil {
 				statusCode = lastResult.ResponseStatus
 			}
-			retryable := n.handler.IsRetryableError(err, statusCode)
-			if !retryable {
-				n.logger.Debug("Non-retryable error in GetLatestBlockNumber",
-					zap.Error(err),
-					zap.String("network", n.Name),
-					zap.String("provider", providerHost))
-			} else {
-				n.logger.Debug("Retryable error in GetLatestBlockNumber",
-					zap.Error(err),
-					zap.String("network", n.Name),
-					zap.String("provider", providerHost))
-			}
-			return retryable
+			return n.handler.IsRetryableError(err, statusCode)
 		},
 		func() error {
 			res, err := n.handler.GetLatestBlockNumber(httpUrl, headers, n.HttpClient, ac, 1)
@@ -617,7 +597,7 @@ func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string
 					responseStatus: res.ResponseStatus,
 				}
 			}
-			if err == nil {
+			if err == nil && res != nil {
 				n.logger.Debug("Handler GetLatestBlockNumber succeeded",
 					zap.Int64("block_number", res.BlockNumber),
 					zap.String("health_status", res.HealthStatus.String()),
@@ -626,6 +606,8 @@ func (n *network) getLatestBlockNumber(httpUrl string, headers map[string]string
 			}
 			return err
 		},
+		zap.String("provider", providerHost),
+		zap.String("network", n.Name),
 	)
 
 	if err != nil {

--- a/modules/network_evaluate_health_test.go
+++ b/modules/network_evaluate_health_test.go
@@ -199,6 +199,8 @@ func TestEvaluateProviderHealth(t *testing.T) {
 				mockHandler.EXPECT().GetChainID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("0x5", nil).AnyTimes()
 				mockHandler.EXPECT().ValidateChainID("0x5").Return(errors.New("invalid chain ID")).AnyTimes()
+				// The retry logic will check if the validation error is retryable
+				mockHandler.EXPECT().IsRetryableError(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
 			}
 
 			// Setup mocks for archive mode

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -400,7 +400,7 @@ func TestArchiveModeCheck(t *testing.T) {
 			httpError:      errors.New("connection failed"),
 			quarterBlock:   "0x64",
 			expectError:    true,
-			expectedErrMsg: "failed after",
+			expectedErrMsg: "error sending HTTP request",
 		},
 		{
 			name:           "service_unavailable",
@@ -410,7 +410,7 @@ func TestArchiveModeCheck(t *testing.T) {
 			httpError:      nil,
 			quarterBlock:   "0x64",
 			expectError:    true,
-			expectedErrMsg: "failed after",
+			expectedErrMsg: "network unavailable",
 		},
 		{
 			name:           "json_rpc_error",
@@ -420,7 +420,7 @@ func TestArchiveModeCheck(t *testing.T) {
 			httpError:      nil,
 			quarterBlock:   "0x64",
 			expectError:    true,
-			expectedErrMsg: "failed after",
+			expectedErrMsg: "archive mode not supported",
 		},
 		{
 			name:         "starknet_successful",
@@ -439,7 +439,7 @@ func TestArchiveModeCheck(t *testing.T) {
 			httpError:      nil,
 			quarterBlock:   "1000",
 			expectError:    true,
-			expectedErrMsg: "failed after",
+			expectedErrMsg: "missing or invalid block_hash",
 		},
 	}
 
@@ -478,7 +478,7 @@ func TestArchiveModeCheck(t *testing.T) {
 				require.NoError(t, n.SetHandler(networklib.NewStarknetHandler(config)))
 			}
 
-			err = n.handler.PerformArchiveCheck("http://test.com", map[string]string{}, n.HttpClient, nil, n.RequestAttemptCount, tt.quarterBlock)
+			err = n.handler.PerformArchiveCheck("http://test.com", map[string]string{}, n.HttpClient, nil, 1, tt.quarterBlock)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -737,7 +737,7 @@ func TestGetLatestBlockNumber(t *testing.T) {
 			httpError:            nil,
 			hcMethod:             "eth_blockNumber",
 			expectedBlockNum:     0,
-			expectedHealthStatus: Unhealthy,
+			expectedHealthStatus: Warning,  // 5xx errors are retryable, so Warning not Unhealthy
 			expectedErr:          true,
 		},
 	}


### PR DESCRIPTION
# Refactor: Centralize retry logic and eliminate redundant retries

**Base:** `feat/tron-full-node`
**Compare:** `feat/tron-full-node-efficient-retries`

## Summary
- Removes redundant retry logic from all network handlers (Level 2) to eliminate request multiplication
- Creates centralized retry mechanism in `lib/network/retry.go`
- Ensures retry logic exists only at middleware/higher level (Level 1)

## Problem Solved
Previously, both middleware and handlers were implementing retry logic, causing up to 9x request multiplication. This PR consolidates all retry logic to a single layer.

## Changes
- **Removed retry logic from handlers**: Tron, Beacon, Bitcoin, Bitcoin Esplora, and shared JSON-RPC helpers now make single attempts only
- **Added centralized retry functions**: `Retry()` and `RetryWithChecker()` in `lib/network/retry.go`
- **Updated middleware**: Uses new centralized retry functions for registry calls and network operations
- **Comprehensive tests**: Added full test coverage for retry logic including context cancellation and exponential backoff
