### PR TITLE
[feature] Add support for human name for provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,11 +157,11 @@ update-deps: ## Update Go dependencies
 ## Docker Commands
 docker-build: ## Build Docker image
 	@echo "$(GREEN)Building Docker image...$(NC)"
-	docker build -t din-caddy-plugins .
+	docker build -t din-caddy .
 
 docker-run: ## Run Docker container
 	@echo "$(GREEN)Running Docker container...$(NC)"
-	docker run -p 80:80 -p 443:443 din-caddy-plugins
+	docker run -p 80:80 -p 443:443 din-caddy
 
 ## Utility Commands
 clean: ## Clean build artifacts and test files

--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -61,7 +61,7 @@ func RegisterMetrics() {
 			Name: DinRequestCountMetricName,
 			Help: "Metric for counting the number of requests to the din http server",
 		},
-		[]string{"service", "method", "provider", "api_key", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "method", "provider", "provider_name", "api_key", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
 	)
 	DinRequestDurationMilliseconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -73,7 +73,7 @@ func RegisterMetrics() {
 				7000, 10000, 20000, 30000, 40000, 50000,
 				60000, 70000, 80000, 90000, 100000}, //
 		},
-		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "method", "provider", "provider_name", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
 	)
 
 	DinRequestBodyBytes = prometheus.NewHistogramVec(
@@ -82,7 +82,7 @@ func RegisterMetrics() {
 			Help:    "Metric for measuring the size of the request body in bytes",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"service", "method", "provider", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "method", "provider", "provider_name", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
 	)
 
 	// Register health check count metric for din health checks
@@ -91,7 +91,7 @@ func RegisterMetrics() {
 			Name: DinHealthCheckCountMetricName,
 			Help: "Metric for counting din health checks with network, provider, response_status and health_status",
 		},
-		[]string{"service", "provider", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "provider", "provider_name", "response_status", "health_status", "priority", "machine_id", "environment"},
 	)
 
 	DinProviderHealthCheckBlockNumber = prometheus.NewGaugeVec(
@@ -99,7 +99,7 @@ func RegisterMetrics() {
 			Name: DinHealthCheckBlockNumberMetricName,
 			Help: "Metric for storing the block number of the latest health check",
 		},
-		[]string{"service", "provider", "priority", "machine_id", "environment"},
+		[]string{"service", "provider", "provider_name", "priority", "machine_id", "environment"},
 	)
 
 	prometheus.MustRegister(DinRequestCount, DinProviderHealthCheckCount, DinRequestDurationMilliseconds, DinRequestBodyBytes, DinProviderHealthCheckBlockNumber)
