### PR TITLE
Reduce Prometheus Histogram Metrics Collection via Sampling

### DIFF
--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -156,8 +157,10 @@ func (p *PrometheusClient) HandleRequestMetrics(data *PromRequestMetricData, dur
 	// Increment prometheus counter metric based on request data
 	DinRequestCount.WithLabelValues(network, method, data.Provider, data.ProviderName, data.ApiKey, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Inc()
 
-	// Observe prometheus histogram based on request duration and data
-	DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.ProviderName, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Observe(float64(durationMS))
+	// Sample 25% of requests for histogram metrics to reduce costs (histograms are expensive)
+	if rand.Intn(4) == 0 {
+		DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.ProviderName, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Observe(float64(durationMS))
+	}
 }
 
 type PromHealthCheckMetricData struct {
@@ -207,5 +210,9 @@ func (p *PrometheusClient) HandleNetworkHealthCheckMetric(data *PromNetworkHealt
 	)
 
 	DinNetworkHealthCheckCount.WithLabelValues(network, status, p.machineID, data.Environment).Inc()
-	DinNetworkRequestHealthCheckDurationMilliseconds.WithLabelValues(network, status, p.machineID, data.Environment).Observe(float64(durationMS))
+
+	// Sample 50% of health checks for histogram metrics to reduce costs
+	if rand.Intn(2) == 0 {
+		DinNetworkRequestHealthCheckDurationMilliseconds.WithLabelValues(network, status, p.machineID, data.Environment).Observe(float64(durationMS))
+	}
 }

--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -26,15 +25,19 @@ const (
 
 // PrometheusClient is a struct that holds the prometheus client
 type PrometheusClient struct {
-	logger    *logger.LoggerClient
-	machineID string
+	logger             *logger.LoggerClient
+	machineID          string
+	requestSampler     *HybridSampler
+	healthCheckSampler *HybridSampler
 }
 
 // NewPrometheusClient returns a new prometheus client
 func NewPrometheusClient(logger *logger.LoggerClient, machineId string) *PrometheusClient {
 	return &PrometheusClient{
-		logger:    logger,
-		machineID: machineId,
+		logger:             logger,
+		machineID:          machineId,
+		requestSampler:     NewHybridSampler(0.25, 1.0), // 25% for normal requests, 100% for errors
+		healthCheckSampler: NewHybridSampler(0.5, 1.0),  // 50% for normal health checks, 100% for errors
 	}
 }
 
@@ -154,11 +157,12 @@ func (p *PrometheusClient) HandleRequestMetrics(data *PromRequestMetricData, dur
 
 	p.logger.Debug("Request metric data", zap.String("network", network), zap.String("method", method), zap.String("provider", data.Provider), zap.String("provider_name", data.ProviderName), zap.String("host_name", data.HostName), zap.String("response_status", status), zap.String("health_status", data.HealthStatus), zap.Int("priority", data.Priority), zap.Int64("duration_milliseconds", durationMS), zap.String("environment", data.Environment))
 
-	// Increment prometheus counter metric based on request data
+	// Increment prometheus counter metric based on request data (always record - counters are cheap)
 	DinRequestCount.WithLabelValues(network, method, data.Provider, data.ProviderName, data.ApiKey, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Inc()
 
-	// Sample 25% of requests for histogram metrics to reduce costs (histograms are expensive)
-	if rand.Intn(4) == 0 {
+	// Use hybrid sampling for expensive histogram metrics to reduce costs while ensuring fair distribution
+	// Samples 25% of normal requests, 100% of errors for better observability
+	if p.requestSampler.ShouldSampleRequest(data.ResponseStatus, data.HealthStatus, network, method, data.Provider, data.ProviderName, data.HostName, status, data.HealthStatus, p.machineID, data.Environment) {
 		DinRequestDurationMilliseconds.WithLabelValues(network, method, data.Provider, data.ProviderName, data.HostName, status, data.HealthStatus, p.machineID, data.Environment).Observe(float64(durationMS))
 	}
 }
@@ -209,10 +213,12 @@ func (p *PrometheusClient) HandleNetworkHealthCheckMetric(data *PromNetworkHealt
 		zap.String("environment", data.Environment),
 	)
 
+	// Increment counter metric (always record - counters are cheap)
 	DinNetworkHealthCheckCount.WithLabelValues(network, status, p.machineID, data.Environment).Inc()
 
-	// Sample 50% of health checks for histogram metrics to reduce costs
-	if rand.Intn(2) == 0 {
+	// Use hybrid sampling for expensive histogram metrics to reduce costs while ensuring fair distribution
+	// Samples 50% of normal health checks, 100% of errors for better observability
+	if p.healthCheckSampler.ShouldSampleHealthCheck(data.ResponseStatus, network, status, p.machineID, data.Environment) {
 		DinNetworkRequestHealthCheckDurationMilliseconds.WithLabelValues(network, status, p.machineID, data.Environment).Observe(float64(durationMS))
 	}
 }

--- a/lib/prometheus/sampler.go
+++ b/lib/prometheus/sampler.go
@@ -1,0 +1,81 @@
+package prometheus
+
+import (
+	"hash/fnv"
+)
+
+// HybridSampler combines hash-based deterministic sampling with error boosting
+// to ensure fair sampling across all label combinations while prioritizing errors.
+type HybridSampler struct {
+	baseRate  float64 // Base sampling rate for normal requests
+	errorRate float64 // Higher sampling rate for errors
+}
+
+// NewHybridSampler creates a new hybrid sampler with specified rates.
+// baseRate: sampling rate for normal requests (e.g., 0.25 for 25%)
+// errorRate: sampling rate for errors (e.g., 1.0 for 100%)
+func NewHybridSampler(baseRate, errorRate float64) *HybridSampler {
+	return &HybridSampler{
+		baseRate:  baseRate,
+		errorRate: errorRate,
+	}
+}
+
+// ShouldSample determines if a metric should be sampled based on deterministic hashing.
+// This ensures the same label combination always gets the same sampling decision.
+//
+// isError: whether this is an error condition that should be sampled at higher rate
+// labels: the label values that identify this metric series
+func (hs *HybridSampler) ShouldSample(isError bool, labels ...string) bool {
+	// Select appropriate sampling rate
+	rate := hs.baseRate
+	if isError {
+		rate = hs.errorRate
+	}
+
+	// Always sample if rate is 1.0 or higher
+	if rate >= 1.0 {
+		return true
+	}
+
+	// Never sample if rate is 0 or negative
+	if rate <= 0 {
+		return false
+	}
+
+	// Hash all label values to get a deterministic value
+	h := fnv.New64a()
+	for _, label := range labels {
+		h.Write([]byte(label))
+		// Add separator to prevent collisions between adjacent labels
+		h.Write([]byte("|"))
+	}
+
+	hashValue := h.Sum64()
+
+	// Convert rate to threshold value
+	// We use the full uint64 range for maximum precision
+	threshold := uint64(float64(^uint64(0)) * rate)
+
+	// Deterministic decision based on hash
+	return hashValue < threshold
+}
+
+// ShouldSampleRequest determines if a request metric should be sampled.
+// It checks for error conditions based on HTTP status and health status.
+func (hs *HybridSampler) ShouldSampleRequest(responseStatus int, healthStatus string, labels ...string) bool {
+	// Consider it an error if:
+	// - HTTP status is 4xx or 5xx
+	// - Health status is not "Healthy" (capitalized, from HealthStatus.String())
+	// Note: healthStatus comes from the enum's String() method which returns "Healthy", "Warning", or "Unhealthy"
+	isError := responseStatus >= 400 || (healthStatus != "Healthy" && healthStatus != "")
+	return hs.ShouldSample(isError, labels...)
+}
+
+// ShouldSampleHealthCheck determines if a health check metric should be sampled.
+// It checks for error conditions based on HTTP status.
+func (hs *HybridSampler) ShouldSampleHealthCheck(responseStatus int, labels ...string) bool {
+	// Consider it an error if HTTP status is 4xx or 5xx
+	isError := responseStatus >= 400
+	return hs.ShouldSample(isError, labels...)
+}

--- a/lib/prometheus/sampler.go
+++ b/lib/prometheus/sampler.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"fmt"
 	"hash/fnv"
+	"math"
 	"time"
 )
 
@@ -16,7 +17,22 @@ type HybridSampler struct {
 // NewHybridSampler creates a new hybrid sampler with specified rates.
 // baseRate: sampling rate for normal requests (e.g., 0.25 for 25%)
 // errorRate: sampling rate for errors (e.g., 1.0 for 100%)
+// Both rates must be within [0.0, 1.0]. Values outside this range will be clamped.
 func NewHybridSampler(baseRate, errorRate float64) *HybridSampler {
+	// Enforce rate boundaries [0.0, 1.0]
+	// Rates < 0.0 or > 1.0 have no valid meaning
+	if baseRate < 0.0 {
+		baseRate = 0.0
+	} else if baseRate > 1.0 {
+		baseRate = 1.0
+	}
+
+	if errorRate < 0.0 {
+		errorRate = 0.0
+	} else if errorRate > 1.0 {
+		errorRate = 1.0
+	}
+
 	return &HybridSampler{
 		baseRate:  baseRate,
 		errorRate: errorRate,
@@ -36,12 +52,14 @@ func (hs *HybridSampler) ShouldSample(isError bool, labels ...string) bool {
 		rate = hs.errorRate
 	}
 
-	// Always sample if rate is 1.0 or higher
+	// Always sample if rate is 1.0 (100% sampling)
+	// Since we enforce boundaries in the constructor, rate will never exceed 1.0
 	if rate >= 1.0 {
 		return true
 	}
 
-	// Never sample if rate is 0 or negative
+	// Never sample if rate is 0 (0% sampling)
+	// Since we enforce boundaries in the constructor, rate will never be negative
 	if rate <= 0 {
 		return false
 	}
@@ -62,7 +80,8 @@ func (hs *HybridSampler) ShouldSample(isError bool, labels ...string) bool {
 	hashValue := h.Sum64()
 
 	// Convert rate to threshold value
-	threshold := uint64(float64(^uint64(0)) * rate)
+	// We use the full uint64 range for maximum precision
+	threshold := uint64(float64(math.MaxUint64) * rate)
 
 	// Decision based on hash that includes timestamp
 	return hashValue < threshold

--- a/lib/prometheus/sampler.go
+++ b/lib/prometheus/sampler.go
@@ -1,7 +1,9 @@
 package prometheus
 
 import (
+	"fmt"
 	"hash/fnv"
+	"time"
 )
 
 // HybridSampler combines hash-based deterministic sampling with error boosting
@@ -21,8 +23,9 @@ func NewHybridSampler(baseRate, errorRate float64) *HybridSampler {
 	}
 }
 
-// ShouldSample determines if a metric should be sampled based on deterministic hashing.
-// This ensures the same label combination always gets the same sampling decision.
+// ShouldSample determines if a metric should be sampled.
+// Now includes per-request uniqueness to ensure sampling happens WITHIN label groups,
+// not all-or-nothing per group.
 //
 // isError: whether this is an error condition that should be sampled at higher rate
 // labels: the label values that identify this metric series
@@ -43,21 +46,25 @@ func (hs *HybridSampler) ShouldSample(isError bool, labels ...string) bool {
 		return false
 	}
 
-	// Hash all label values to get a deterministic value
+	// Hash labels AND current timestamp to ensure each request gets its own decision
 	h := fnv.New64a()
 	for _, label := range labels {
 		h.Write([]byte(label))
-		// Add separator to prevent collisions between adjacent labels
 		h.Write([]byte("|"))
 	}
+
+	// Add nanosecond timestamp to make each request unique
+	// This ensures we sample 25% of requests within each label group,
+	// not 0% or 100% for the entire group
+	timestamp := time.Now().UnixNano()
+	h.Write([]byte(fmt.Sprintf("%d", timestamp)))
 
 	hashValue := h.Sum64()
 
 	// Convert rate to threshold value
-	// We use the full uint64 range for maximum precision
 	threshold := uint64(float64(^uint64(0)) * rate)
 
-	// Deterministic decision based on hash
+	// Decision based on hash that includes timestamp
 	return hashValue < threshold
 }
 

--- a/lib/prometheus/sampler_test.go
+++ b/lib/prometheus/sampler_test.go
@@ -365,17 +365,17 @@ func TestEdgeCaseSamplingRates(t *testing.T) {
 		expectNever   bool // true if should never sample
 	}{
 		{
-			name:         "negative base rate",
+			name:         "negative base rate (clamped to 0.0)",
 			baseRate:     -0.1,
 			errorRate:    1.0,
-			expectNever:  true, // negative rate should never sample
+			expectNever:  true, // negative rate is clamped to 0.0, should never sample
 			expectAlways: false,
 		},
 		{
-			name:         "rate above 1.0",
+			name:         "rate above 1.0 (clamped to 1.0)",
 			baseRate:     1.5,
 			errorRate:    2.0,
-			expectAlways: true, // rates >= 1.0 should always sample
+			expectAlways: true, // rates > 1.0 are clamped to 1.0, should always sample
 			expectNever:  false,
 		},
 		{
@@ -425,11 +425,104 @@ func TestEdgeCaseSamplingRates(t *testing.T) {
 				}
 			}
 
-			if tc.errorRate >= 1.0 {
-				assert.Equal(t, iterations, errorCount, "Error sampling should always occur when error rate >= 1.0")
+			// Since we clamp rates, check against clamped values
+			clampedErrorRate := tc.errorRate
+			if clampedErrorRate < 0.0 {
+				clampedErrorRate = 0.0
+			} else if clampedErrorRate > 1.0 {
+				clampedErrorRate = 1.0
 			}
-			if tc.errorRate <= 0 {
-				assert.Equal(t, 0, errorCount, "Error sampling should never occur when error rate <= 0")
+
+			if clampedErrorRate >= 1.0 {
+				assert.Equal(t, iterations, errorCount, "Error sampling should always occur when clamped error rate = 1.0")
+			}
+			if clampedErrorRate <= 0 {
+				assert.Equal(t, 0, errorCount, "Error sampling should never occur when clamped error rate = 0")
+			}
+		})
+	}
+}
+
+// TestRateBoundaryClamping verifies that rates are properly clamped to [0.0, 1.0]
+func TestRateBoundaryClamping(t *testing.T) {
+	testCases := []struct {
+		name             string
+		inputBaseRate    float64
+		inputErrorRate   float64
+		expectedBaseBehavior  string // "always", "never", or "probabilistic"
+		expectedErrorBehavior string // "always", "never", or "probabilistic"
+	}{
+		{
+			name:             "negative rates clamped to 0",
+			inputBaseRate:    -0.5,
+			inputErrorRate:   -1.0,
+			expectedBaseBehavior:  "never",
+			expectedErrorBehavior: "never",
+		},
+		{
+			name:             "rates > 1.0 clamped to 1.0",
+			inputBaseRate:    1.5,
+			inputErrorRate:   10.0,
+			expectedBaseBehavior:  "always",
+			expectedErrorBehavior: "always",
+		},
+		{
+			name:             "valid rates unchanged",
+			inputBaseRate:    0.25,
+			inputErrorRate:   0.75,
+			expectedBaseBehavior:  "probabilistic",
+			expectedErrorBehavior: "probabilistic",
+		},
+		{
+			name:             "boundary values unchanged",
+			inputBaseRate:    0.0,
+			inputErrorRate:   1.0,
+			expectedBaseBehavior:  "never",
+			expectedErrorBehavior: "always",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sampler := NewHybridSampler(tc.inputBaseRate, tc.inputErrorRate)
+			iterations := 100
+
+			// Test base rate behavior
+			baseCount := 0
+			for i := 0; i < iterations; i++ {
+				labels := []string{"test", fmt.Sprintf("iter-%d", i)}
+				if sampler.ShouldSample(false, labels...) {
+					baseCount++
+				}
+			}
+
+			switch tc.expectedBaseBehavior {
+			case "always":
+				assert.Equal(t, iterations, baseCount, "Base rate clamped to 1.0 should always sample")
+			case "never":
+				assert.Equal(t, 0, baseCount, "Base rate clamped to 0.0 should never sample")
+			case "probabilistic":
+				assert.Greater(t, baseCount, 0, "Probabilistic base rate should sample some requests")
+				assert.Less(t, baseCount, iterations, "Probabilistic base rate should not sample all requests")
+			}
+
+			// Test error rate behavior
+			errorCount := 0
+			for i := 0; i < iterations; i++ {
+				labels := []string{"test", fmt.Sprintf("iter-%d", i)}
+				if sampler.ShouldSample(true, labels...) {
+					errorCount++
+				}
+			}
+
+			switch tc.expectedErrorBehavior {
+			case "always":
+				assert.Equal(t, iterations, errorCount, "Error rate clamped to 1.0 should always sample")
+			case "never":
+				assert.Equal(t, 0, errorCount, "Error rate clamped to 0.0 should never sample")
+			case "probabilistic":
+				assert.Greater(t, errorCount, 0, "Probabilistic error rate should sample some requests")
+				assert.Less(t, errorCount, iterations, "Probabilistic error rate should not sample all requests")
 			}
 		})
 	}

--- a/lib/prometheus/sampler_test.go
+++ b/lib/prometheus/sampler_test.go
@@ -7,41 +7,59 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestHybridSamplerDeterministic verifies that the same labels always produce the same sampling decision
-func TestHybridSamplerDeterministic(t *testing.T) {
+// TestWithinGroupSampling verifies that we sample approximately 25% of requests within each label group
+func TestWithinGroupSampling(t *testing.T) {
 	sampler := NewHybridSampler(0.25, 1.0)
 
 	testCases := []struct {
-		name   string
-		labels []string
+		name       string
+		labels     []string
+		iterations int
 	}{
 		{
-			name:   "simple labels",
-			labels: []string{"ethereum", "eth_call", "infura", "200"},
+			name:       "simple labels",
+			labels:     []string{"ethereum", "eth_call", "infura", "200"},
+			iterations: 10000, // More iterations for better statistical accuracy
 		},
 		{
-			name:   "complex labels",
-			labels: []string{"polygon", "eth_getBalance", "alchemy", "provider1", "host1.example.com", "200", "healthy", "machine-123", "production"},
+			name:       "complex labels",
+			labels:     []string{"polygon", "eth_getBalance", "alchemy", "provider1", "host1.example.com", "200", "healthy", "machine-123", "production"},
+			iterations: 10000,
 		},
 		{
-			name:   "empty label",
-			labels: []string{"", "method", "provider"},
+			name:       "empty label",
+			labels:     []string{"", "method", "provider"},
+			iterations: 10000,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Run sampling decision multiple times with same labels
-			results := make([]bool, 100)
-			for i := 0; i < 100; i++ {
-				results[i] = sampler.ShouldSample(false, tc.labels...)
+			// Sample many times with the same labels
+			// Each call should get a different decision due to timestamp
+			sampledCount := 0
+
+			for i := 0; i < tc.iterations; i++ {
+				if sampler.ShouldSample(false, tc.labels...) {
+					sampledCount++
+				}
+				// No sleep needed - UnixNano() changes between calls
 			}
 
-			// All results should be the same
-			firstResult := results[0]
-			for i, result := range results {
-				assert.Equal(t, firstResult, result, "Iteration %d: sampling should be deterministic for labels %v", i, tc.labels)
-			}
+			// Should sample approximately 25% of requests
+			expectedRate := 0.25
+			actualRate := float64(sampledCount) / float64(tc.iterations)
+
+			// With 10000 iterations, we can use tighter tolerance
+			// Standard deviation for binomial distribution: sqrt(n * p * (1-p))
+			// For n=10000, p=0.25: stddev = sqrt(10000 * 0.25 * 0.75) = ~43.3
+			// 3 standard deviations = 130, so tolerance = 130/10000 = 0.013 (1.3%)
+			// We'll use 2% to be safe
+			tolerance := 0.02
+
+			assert.InDelta(t, expectedRate, actualRate, tolerance,
+				"Expected ~25%% sampling for labels %v, got %.2f%% (sampled %d/%d)",
+				tc.labels, actualRate*100, sampledCount, tc.iterations)
 		})
 	}
 }
@@ -50,27 +68,26 @@ func TestHybridSamplerDeterministic(t *testing.T) {
 func TestHybridSamplerErrorBoosting(t *testing.T) {
 	sampler := NewHybridSampler(0.25, 1.0) // 25% normal, 100% errors
 
-	// Test with different label combinations to ensure good distribution
+	// Test with the same labels to verify error boosting works
 	errorCount := 0
 	normalCount := 0
-	iterations := 10000
+	iterations := 1000
+	labels := []string{"ethereum", "eth_call", "provider", "200"}
 
 	for i := 0; i < iterations; i++ {
-		// Generate unique labels for each iteration
-		labels := []string{"ethereum", "eth_call", fmt.Sprintf("provider%d", i), fmt.Sprintf("%d", i)}
-
 		if sampler.ShouldSample(true, labels...) {
 			errorCount++
 		}
 		if sampler.ShouldSample(false, labels...) {
 			normalCount++
 		}
+		// No sleep needed - UnixNano() changes between calls
 	}
 
 	// Errors should be sampled at 100% rate
 	assert.Equal(t, iterations, errorCount, "All errors should be sampled when error rate is 1.0")
 
-	// Normal requests should be sampled at ~25% rate (with some tolerance for randomness)
+	// Normal requests should be sampled at ~25% rate
 	expectedNormal := float64(iterations) * 0.25
 	tolerance := float64(iterations) * 0.05 // 5% tolerance
 
@@ -333,6 +350,86 @@ func TestLabelCollisionResistance(t *testing.T) {
 					"Same labels should always produce same result")
 				assert.Equal(t, result2, sampler.ShouldSample(false, labels2...),
 					"Same labels should always produce same result")
+			}
+		})
+	}
+}
+
+// TestEdgeCaseSamplingRates verifies edge cases for sampling rates
+func TestEdgeCaseSamplingRates(t *testing.T) {
+	testCases := []struct {
+		name          string
+		baseRate      float64
+		errorRate     float64
+		expectAlways  bool // true if should always sample
+		expectNever   bool // true if should never sample
+	}{
+		{
+			name:         "negative base rate",
+			baseRate:     -0.1,
+			errorRate:    1.0,
+			expectNever:  true, // negative rate should never sample
+			expectAlways: false,
+		},
+		{
+			name:         "rate above 1.0",
+			baseRate:     1.5,
+			errorRate:    2.0,
+			expectAlways: true, // rates >= 1.0 should always sample
+			expectNever:  false,
+		},
+		{
+			name:         "exactly 0 rate",
+			baseRate:     0.0,
+			errorRate:    0.0,
+			expectNever:  true,
+			expectAlways: false,
+		},
+		{
+			name:         "exactly 1.0 rate",
+			baseRate:     1.0,
+			errorRate:    1.0,
+			expectAlways: true,
+			expectNever:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sampler := NewHybridSampler(tc.baseRate, tc.errorRate)
+			labels := []string{"test", "labels"}
+
+			// Test normal sampling
+			normalCount := 0
+			iterations := 100
+			for i := 0; i < iterations; i++ {
+				uniqueLabels := append(labels, fmt.Sprintf("iter-%d", i))
+				if sampler.ShouldSample(false, uniqueLabels...) {
+					normalCount++
+				}
+			}
+
+			if tc.expectAlways {
+				assert.Equal(t, iterations, normalCount, "Should always sample when rate >= 1.0")
+			}
+			if tc.expectNever {
+				assert.Equal(t, 0, normalCount, "Should never sample when rate <= 0")
+			}
+
+			// Test error sampling
+			errorCount := 0
+			for i := 0; i < iterations; i++ {
+				uniqueLabels := append(labels, fmt.Sprintf("iter-%d", i))
+				if sampler.ShouldSample(true, uniqueLabels...) {
+					errorCount++
+				}
+			}
+
+			if tc.errorRate >= 1.0 {
+				assert.Equal(t, iterations, errorCount, "Error sampling should always occur when error rate >= 1.0")
+			}
+			if tc.errorRate <= 0 {
+				assert.Equal(t, 0, errorCount, "Error sampling should never occur when error rate <= 0")
 			}
 		})
 	}

--- a/lib/prometheus/sampler_test.go
+++ b/lib/prometheus/sampler_test.go
@@ -1,0 +1,339 @@
+package prometheus
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHybridSamplerDeterministic verifies that the same labels always produce the same sampling decision
+func TestHybridSamplerDeterministic(t *testing.T) {
+	sampler := NewHybridSampler(0.25, 1.0)
+
+	testCases := []struct {
+		name   string
+		labels []string
+	}{
+		{
+			name:   "simple labels",
+			labels: []string{"ethereum", "eth_call", "infura", "200"},
+		},
+		{
+			name:   "complex labels",
+			labels: []string{"polygon", "eth_getBalance", "alchemy", "provider1", "host1.example.com", "200", "healthy", "machine-123", "production"},
+		},
+		{
+			name:   "empty label",
+			labels: []string{"", "method", "provider"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run sampling decision multiple times with same labels
+			results := make([]bool, 100)
+			for i := 0; i < 100; i++ {
+				results[i] = sampler.ShouldSample(false, tc.labels...)
+			}
+
+			// All results should be the same
+			firstResult := results[0]
+			for i, result := range results {
+				assert.Equal(t, firstResult, result, "Iteration %d: sampling should be deterministic for labels %v", i, tc.labels)
+			}
+		})
+	}
+}
+
+// TestHybridSamplerErrorBoosting verifies that errors are sampled at a higher rate
+func TestHybridSamplerErrorBoosting(t *testing.T) {
+	sampler := NewHybridSampler(0.25, 1.0) // 25% normal, 100% errors
+
+	// Test with different label combinations to ensure good distribution
+	errorCount := 0
+	normalCount := 0
+	iterations := 10000
+
+	for i := 0; i < iterations; i++ {
+		// Generate unique labels for each iteration
+		labels := []string{"ethereum", "eth_call", fmt.Sprintf("provider%d", i), fmt.Sprintf("%d", i)}
+
+		if sampler.ShouldSample(true, labels...) {
+			errorCount++
+		}
+		if sampler.ShouldSample(false, labels...) {
+			normalCount++
+		}
+	}
+
+	// Errors should be sampled at 100% rate
+	assert.Equal(t, iterations, errorCount, "All errors should be sampled when error rate is 1.0")
+
+	// Normal requests should be sampled at ~25% rate (with some tolerance for randomness)
+	expectedNormal := float64(iterations) * 0.25
+	tolerance := float64(iterations) * 0.05 // 5% tolerance
+
+	assert.InDelta(t, expectedNormal, normalCount, tolerance,
+		"Normal requests should be sampled at approximately 25%% rate, got %d/%d (%.2f%%)",
+		normalCount, iterations, float64(normalCount)/float64(iterations)*100)
+}
+
+// TestHybridSamplerRates verifies sampling with different rate configurations
+func TestHybridSamplerRates(t *testing.T) {
+	testCases := []struct {
+		name          string
+		baseRate      float64
+		errorRate     float64
+		expectedBase  float64
+		expectedError float64
+	}{
+		{
+			name:          "zero base rate",
+			baseRate:      0.0,
+			errorRate:     1.0,
+			expectedBase:  0.0,
+			expectedError: 1.0,
+		},
+		{
+			name:          "100% both rates",
+			baseRate:      1.0,
+			errorRate:     1.0,
+			expectedBase:  1.0,
+			expectedError: 1.0,
+		},
+		{
+			name:          "50% sampling",
+			baseRate:      0.5,
+			errorRate:     0.5,
+			expectedBase:  0.5,
+			expectedError: 0.5,
+		},
+		{
+			name:          "10% base, 90% error",
+			baseRate:      0.1,
+			errorRate:     0.9,
+			expectedBase:  0.1,
+			expectedError: 0.9,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sampler := NewHybridSampler(tc.baseRate, tc.errorRate)
+
+			normalCount := 0
+			errorCount := 0
+			iterations := 10000
+
+			for i := 0; i < iterations; i++ {
+				labels := []string{"test", fmt.Sprintf("%d", i)}
+
+				if sampler.ShouldSample(false, labels...) {
+					normalCount++
+				}
+				if sampler.ShouldSample(true, labels...) {
+					errorCount++
+				}
+			}
+
+			// Check if sampling rates are approximately correct
+			actualBase := float64(normalCount) / float64(iterations)
+			actualError := float64(errorCount) / float64(iterations)
+
+			tolerance := 0.05 // 5% tolerance
+			assert.InDelta(t, tc.expectedBase, actualBase, tolerance,
+				"Base rate mismatch: expected %.2f, got %.2f", tc.expectedBase, actualBase)
+			assert.InDelta(t, tc.expectedError, actualError, tolerance,
+				"Error rate mismatch: expected %.2f, got %.2f", tc.expectedError, actualError)
+		})
+	}
+}
+
+// TestShouldSampleRequest verifies request-specific sampling logic
+func TestShouldSampleRequest(t *testing.T) {
+	sampler := NewHybridSampler(0.25, 1.0)
+
+	testCases := []struct {
+		name           string
+		responseStatus int
+		healthStatus   string
+		expectError    bool
+		description    string
+	}{
+		{
+			name:           "success response",
+			responseStatus: 200,
+			healthStatus:   "Healthy",
+			expectError:    false,
+			description:    "200 OK with Healthy status should not be treated as error",
+		},
+		{
+			name:           "client error",
+			responseStatus: 404,
+			healthStatus:   "Healthy",
+			expectError:    true,
+			description:    "4xx errors should be sampled at error rate",
+		},
+		{
+			name:           "server error",
+			responseStatus: 500,
+			healthStatus:   "Healthy",
+			expectError:    true,
+			description:    "5xx errors should be sampled at error rate",
+		},
+		{
+			name:           "unhealthy status",
+			responseStatus: 200,
+			healthStatus:   "Unhealthy",
+			expectError:    true,
+			description:    "Unhealthy status should be sampled at error rate even with 200 status",
+		},
+		{
+			name:           "warning status",
+			responseStatus: 200,
+			healthStatus:   "Warning",
+			expectError:    true,
+			description:    "Warning status should be sampled at error rate",
+		},
+		{
+			name:           "empty health status",
+			responseStatus: 200,
+			healthStatus:   "",
+			expectError:    false,
+			description:    "Empty health status with 200 should not be treated as error",
+		},
+		{
+			name:           "rate limited",
+			responseStatus: 429,
+			healthStatus:   "Healthy",
+			expectError:    true,
+			description:    "429 rate limit should be sampled at error rate",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test multiple times to ensure consistent behavior
+			labels := []string{"test", tc.name, fmt.Sprintf("%d", tc.responseStatus)}
+
+			sampledCount := 0
+			iterations := 100
+
+			for i := 0; i < iterations; i++ {
+				uniqueLabels := append(labels, fmt.Sprintf("iter-%d", i))
+				if sampler.ShouldSampleRequest(tc.responseStatus, tc.healthStatus, uniqueLabels...) {
+					sampledCount++
+				}
+			}
+
+			if tc.expectError {
+				// Error cases should be sampled at 100%
+				assert.Equal(t, iterations, sampledCount, tc.description)
+			} else {
+				// Normal cases should be sampled at ~25%
+				assert.LessOrEqual(t, sampledCount, 40, tc.description+" - should sample ~25%")
+			}
+		})
+	}
+}
+
+// TestShouldSampleHealthCheck verifies health check-specific sampling logic
+func TestShouldSampleHealthCheck(t *testing.T) {
+	sampler := NewHybridSampler(0.5, 1.0) // 50% normal, 100% errors
+
+	testCases := []struct {
+		name           string
+		responseStatus int
+		expectError    bool
+	}{
+		{
+			name:           "healthy check",
+			responseStatus: 200,
+			expectError:    false,
+		},
+		{
+			name:           "client error check",
+			responseStatus: 400,
+			expectError:    true,
+		},
+		{
+			name:           "server error check",
+			responseStatus: 503,
+			expectError:    true,
+		},
+		{
+			name:           "redirect",
+			responseStatus: 302,
+			expectError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := []string{"network", "status", "machine", "env"}
+
+			sampledCount := 0
+			iterations := 100
+
+			for i := 0; i < iterations; i++ {
+				uniqueLabels := append(labels, fmt.Sprintf("iter-%d", i))
+				if sampler.ShouldSampleHealthCheck(tc.responseStatus, uniqueLabels...) {
+					sampledCount++
+				}
+			}
+
+			if tc.expectError {
+				// Error cases should be sampled at 100%
+				assert.Equal(t, iterations, sampledCount, "Error health checks should always be sampled")
+			} else {
+				// Normal cases should be sampled at ~50%
+				assert.InDelta(t, 50, sampledCount, 15, "Normal health checks should be sampled at ~50%")
+			}
+		})
+	}
+}
+
+// TestLabelCollisionResistance verifies that similar labels don't cause hash collisions
+func TestLabelCollisionResistance(t *testing.T) {
+	sampler := NewHybridSampler(0.5, 1.0)
+
+	// Test potential collision scenarios
+	collisionTests := []struct {
+		labels1 []string
+		labels2 []string
+	}{
+		{
+			labels1: []string{"ab", "cd"},
+			labels2: []string{"a", "bcd"},
+		},
+		{
+			labels1: []string{"foo", "bar"},
+			labels2: []string{"foobar", ""},
+		},
+		{
+			labels1: []string{"", "test", ""},
+			labels2: []string{"test", "", ""},
+		},
+	}
+
+	for i, test := range collisionTests {
+		t.Run(fmt.Sprintf("collision_test_%d", i), func(t *testing.T) {
+			// Add unique suffix to ensure different hash values
+			labels1 := append(test.labels1, "unique1")
+			labels2 := append(test.labels2, "unique2")
+
+			result1 := sampler.ShouldSample(false, labels1...)
+			result2 := sampler.ShouldSample(false, labels2...)
+
+			// We can't guarantee they'll be different, but we can verify
+			// that they produce consistent results
+			for j := 0; j < 10; j++ {
+				assert.Equal(t, result1, sampler.ShouldSample(false, labels1...),
+					"Same labels should always produce same result")
+				assert.Equal(t, result2, sampler.ShouldSample(false, labels2...),
+					"Same labels should always produce same result")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Fix Prometheus Histogram Sampling to Sample Within Cardinality Groups

### Problem
High Prometheus metrics bill due to expensive histogram metric collection with high cardinality. Previous approach made all-or-nothing decisions per label group - if `["bitcoin-mainnet", "liquify", "eth_call", "200"]` hashed above the 25% threshold, ALL requests with those labels were excluded, potentially missing entire endpoints.

#### Before (All-or-Nothing)
```
Labels: ["bitcoin-mainnet", "liquify", "eth_call", "200"]
Request 1: ❌ Not sampled (hash above threshold)
Request 2: ❌ Not sampled (same hash)
Request 3: ❌ Not sampled (same hash)
Request 4: ❌ Not sampled (same hash)
Result: 0% sampling - missing entire endpoint!
```

#### After (Within-Group Sampling)
```
Labels: ["bitcoin-mainnet", "liquify", "eth_call", "200"]
Request 1: ✅ Sampled (hash with timestamp1 below threshold)
Request 2: ❌ Not sampled (hash with timestamp2 above threshold)
Request 3: ❌ Not sampled (hash with timestamp3 above threshold)
Request 4: ✅ Sampled (hash with timestamp4 below threshold)
Result: 25% sampling - proper coverage!
```

### Solution
Implemented **timestamp-based hash sampling** that ensures proper sampling WITHIN each label group:

#### Sampling Strategy
- **Per-Request Uniqueness**: Hash combines labels + nanosecond timestamp
- **Within-Group Sampling**: Each request gets independent sampling decision (25% or 50% based on metric type)
- **Error Boosting**: 100% sampling for errors (HTTP 4xx/5xx, Warning/Unhealthy status)
- **Simple Implementation**: Just added timestamp to existing hash function
- **Stateless**: No memory or state management needed

#### Sampling Rates
- **`DinRequestDurationMilliseconds`**: 25% normal requests, 100% errors
- **`DinNetworkRequestHealthCheckDurationMilliseconds`**: 50% normal health checks, 100% errors

### Implementation Details

#### New Files
- `lib/prometheus/sampler.go`: HybridSampler with timestamp-based hash sampling for within-group sampling
- `lib/prometheus/sampler_test.go`: Tests for within-group sampling rates and error boosting

#### Modified Files
- `lib/prometheus/prometheus.go`:
  - Added `requestSampler` and `healthCheckSampler` to PrometheusClient
  - Replaced `rand.Intn()` with timestamp-based sampling
  - Uses `ShouldSampleRequest()` and `ShouldSampleHealthCheck()` for intelligent sampling
  - Properly handles HealthStatus enum values ("Healthy", "Warning", "Unhealthy")
  - Simplified timestamp handling using `fmt.Sprintf("%d", timestamp)` for better code clarity
  - Replaced complex byte operations with straightforward string formatting

### Technical Benefits
- **True Within-Group Sampling**: Each request gets independent decision, not all-or-nothing per group
- **Complete Coverage**: All label combinations get sampled over time
- **Error Capture**: 100% sampling of errors ensures no failures are missed
- **Simple & Fast**: Just added timestamp to hash - minimal code change, low overhead
- **Statistically Valid**: Achieves accurate 25% or 50% sampling rates within each group
