### PR TITLE
Don't include path for metrics method in esplora

### DIFF
--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -100,7 +100,7 @@ func (h *BitcoinEsploraHandler) ProcessRequest(req *http.Request) error {
 
 // ExtractMethod extracts the method name from the request for logging/metrics
 func (h *BitcoinEsploraHandler) ExtractMethod(req *http.Request, body []byte) (string, error) {
-	return req.URL.Path, nil
+	return "REST", nil
 }
 
 // ConfigureRequestPath configures the request path for REST API requests


### PR DESCRIPTION
Long term we need to get a better method here for metrics, but right now we need to reduce the cardinality of our metrics.