@@ -133,6 +133,7 @@ type PromRequestMetricData struct {
 	Method         string
 	Network        string
 	Provider       string
+	ProviderName   string
 	ApiKey         string
 	HostName       string
 	ResponseStatus int
@@ -151,18 +152,19 @@ func (p *PrometheusClient) HandleRequestMetrics(data *PromRequestMetricData, dur
 
 	durationMS := duration.Milliseconds()
 
-	p.logger.Debug("Request metric data", zap.String("network", network), zap.String("method", method), zap.String("provider", data.Provider), zap.String("host_name", data.HostName), zap.String("response_status", status), zap.String("health_status", data.HealthStatus), zap.Int("priority", data.Priority), zap.Int64("duration_milliseconds", durationMS), zap.String("environment", data.Environment))
+	p.logger.Debug("Request metric data", zap.String("network", network), zap.String("method", method), zap.String("provider", data.Provider), zap.String("provider_name", data.ProviderName), zap.String("host_name", data.HostName), zap.String("response_status", status), zap.String("health_status", data.HealthStatus), zap.Int("priority", data.Priority), zap.Int64("duration_milliseconds", durationMS), zap.String("environment", data.Environment))
 
 	// Increment prometheus counter metric based on request data
-	DinRequestCount.WithLabelValues(network, method, data.Provider, data.ApiKey, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Inc()
+	DinRequestCount.WithLabelValues(network, method, data.Provider, data.ProviderName, data.ApiKey, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Inc()
 
 	// Observe prometheus histogram based on request duration and data
-	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Observe(float64(durationMS))
+	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.ProviderName, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Observe(float64(durationMS))
 }
 
 type PromHealthCheckMetricData struct {
 	Network        string
 	Provider       string
+	ProviderName   string
 	ResponseStatus int
 	HealthStatus   string
 	BlockNumber    int64
@@ -174,13 +176,13 @@ func (p *PrometheusClient) HandleHealthCheckMetric(data *PromHealthCheckMetricDa
 	network := strings.TrimPrefix(data.Network, "/")
 	priority := strconv.Itoa(data.Priority)
 
-	p.logger.Debug("Latest block metric data", zap.String("network", network), zap.String("provider", data.Provider), zap.String("health_status", data.HealthStatus), zap.Int("priority", data.Priority), zap.String("environment", data.Environment))
+	p.logger.Debug("Latest block metric data", zap.String("network", network), zap.String("provider", data.Provider), zap.String("provider_name", data.ProviderName), zap.String("health_status", data.HealthStatus), zap.Int("priority", data.Priority), zap.String("environment", data.Environment))
 
 	// Increment prometheus metric based on request data
-	DinProviderHealthCheckCount.WithLabelValues(network, data.Provider, strconv.Itoa(data.ResponseStatus), data.HealthStatus, priority, p.machineID, data.Environment).Inc()
+	DinProviderHealthCheckCount.WithLabelValues(network, data.Provider, data.ProviderName, strconv.Itoa(data.ResponseStatus), data.HealthStatus, priority, p.machineID, data.Environment).Inc()
 
 	// Update prometheus metric based on block number
-	DinProviderHealthCheckBlockNumber.WithLabelValues(network, data.Provider, priority, p.machineID, data.Environment).Set(float64(data.BlockNumber))
+	DinProviderHealthCheckBlockNumber.WithLabelValues(network, data.Provider, data.ProviderName, priority, p.machineID, data.Environment).Set(float64(data.BlockNumber))
 }
 
 // PromNetworkHealthCheckMetricData holds data for network level health check metrics

--- a/lib/prometheus/prometheus_test.go
+++ b/lib/prometheus/prometheus_test.go
@@ -43,6 +43,7 @@ func TestHandleRequestMetric(t *testing.T) {
 			data: &PromRequestMetricData{
 				Network:        "/ethereum",
 				Provider:       "infura",
+				ProviderName:   "infura",
 				ApiKey:         "abc123",
 				HostName:       "node1",
 				ResponseStatus: 200,
@@ -53,6 +54,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				"service":         "ethereum",
 				"method":          "eth_getBlockByNumber",
 				"provider":        "infura",
+				"provider_name":   "infura",
 				"api_key":         "abc123",
 				"host_name":       "node1",
 				"response_status": "200",
@@ -69,6 +71,7 @@ func TestHandleRequestMetric(t *testing.T) {
 			data: &PromRequestMetricData{
 				Network:        "/ethereum",
 				Provider:       "infura",
+				ProviderName:   "infura",
 				ApiKey:         "abc123",
 				HostName:       "node1",
 				ResponseStatus: 200,
@@ -79,6 +82,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				"service":         "ethereum",
 				"method":          "",
 				"provider":        "infura",
+				"provider_name":   "infura",
 				"api_key":         "abc123",
 				"host_name":       "node1",
 				"response_status": "200",
@@ -103,6 +107,7 @@ func TestHandleRequestMetric(t *testing.T) {
 				tt.expectedLabels["service"],
 				tt.expectedLabels["method"],
 				tt.expectedLabels["provider"],
+				tt.expectedLabels["provider_name"],
 				tt.expectedLabels["host_name"],
 				tt.expectedLabels["response_status"],
 				tt.expectedLabels["health_status"],
@@ -133,6 +138,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 			data: &PromHealthCheckMetricData{
 				Network:        "/ethereum",
 				Provider:       "infura",
+				ProviderName:   "infura",
 				ResponseStatus: 200,
 				HealthStatus:   "healthy",
 				Environment:    "test",
@@ -140,6 +146,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 			expectedLabels: map[string]string{
 				"service":         "ethereum",
 				"provider":        "infura",
+				"provider_name":   "infura",
 				"response_status": "200",
 				"health_status":   "healthy",
 				"machine_id":      client.machineID,
@@ -151,6 +158,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 			data: &PromHealthCheckMetricData{
 				Network:        "/ethereum",
 				Provider:       "infura",
+				ProviderName:   "infura",
 				ResponseStatus: 500,
 				HealthStatus:   "unhealthy",
 				Environment:    "test",
@@ -158,6 +166,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 			expectedLabels: map[string]string{
 				"service":         "ethereum",
 				"provider":        "infura",
+				"provider_name":   "infura",
 				"response_status": "500",
 				"health_status":   "unhealthy",
 				"machine_id":      client.machineID,
@@ -178,6 +187,7 @@ func TestHandleHealthCheckMetric(t *testing.T) {
 			metric := testutil.ToFloat64(DinProviderHealthCheckCount.WithLabelValues(
 				tt.expectedLabels["service"],
 				tt.expectedLabels["provider"],
+				tt.expectedLabels["provider_name"],
 				tt.expectedLabels["response_status"],
 				tt.expectedLabels["health_status"],
 				tt.expectedLabels["machine_id"],

--- a/modules/caddy_unmarshaller.go
+++ b/modules/caddy_unmarshaller.go
@@ -320,6 +320,7 @@ func (p *caddyfileParser) parseProvider(network *network, providerUrl string, pa
 		p.middleware.logger.Debug("Added provider to network map",
 			zap.String("network", network.Name),
 			zap.String("providerHost", providerObj.host),
+			zap.String("providerName", providerObj.Name),
 			zap.String("providerUrl", providerObj.HttpUrl))
 	}
 
@@ -337,6 +338,8 @@ func (p *caddyfileParser) parseProviderField(provider *provider, nesting int) er
 		return p.parseProviderHeaders(provider, nesting)
 	case "priority":
 		return p.parseProviderPriority(provider, nesting)
+	case "name":
+		return p.parseProviderName(provider, nesting)
 	default:
 		return p.dispenser.Errf("unrecognized provider option: %s", p.dispenser.Val())
 	}
@@ -521,6 +524,13 @@ func (p *caddyfileParser) parseProviderPriority(provider *provider, nesting int)
 		return fmt.Errorf("invalid priority: %w", err)
 	}
 	provider.Priority = priority
+	return nil
+}
+
+// parseProviderName parses provider name
+func (p *caddyfileParser) parseProviderName(provider *provider, nesting int) error {
+	p.dispenser.NextBlock(nesting)
+	provider.Name = p.dispenser.Val()
 	return nil
 }
 

--- a/modules/caddy_unmarshaller_test.go
+++ b/modules/caddy_unmarshaller_test.go
@@ -266,7 +266,7 @@ func TestCaddyUnmarshallerProviders(t *testing.T) {
 			},
 		},
 		{
-			name: "Valid Caddyfile with providers (default values)",
+			name: "Valid Caddyfile with providers (set name and priority)",
 			caddyfile: `networks {
 				eth {
 					chain_id 0x1

--- a/modules/caddy_unmarshaller_test.go
+++ b/modules/caddy_unmarshaller_test.go
@@ -238,3 +238,82 @@ func TestReflectionBasedConfigErrorHandling(t *testing.T) {
 		})
 	}
 }
+
+func TestCaddyUnmarshallerProviders(t *testing.T) {
+	tests := []struct {
+		name              string
+		caddyfile         string
+		expectedProviders map[string]*provider
+	}{
+		{
+			name: "Valid Caddyfile with providers (default values)",
+			caddyfile: `networks {
+				eth {
+					chain_id 0x1
+					providers {
+						http://test.com/eth {
+						}
+					}
+				}
+			}`,
+			expectedProviders: map[string]*provider{
+				"test.com": {
+					HttpUrl:  "http://test.com/eth",
+					host:     "test.com",
+					Name:     "test",
+					Priority: 0,
+				},
+			},
+		},
+		{
+			name: "Valid Caddyfile with providers (default values)",
+			caddyfile: `networks {
+				eth {
+					chain_id 0x1
+					providers {
+						http://subdomain.test.com/eth {
+							priority 1
+							name MyCustomProvider
+						}
+					}
+				}
+			}`,
+			expectedProviders: map[string]*provider{
+				"subdomain.test.com": {
+					HttpUrl:  "http://subdomain.test.com/eth",
+					host:     "subdomain.test.com",
+					Name:     "MyCustomProvider",
+					Priority: 1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dinMiddleware := new(DinMiddleware)
+			dinMiddleware.logger = logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
+
+			dispenser := caddyfile.NewTestDispenser(tt.caddyfile)
+			err := dinMiddleware.UnmarshalCaddyfile(dispenser)
+
+			assert.NoError(t, err)
+
+			// Get the network
+			network, networkExists := dinMiddleware.Networks["eth"]
+			assert.True(t, networkExists, "Network 'eth' should exist")
+
+			assert.Equal(t, len(tt.expectedProviders), len(network.Providers), "Should have %d providers", len(tt.expectedProviders))
+
+			// Check providers
+			for _, expectedProvider := range tt.expectedProviders {
+				actualProvider, exists := network.Providers[expectedProvider.host]
+				assert.True(t, exists, "Provider %s should exist", expectedProvider.host)
+				assert.Equal(t, expectedProvider.HttpUrl, actualProvider.HttpUrl, "Provider %s should have the correct HTTP URL", expectedProvider.host)
+				assert.Equal(t, expectedProvider.host, actualProvider.host, "Provider %s should have the correct host", expectedProvider.host)
+				assert.Equal(t, expectedProvider.Name, actualProvider.Name, "Provider %s should have the correct name", expectedProvider.host)
+				assert.Equal(t, expectedProvider.Priority, actualProvider.Priority, "Provider %s should have the correct priority", expectedProvider.host)
+			}
+		})
+	}
+}

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -430,7 +430,7 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 		}
 	}
 	provider.logger = d.logger
-	d.logger.Debug("Provider provisioned", zap.String("Provider", provider.HttpUrl), zap.String("Host", provider.host), zap.Int("Priority", provider.Priority), zap.Any("Headers", provider.Headers), zap.Any("Auth", provider.Auth), zap.Any("Upstream", provider.upstream), zap.Any("Path", provider.path))
+	d.logger.Debug("Provider provisioned", zap.String("Provider", provider.HttpUrl), zap.String("Host", provider.host), zap.String("Name", provider.Name), zap.Int("Priority", provider.Priority), zap.Any("Headers", provider.Headers), zap.Any("Auth", provider.Auth), zap.Any("Upstream", provider.upstream), zap.Any("Path", provider.path))
 
 	// Make sure blockHistory is initialized
 	if provider.blockHistory == nil {
@@ -721,7 +721,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 		if v, ok := repl.Get(RequestProviderKey); ok {
 			provider = v.(string)
 		}
-		
+
 		// Get priority for metrics
 		priority := 0
 		if v, ok := repl.Get(RequestProviderPriorityKey); ok {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -730,6 +730,12 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 			}
 		}
 
+		// Get provider name for metrics
+		providerName := "unknown"
+		if v, ok := networkObj.Providers[provider]; ok {
+			providerName = v.Name
+		}
+
 		duration := time.Since(reqStartTime)
 
 		// Determine appropriate status code for the failure
@@ -745,6 +751,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 				Method:         method,
 				Network:        networkPath,
 				Provider:       provider,
+				ProviderName:   providerName,
 				ApiKey:         getRequestAPIKey(repl),
 				HostName:       r.Host,
 				ResponseStatus: statusCode,

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -185,6 +185,7 @@ func (d *DinMiddleware) addNetworkWithRegistryData(regNetwork *din.Network) erro
 				d.logger.Debug("Registry: Added provider to network map",
 					zap.String("network", network.Name),
 					zap.String("providerHost", provider.host),
+					zap.String("providerName", provider.Name),
 					zap.String("providerUrl", provider.HttpUrl))
 			}
 		}

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -216,10 +216,20 @@ type LogFailedAttemptParams struct {
 // should be handled by the caller before passing data to this function.
 func logFailedAttempt(params LogFailedAttemptParams) {
 	// Extract provider information from the Caddy replacer context
-	provider := "unknown"
+	providerHost := "unknown"
+	providerName := "unknown"
 	if provVal, provOk := params.Replacer.Get(RequestProviderKey); provOk {
 		if pStr, strOk := provVal.(string); strOk {
-			provider = pStr
+			providerHost = pStr
+
+			// Now get the provider name from the providers map
+			if providerMapVal, exists := params.Replacer.Get(DinUpstreamsContextKey); exists {
+				if providers, castOk := providerMapVal.(map[string]*provider); castOk {
+					if providerObj, exists := providers[providerHost]; exists {
+						providerName = providerObj.Name
+					}
+				}
+			}
 		}
 	}
 
@@ -245,7 +255,8 @@ func logFailedAttempt(params LogFailedAttemptParams) {
 	// Build the base log fields
 	logFields := []zap.Field{
 		zap.String("network", params.NetworkPath),
-		zap.String("provider", provider),
+		zap.String("provider", providerHost),
+		zap.String("provider_name", providerName),
 		zap.Int("failed_attempt_number", params.FailedAttemptNumber),
 		zap.Int("max_attempts", params.MaxAttempts),
 		zap.Int("status_code", params.StatusCodeOfFailure),
@@ -431,12 +442,19 @@ func handlePostRequestTasks(params PostRequestTaskParams) {
 		}
 	}
 
+	// Get provider name for metrics
+	providerName := "unknown"
+	if v, ok := params.NetworkObj.Providers[params.Provider]; ok {
+		providerName = v.Name
+	}
+
 	// Record Prometheus metrics for the request.
 	// This includes details like network, provider, response status, health status, priority, and duration.
 	params.DinMiddleware.PrometheusClient.HandleRequestMetrics(&prom.PromRequestMetricData{
 		Method:         requestMethod,
 		Network:        params.NetworkPath,
 		Provider:       params.Provider,
+		ProviderName:   providerName,
 		ApiKey:         getRequestAPIKey(params.Replacer),
 		HostName:       params.OriginalReq.Host,
 		ResponseStatus: effectiveStatusCode,
@@ -639,11 +657,18 @@ func handleContextCancellation(l *logger.LoggerClient, promClient *prom.Promethe
 			}
 		}
 
+		// Get provider name for metrics
+		providerName := "unknown"
+		if v, ok := networkObj.Providers[provider]; ok {
+			providerName = v.Name
+		}
+
 		// Record metrics for the context cancellation
 		promClient.HandleRequestMetrics(&prom.PromRequestMetricData{
 			Method:         "unknown", // Generic - no network-specific parsing
 			Network:        networkPath,
 			Provider:       provider,
+			ProviderName:   providerName,
 			ApiKey:         getRequestAPIKey(repl),
 			HostName:       r.Host,
 			ResponseStatus: statusCode,

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
 	"go.uber.org/zap"
+	"golang.org/x/net/publicsuffix"
 
 	dinHttp "github.com/DIN-center/din-caddy-plugins/lib/http"
 	"github.com/DIN-center/din-caddy-plugins/lib/logger"
@@ -647,7 +649,25 @@ func handleContextCancellation(l *logger.LoggerClient, promClient *prom.Promethe
 			ResponseStatus: statusCode,
 			HealthStatus:   "unhealthy", // Context cancellation indicates unhealthy state
 			Priority:       priority,
-			Environment:    "unknown",   // We don't have access to environment here
+			Environment:    "unknown", // We don't have access to environment here
 		}, duration, nil) // No parsed request body - completely generic
 	}
+}
+
+// SafeExtractMainDomainWithPSL extracts the main domain from the URL using the Public Suffix List
+// if this fails, return the hostname
+func safeExtractMainDomainWithPSL(url *url.URL) string {
+	// Get the eTLD+1 (effective TLD plus one label)
+	domain, err := publicsuffix.EffectiveTLDPlusOne(url.Hostname())
+	if err != nil {
+		return url.Hostname()
+	}
+
+	// Split and get the main part (before the TLD)
+	parts := strings.Split(domain, ".")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+
+	return domain
 }

--- a/modules/network.go
+++ b/modules/network.go
@@ -208,6 +208,7 @@ func (n *network) healthCheck() {
 			n.logProviderWarning("Health check failed after all attempts for provider", provider,
 				zap.Int64("block_number", latestBlockResult.blockNumber),
 				zap.String("provider", provider.host),
+				zap.String("providerName", provider.Name),
 				zap.Int("response_status", latestBlockResult.responseStatus),
 				zap.String("health_status", latestBlockResult.healthStatus.String()),
 				zap.Int("total_attempts", n.RequestAttemptCount),
@@ -290,6 +291,7 @@ func (n *network) handleErrorWithGracePeriod(provider *provider, healthStatus He
 func (n *network) logProviderWarning(msg string, provider *provider, fields ...zap.Field) {
 	baseFields := []zap.Field{
 		zap.String("provider", provider.host),
+		zap.String("providerName", provider.Name),
 		zap.String("network", n.Name),
 		zap.Int("priority", provider.Priority),
 	}

--- a/modules/network.go
+++ b/modules/network.go
@@ -219,7 +219,7 @@ func (n *network) healthCheck() {
 			if healthStatus == Unhealthy {
 				// Add the block entry and send metric
 				provider.AddBlockEntry(latestBlockResult.blockNumber, Unhealthy, n.ProviderBlockHistorySize)
-				n.sendHealthCheckMetric(provider.host, latestBlockResult.responseStatus, latestBlockResult.healthStatus.String(), latestBlockResult.blockNumber, provider.Priority, string(n.Environment))
+				n.sendHealthCheckMetric(provider.host, provider.Name, latestBlockResult.responseStatus, latestBlockResult.healthStatus.String(), latestBlockResult.blockNumber, provider.Priority, string(n.Environment))
 
 				continue // Skip further checks for confirmed unhealthy providers
 			}
@@ -229,7 +229,7 @@ func (n *network) healthCheck() {
 
 		// Update metrics and history
 		provider.AddBlockEntry(latestBlockResult.blockNumber, newStatus, n.ProviderBlockHistorySize)
-		n.sendHealthCheckMetric(provider.host, latestBlockResult.responseStatus, newStatus.String(), latestBlockResult.blockNumber, provider.Priority, string(n.Environment))
+		n.sendHealthCheckMetric(provider.host, provider.Name, latestBlockResult.responseStatus, newStatus.String(), latestBlockResult.blockNumber, provider.Priority, string(n.Environment))
 	}
 }
 
@@ -516,10 +516,11 @@ func (n *network) getLatestHealthyBlock() int64 {
 	return latestBlockFromWarning
 }
 
-func (n *network) sendHealthCheckMetric(providerName string, responseStatus int, healthStatus string, blockNumber int64, priority int, environment string) {
+func (n *network) sendHealthCheckMetric(provider string, providerName string, responseStatus int, healthStatus string, blockNumber int64, priority int, environment string) {
 	n.PrometheusClient.HandleHealthCheckMetric(&prom.PromHealthCheckMetricData{
 		Network:        n.Name,
-		Provider:       providerName,
+		Provider:       provider,
+		ProviderName:   providerName,
 		ResponseStatus: responseStatus,
 		HealthStatus:   healthStatus,
 		BlockNumber:    blockNumber,

--- a/modules/network_loopback_test.go
+++ b/modules/network_loopback_test.go
@@ -188,6 +188,7 @@ func TestSendHealthCheckMetric(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		provider       string
 		providerName   string
 		responseStatus int
 		healthStatus   string
@@ -198,7 +199,8 @@ func TestSendHealthCheckMetric(t *testing.T) {
 	}{
 		{
 			name:           "send_healthy_metric",
-			providerName:   "provider1.com",
+			provider:       "provider1.com",
+			providerName:   "provider1",
 			responseStatus: 200,
 			healthStatus:   "Healthy",
 			blockNumber:    12345,
@@ -207,6 +209,7 @@ func TestSendHealthCheckMetric(t *testing.T) {
 			expectedMetric: &prom.PromHealthCheckMetricData{
 				Network:        "test-network",
 				Provider:       "provider1.com",
+				ProviderName:   "provider1",
 				ResponseStatus: 200,
 				HealthStatus:   "Healthy",
 				BlockNumber:    12345,
@@ -216,7 +219,8 @@ func TestSendHealthCheckMetric(t *testing.T) {
 		},
 		{
 			name:           "send_warning_metric",
-			providerName:   "provider2.com",
+			provider:       "provider2.com",
+			providerName:   "provider2",
 			responseStatus: 200,
 			healthStatus:   "Warning",
 			blockNumber:    12340,
@@ -225,6 +229,7 @@ func TestSendHealthCheckMetric(t *testing.T) {
 			expectedMetric: &prom.PromHealthCheckMetricData{
 				Network:        "test-network",
 				Provider:       "provider2.com",
+				ProviderName:   "provider2",
 				ResponseStatus: 200,
 				HealthStatus:   "Warning",
 				BlockNumber:    12340,
@@ -234,7 +239,8 @@ func TestSendHealthCheckMetric(t *testing.T) {
 		},
 		{
 			name:           "send_unhealthy_metric",
-			providerName:   "provider3.com",
+			provider:       "provider3.com",
+			providerName:   "provider3",
 			responseStatus: 500,
 			healthStatus:   "Unhealthy",
 			blockNumber:    0,
@@ -243,6 +249,7 @@ func TestSendHealthCheckMetric(t *testing.T) {
 			expectedMetric: &prom.PromHealthCheckMetricData{
 				Network:        "test-network",
 				Provider:       "provider3.com",
+				ProviderName:   "provider3",
 				ResponseStatus: 500,
 				HealthStatus:   "Unhealthy",
 				BlockNumber:    0,
@@ -252,7 +259,8 @@ func TestSendHealthCheckMetric(t *testing.T) {
 		},
 		{
 			name:           "send_rate_limit_metric",
-			providerName:   "provider4.com",
+			provider:       "provider4.com",
+			providerName:   "provider4",
 			responseStatus: 429,
 			healthStatus:   "Warning",
 			blockNumber:    12345,
@@ -261,6 +269,7 @@ func TestSendHealthCheckMetric(t *testing.T) {
 			expectedMetric: &prom.PromHealthCheckMetricData{
 				Network:        "test-network",
 				Provider:       "provider4.com",
+				ProviderName:   "provider4",
 				ResponseStatus: 429,
 				HealthStatus:   "Warning",
 				BlockNumber:    12345,
@@ -294,7 +303,7 @@ func TestSendHealthCheckMetric(t *testing.T) {
 			})
 
 			// Execute
-			n.sendHealthCheckMetric(tt.providerName, tt.responseStatus, tt.healthStatus, tt.blockNumber, tt.priority, tt.environment)
+			n.sendHealthCheckMetric(tt.provider, tt.providerName, tt.responseStatus, tt.healthStatus, tt.blockNumber, tt.priority, tt.environment)
 		})
 	}
 }

--- a/modules/provider.go
+++ b/modules/provider.go
@@ -24,6 +24,7 @@ type provider struct {
 	upstream *reverseproxy.Upstream
 	logger   *logger.LoggerClient
 	Priority int
+	Name     string
 
 	// Registry Configuration Values
 	Methods map[string]struct{}  `json:"methods"`
@@ -69,6 +70,7 @@ func NewProvider(urlStr string) (*provider, error) {
 	p := &provider{
 		HttpUrl:      urlStr,
 		host:         url.Host,
+		Name:         safeExtractMainDomainWithPSL(url),
 		Headers:      make(map[string]string),
 		blockHistory: list.New(),
 	}

--- a/modules/provider_test.go
+++ b/modules/provider_test.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"container/list"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -579,6 +580,64 @@ func TestProviderBlockHistory(t *testing.T) {
 						t.Errorf("BlockHistory()[%d].timestamp is not a deep copy, got same pointer", i)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestSafeExtractMainDomainWithPSL(t *testing.T) {
+	tests := []struct {
+		name         string
+		urlStr       string
+		expectedName string
+	}{
+		{
+			name:         "valid url",
+			urlStr:       "https://example.com",
+			expectedName: "example",
+		},
+		{
+			name:         "valid url with port",
+			urlStr:       "https://example.com:8545",
+			expectedName: "example",
+		},
+		{
+			name:         "valid url with path",
+			urlStr:       "https://example.com/path",
+			expectedName: "example",
+		},
+		{
+			name:         "valid url with query params",
+			urlStr:       "https://example.com/path?query=value",
+			expectedName: "example",
+		},
+		{
+			name:         "valid url with two level domain",
+			urlStr:       "https://example.com.au",
+			expectedName: "example",
+		},
+		{
+			name:         "valid url multple subdomains and two level domain",
+			urlStr:       "https://subdomain.buying-spree.example.com.au",
+			expectedName: "example",
+		},
+		{
+			name:         "valid url with suffix",
+			urlStr:       "https://invalid.domain.io-XHG",
+			expectedName: "domain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, err := url.Parse(tt.urlStr)
+			if err != nil {
+				t.Errorf("failed to parse url: %v", err)
+			}
+
+			name := safeExtractMainDomainWithPSL(url)
+			if name != tt.expectedName {
+				t.Errorf("expected name %q, but got %q", tt.expectedName, name)
 			}
 		})
 	}


### PR DESCRIPTION
This PR introduces the ability to send more human-readable provider names to metrics and logs. This allows easier log exploration and automation based on provider names (instead of provider hostnames).  

A custom provider name can be added directly in the Caddyfile config (optional):  
```  
eth {  
  providers {  
    https://din.rivet.cloud/eth {  
      auth {  
        type siwe  
        url https://din.rivet.cloud/auth  
      }  
      name RivetByOpenRelay  
    }  
  }  
  chain_id eip155:0x1  
}  
```  

If no custom name is provided, the default name is derived from the effective top-level domain, for example:  
- `testnet.opbnb.validationcloud.io` => `validationcloud`  
- `subdomain.gateway.co.uk` => `gateway`  

**Minor adjustments included in this PR:**  
- Fixed the Makefile for Docker build image (previously not aligned with `docker-compose.yml` and error-prone).