### PR TITLE
Add API Key Metric for requests

### DIFF
--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -61,7 +61,7 @@ func RegisterMetrics() {
 			Name: DinRequestCountMetricName,
 			Help: "Metric for counting the number of requests to the din http server",
 		},
-		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "method", "provider", "api_key", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
 	)
 	DinRequestDurationMilliseconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -133,6 +133,7 @@ type PromRequestMetricData struct {
 	Method         string
 	Network        string
 	Provider       string
+	ApiKey         string
 	HostName       string
 	ResponseStatus int
 	HealthStatus   string
@@ -153,7 +154,7 @@ func (p *PrometheusClient) HandleRequestMetrics(data *PromRequestMetricData, dur
 	p.logger.Debug("Request metric data", zap.String("network", network), zap.String("method", method), zap.String("provider", data.Provider), zap.String("host_name", data.HostName), zap.String("response_status", status), zap.String("health_status", data.HealthStatus), zap.Int("priority", data.Priority), zap.Int64("duration_milliseconds", durationMS), zap.String("environment", data.Environment))
 
 	// Increment prometheus counter metric based on request data
-	DinRequestCount.WithLabelValues(network, method, data.Provider, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Inc()
+	DinRequestCount.WithLabelValues(network, method, data.Provider, data.ApiKey, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Inc()
 
 	// Observe prometheus histogram based on request duration and data
 	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Observe(float64(durationMS))

--- a/lib/prometheus/prometheus_test.go
+++ b/lib/prometheus/prometheus_test.go
@@ -43,6 +43,7 @@ func TestHandleRequestMetric(t *testing.T) {
 			data: &PromRequestMetricData{
 				Network:        "/ethereum",
 				Provider:       "infura",
+				ApiKey:         "abc123",
 				HostName:       "node1",
 				ResponseStatus: 200,
 				HealthStatus:   "healthy",
@@ -52,6 +53,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				"service":         "ethereum",
 				"method":          "eth_getBlockByNumber",
 				"provider":        "infura",
+				"api_key":         "abc123",
 				"host_name":       "node1",
 				"response_status": "200",
 				"health_status":   "healthy",
@@ -67,6 +69,7 @@ func TestHandleRequestMetric(t *testing.T) {
 			data: &PromRequestMetricData{
 				Network:        "/ethereum",
 				Provider:       "infura",
+				ApiKey:         "abc123",
 				HostName:       "node1",
 				ResponseStatus: 200,
 				HealthStatus:   "healthy",
@@ -76,6 +79,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				"service":         "ethereum",
 				"method":          "",
 				"provider":        "infura",
+				"api_key":         "abc123",
 				"host_name":       "node1",
 				"response_status": "200",
 				"health_status":   "healthy",

--- a/modules/caddy_unmarshaller.go
+++ b/modules/caddy_unmarshaller.go
@@ -78,6 +78,11 @@ func (p *caddyfileParser) initialize() error {
 		p.middleware.Networks = make(map[string]*network)
 	}
 
+	// Initialize API Key map if needed
+	if p.middleware.ApiKeys == nil {
+		p.middleware.ApiKeys = make(map[string]string)
+	}
+
 	// Set environment
 	p.middleware.Env = utils.GetEnv()
 
@@ -106,6 +111,10 @@ func (p *caddyfileParser) parseDirective() error {
 		return p.parseNetworks()
 	case "din_registry":
 		return p.parseDinRegistry()
+	case "api_keys":
+		return p.parseAPIKeys()
+	case "unknown_api_key_salt":
+		return p.parseAPISalt()
 	default:
 		// Continue processing for other directives
 		return nil
@@ -587,6 +596,25 @@ func (p *caddyfileParser) parseDinRegistry() error {
 			return p.dispenser.Errf("unrecognized registry option: %s", p.dispenser.Val())
 		}
 	}
+	return nil
+}
+
+func (p *caddyfileParser) parseAPIKeys() error {
+	for n1 := p.dispenser.Nesting(); p.dispenser.NextBlock(n1); {
+		key := p.dispenser.Val()
+		if !p.dispenser.Next() {
+			return p.dispenser.Errf("API keys must specify user IDs")
+		}
+		p.middleware.ApiKeys[key] = p.dispenser.Val()
+	}
+	return nil
+}
+
+func (p *caddyfileParser) parseAPISalt() error {
+	if !p.dispenser.Next() {
+		return p.dispenser.Errf("unknown_api_key_salt must be followed with a value")
+	}
+	p.middleware.ApiSalt = p.dispenser.Val()
 	return nil
 }
 

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -107,6 +107,10 @@ type DinMiddleware struct {
 	// Internal registry tracking - this is not exposed in config
 	registryLastUpdatedEpochBlockNumber uint64
 
+	// Map for associating API keys with users
+	ApiKeys map[string]string
+	ApiSalt string
+
 	// The channel to quit the goroutines
 	quit chan struct{}
 }
@@ -479,7 +483,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	// Store network object in replacer for later use
 	repl.Set("network_object", networkObj)
 	if api_key := r.Header.Get("Din-Api-Key"); api_key != "" {
-		repl.Set("din_api_key", api_key)
+		repl.Set("din_api_key", d.getAPIKeyId(api_key))
 		r.Header.Del("Din-Api-Key") // We don't want to pass this information to providers
 	} else {
 		repl.Set("din_api_key", "unspecified")

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -478,6 +478,12 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 
 	// Store network object in replacer for later use
 	repl.Set("network_object", networkObj)
+	if api_key := r.Header.Get("Din-Api-Key"); api_key != "" {
+		repl.Set("din_api_key", api_key)
+		r.Header.Del("Din-Api-Key") // We don't want to pass this information to providers
+	} else {
+		repl.Set("din_api_key", "unspecified")
+	}
 
 	// Middleware focuses on request validation only
 	// DinSelect will handle all REST API path processing during provider configuration
@@ -735,7 +741,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 				Method:         method,
 				Network:        networkPath,
 				Provider:       provider,
-				ApiKey:         getRequestAPIKey(r),
+				ApiKey:         getRequestAPIKey(repl),
 				HostName:       r.Host,
 				ResponseStatus: statusCode,
 				HealthStatus:   "unhealthy", // All providers failed

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -735,6 +735,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 				Method:         method,
 				Network:        networkPath,
 				Provider:       provider,
+				ApiKey:         getRequestAPIKey(r),
 				HostName:       r.Host,
 				ResponseStatus: statusCode,
 				HealthStatus:   "unhealthy", // All providers failed

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -1,11 +1,13 @@
 package modules
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
+	"encoding/hex"
 	"encoding/json"
 
 	"github.com/DIN-center/din-sc/apps/din-go/lib/din"
@@ -761,4 +763,14 @@ func (d *DinMiddleware) processHCMethodResponseAsync(networkObj *network, networ
 	// save the block number to the network object's history
 	networkObj.AddNetworkBlockEntry(blockNumber, block) // Add the block number and block hash to the network object's history as long as its the the latest block number
 	d.logger.Debug("Goroutine: HCMethod matched, successfully processed block number and added to network history", zap.Int64("block_number", blockNumber), zap.String("network", networkPath))
+}
+
+func (d *DinMiddleware) getAPIKeyId(key string) string {
+	if v, ok := d.ApiKeys[key]; ok {
+		return v
+	}
+	h := sha256.New()
+	h.Write([]byte(d.ApiSalt))
+	h.Write([]byte(key))
+	return hex.EncodeToString(h.Sum(nil))[:10]
 }

--- a/modules/din_middleware_test.go
+++ b/modules/din_middleware_test.go
@@ -495,6 +495,70 @@ func TestUnmarshalCaddyfile(t *testing.T) {
 	}
 }
 
+func TestUnmarshalCaddyfileAPIKeys(t *testing.T) {
+	dinMiddleware := new(DinMiddleware)
+	dinMiddleware.logger = logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
+
+	tests := []struct {
+		name      string
+		caddyfile string
+		hasErr    bool
+		expectKeys map[string]string
+	}{
+		{
+			name: "Valid Caddyfile",
+			caddyfile: `networks {
+				eth {
+					methods eth_blockNumber eth_getBlockByNumber
+					providers {
+						http://test-website-1.com/eth {
+							headers {
+								Content-Type application/json
+							}
+							priority 1
+						}
+						http://test-website-2.com/eth {
+							headers {
+								Content-Type application/json
+							}
+							priority 2
+						}
+					}
+					chain_id 0x1
+					healthcheck_threshold 2
+					healthcheck_interval 5
+					healthcheck_blocklag_limit 10
+					max_request_payload_size_kb 100
+				}
+			}
+			unknown_api_key_salt foo
+			api_keys {
+				test-key some-user
+				other-key other-user
+			}`,
+			expectKeys: map[string]string{
+				"test-key": "some-user",
+				"other-key": "other-user",
+				"missing-key": "c92388d1d4", // sha256(foo + missing-key)[:10]
+			},
+			hasErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dispenser := caddyfile.NewTestDispenser(tt.caddyfile)
+			err := dinMiddleware.UnmarshalCaddyfile(dispenser)
+			if err != nil && !tt.hasErr {
+				t.Errorf("UnmarshalCaddyfile() = %v, want %v", err, tt.hasErr)
+			}
+			for k, v := range tt.expectKeys {
+				assert.Equal(t, dinMiddleware.getAPIKeyId(k), v)
+			}
+		})
+	}
+}
+
 func TestProcessHCMethodResponseAsync(t *testing.T) {
 	// Helper to capture stdout for fmt.Printf checks
 	captureOutput := func(f func()) string {

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -146,6 +146,13 @@ func getRequestBody(repl *caddy.Replacer) (*dinHttp.JSONRPCRequest, error) {
 	return nil, nil
 }
 
+func getRequestAPIKey(req *http.Request) string {
+	if key := req.Header.Get("Din-Api-Key"); key != "" {
+		return key
+	}
+	return "unspecified"
+}
+
 func getRequestMethod(repl *caddy.Replacer) (string, error) {
 	method, ok := repl.Get(RequestMethodKey)
 	if !ok {
@@ -428,6 +435,7 @@ func handlePostRequestTasks(params PostRequestTaskParams) {
 		Method:         requestMethod,
 		Network:        params.NetworkPath,
 		Provider:       params.Provider,
+		ApiKey:         getRequestAPIKey(params.OriginalReq),
 		HostName:       params.OriginalReq.Host,
 		ResponseStatus: effectiveStatusCode,
 		HealthStatus:   healthStatus,
@@ -634,6 +642,7 @@ func handleContextCancellation(l *logger.LoggerClient, promClient *prom.Promethe
 			Method:         "unknown", // Generic - no network-specific parsing
 			Network:        networkPath,
 			Provider:       provider,
+			ApiKey:         getRequestAPIKey(r),
 			HostName:       r.Host,
 			ResponseStatus: statusCode,
 			HealthStatus:   "unhealthy", // Context cancellation indicates unhealthy state

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -146,9 +146,9 @@ func getRequestBody(repl *caddy.Replacer) (*dinHttp.JSONRPCRequest, error) {
 	return nil, nil
 }
 
-func getRequestAPIKey(req *http.Request) string {
-	if key := req.Header.Get("Din-Api-Key"); key != "" {
-		return key
+func getRequestAPIKey(repl *caddy.Replacer) string {
+	if key, ok := repl.Get("din_api_key"); ok {
+		return key.(string)
 	}
 	return "unspecified"
 }
@@ -435,7 +435,7 @@ func handlePostRequestTasks(params PostRequestTaskParams) {
 		Method:         requestMethod,
 		Network:        params.NetworkPath,
 		Provider:       params.Provider,
-		ApiKey:         getRequestAPIKey(params.OriginalReq),
+		ApiKey:         getRequestAPIKey(params.Replacer),
 		HostName:       params.OriginalReq.Host,
 		ResponseStatus: effectiveStatusCode,
 		HealthStatus:   healthStatus,
@@ -642,7 +642,7 @@ func handleContextCancellation(l *logger.LoggerClient, promClient *prom.Promethe
 			Method:         "unknown", // Generic - no network-specific parsing
 			Network:        networkPath,
 			Provider:       provider,
-			ApiKey:         getRequestAPIKey(r),
+			ApiKey:         getRequestAPIKey(repl),
 			HostName:       r.Host,
 			ResponseStatus: statusCode,
 			HealthStatus:   "unhealthy", // Context cancellation indicates unhealthy state

--- a/modules/helpers_test.go
+++ b/modules/helpers_test.go
@@ -947,38 +947,29 @@ func TestLogFailedAttempt(t *testing.T) {
 func TestGetRequestAPIKey(t *testing.T) {
 	tests := []struct {
 		name       string
-		headerKey  string
-		headerVal  string
+		apiKey  string
 		want       string
 	}{
 		{
 			name:      "Header present with value",
-			headerKey: "Din-Api-Key",
-			headerVal: "abc123",
+			apiKey:    "abc123",
 			want:      "abc123",
 		},
 		{
-			name:      "Header present but empty",
-			headerKey: "Din-Api-Key",
-			headerVal: "",
-			want:      "unspecified",
-		},
-		{
 			name:      "Header absent entirely",
-			headerKey: "",
-			headerVal: "",
+			apiKey:    "",
 			want:      "unspecified",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
-			if tt.headerKey != "" {
-				req.Header.Set(tt.headerKey, tt.headerVal)
+			repl := caddy.NewReplacer()
+			if tt.apiKey != "" {
+				repl.Set("din_api_key", tt.apiKey)
 			}
 
-			got := getRequestAPIKey(req)
+			got := getRequestAPIKey(repl)
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}

--- a/modules/helpers_test.go
+++ b/modules/helpers_test.go
@@ -943,3 +943,45 @@ func TestLogFailedAttempt(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRequestAPIKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerKey  string
+		headerVal  string
+		want       string
+	}{
+		{
+			name:      "Header present with value",
+			headerKey: "Din-Api-Key",
+			headerVal: "abc123",
+			want:      "abc123",
+		},
+		{
+			name:      "Header present but empty",
+			headerKey: "Din-Api-Key",
+			headerVal: "",
+			want:      "unspecified",
+		},
+		{
+			name:      "Header absent entirely",
+			headerKey: "",
+			headerVal: "",
+			want:      "unspecified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.headerKey != "" {
+				req.Header.Set(tt.headerKey, tt.headerVal)
+			}
+
+			got := getRequestAPIKey(req)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We're going to start requiring keys for access to the gateway, and we want to know which keys are making which requests.

This adds the api key to prometheus metrics, and passes it through from the request.