### PR TITLE
Remove priority label from request metrics to reduce cardinality

### DIFF
--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -61,7 +61,7 @@ func RegisterMetrics() {
 			Name: DinRequestCountMetricName,
 			Help: "Metric for counting the number of requests to the din http server",
 		},
-		[]string{"service", "method", "provider", "provider_name", "api_key", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "method", "provider", "provider_name", "api_key", "host_name", "response_status", "health_status", "machine_id", "environment"},
 	)
 	DinRequestDurationMilliseconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -73,7 +73,7 @@ func RegisterMetrics() {
 				7000, 10000, 20000, 30000, 40000, 50000,
 				60000, 70000, 80000, 90000, 100000}, //
 		},
-		[]string{"service", "method", "provider", "provider_name", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "method", "provider", "provider_name", "host_name", "response_status", "health_status", "machine_id", "environment"},
 	)
 
 	DinRequestBodyBytes = prometheus.NewHistogramVec(
@@ -82,7 +82,7 @@ func RegisterMetrics() {
 			Help:    "Metric for measuring the size of the request body in bytes",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"service", "method", "provider", "provider_name", "host_name", "response_status", "health_status", "priority", "machine_id", "environment"},
+		[]string{"service", "method", "provider", "provider_name", "host_name", "response_status", "health_status", "machine_id", "environment"},
 	)
 
 	// Register health check count metric for din health checks
@@ -99,7 +99,7 @@ func RegisterMetrics() {
 			Name: DinHealthCheckBlockNumberMetricName,
 			Help: "Metric for storing the block number of the latest health check",
 		},
-		[]string{"service", "provider", "provider_name", "priority", "machine_id", "environment"},
+		[]string{"service", "provider", "provider_name", "machine_id", "environment"},
 	)
 
 	prometheus.MustRegister(DinRequestCount, DinProviderHealthCheckCount, DinRequestDurationMilliseconds, DinRequestBodyBytes, DinProviderHealthCheckBlockNumber)
@@ -148,17 +148,16 @@ func (p *PrometheusClient) HandleRequestMetrics(data *PromRequestMetricData, dur
 	method := data.Method
 	network := strings.TrimPrefix(data.Network, "/")
 	status := strconv.Itoa(data.ResponseStatus)
-	priority := strconv.Itoa(data.Priority)
 
 	durationMS := duration.Milliseconds()
 
 	p.logger.Debug("Request metric data", zap.String("network", network), zap.String("method", method), zap.String("provider", data.Provider), zap.String("provider_name", data.ProviderName), zap.String("host_name", data.HostName), zap.String("response_status", status), zap.String("health_status", data.HealthStatus), zap.Int("priority", data.Priority), zap.Int64("duration_milliseconds", durationMS), zap.String("environment", data.Environment))
 
 	// Increment prometheus counter metric based on request data
-	DinRequestCount.WithLabelValues(network, method, data.Provider, data.ProviderName, data.ApiKey, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Inc()
+	DinRequestCount.WithLabelValues(network, method, data.Provider, data.ProviderName, data.ApiKey, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Inc()
 
 	// Observe prometheus histogram based on request duration and data
-	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.ProviderName, data.HostName, status, data.HealthStatus, priority, p.machineID, data.Environment).Observe(float64(durationMS))
+	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.ProviderName, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Observe(float64(durationMS))
 }
 
 type PromHealthCheckMetricData struct {
@@ -182,7 +181,7 @@ func (p *PrometheusClient) HandleHealthCheckMetric(data *PromHealthCheckMetricDa
 	DinProviderHealthCheckCount.WithLabelValues(network, data.Provider, data.ProviderName, strconv.Itoa(data.ResponseStatus), data.HealthStatus, priority, p.machineID, data.Environment).Inc()
 
 	// Update prometheus metric based on block number
-	DinProviderHealthCheckBlockNumber.WithLabelValues(network, data.Provider, data.ProviderName, priority, p.machineID, data.Environment).Set(float64(data.BlockNumber))
+	DinProviderHealthCheckBlockNumber.WithLabelValues(network, data.Provider, data.ProviderName, p.machineID, data.Environment).Set(float64(data.BlockNumber))
 }
 
 // PromNetworkHealthCheckMetricData holds data for network level health check metrics


### PR DESCRIPTION
## Summary
Remove the `priority` label from request-level metrics to reduce metric cardinality in SigNoz. The `priority` label is now only retained for `DinProviderHealthCheckCount` where it provides value for health check monitoring.

## Changes
- **Removed `priority` label from:**
  - `DinRequestCount`
  - `DinRequestDurationMilliseconds`
  - `DinRequestBodyBytes`
  - `DinProviderHealthCheckBlockNumber`

- **Retained `priority` label for:**
  - `DinProviderHealthCheckCount`

- **Updated `HandleRequestMetrics` function** to match new label structure
- **Updated `HandleHealthCheckMetric` function** for `DinProviderHealthCheckBlockNumber`

## Impact
This reduces the cardinality of request metrics in SigNoz by removing the priority dimension from request-level metrics, which are high-volume. Priority is still tracked for health checks where it provides monitoring value at the provider level.
