### PR TITLE
Fix score transformation logic to prevent invalid score loop.

### DIFF
--- a/lib/watcherscore/transformers.go
+++ b/lib/watcherscore/transformers.go
@@ -33,45 +33,38 @@ func NewCompositeTransformer(chain ...ScoreTransformer) *CompositeTransformer {
 // A lower value of alpha means less change and more smoothing; a higher value means more rapid adaptation to new provider situation.
 // See https://en.wikipedia.org/wiki/Exponential_smoothing#Basic_(simple)_exponential_smoothing
 type EWMATransformer struct {
-	alpha             float64
-	previousScores    map[string]*Score
-	hasPreviousScores bool
-	logger            *zap.Logger
+	alpha          float64
+	previousScores map[string]*Score
+	logger         *zap.Logger
 }
 
 func (t *EWMATransformer) TransformScore(network string, scores map[string]*Score) (map[string]*Score, error) {
-	// If this is the first time we're running the transformer, initialize the previousScores and return same scores
-	if !t.hasPreviousScores {
-		t.previousScores = scores
-		t.hasPreviousScores = true
-		return scores, nil
-	}
 
 	// Apply EWMA to the scores using the previous scores as the T-1 scores
 	smoothedScores := map[string]*Score{}
-	for providerID, score := range scores {
-		if !score.HasValue() {
+	for providerID, currentScore := range scores {
+		if !currentScore.HasValue() {
 			smoothedScores[providerID] = EmptyScore
 			continue
 		}
 
 		previousScore, exists := t.previousScores[providerID]
 		if !exists || !previousScore.HasValue() {
-			smoothedScores[providerID] = EmptyScore
+			smoothedScores[providerID] = currentScore
 			continue
 		}
 
 		//The update formula is:
 		// S_t = alpha * S_t + (1 - alpha) * S_t-1
-		transformedScore := score.Value()*t.alpha + (1-t.alpha)*previousScore.Value()
+		transformedScore := currentScore.Value()*t.alpha + (1-t.alpha)*previousScore.Value()
 		t.logger.Info("[WATCHER_SCORE] EWMA transformed score",
 			zap.String("network", network),
 			zap.String("providerID", providerID),
 			zap.Float64("alpha", t.alpha),
-			zap.Float64("currentScore", score.Value()),
+			zap.Float64("currentScore", currentScore.Value()),
 			zap.Float64("previousScore", previousScore.Value()),
 			zap.Float64("newScore", transformedScore))
-		smoothedScores[providerID], _ = NewScore(math.Round(transformedScore*10000)/10000, score.LastUpdated())
+		smoothedScores[providerID], _ = NewScore(math.Round(transformedScore*10000)/10000, currentScore.LastUpdated())
 	}
 
 	// Update the previous scores with the smoothed scores

--- a/lib/watcherscore/transformers_test.go
+++ b/lib/watcherscore/transformers_test.go
@@ -59,27 +59,54 @@ func TestEWMATransformer(t *testing.T) {
 		}
 	})
 
-	t.Run("handles empty scores", func(t *testing.T) {
+	t.Run("previous scores valid, current scores empty, then result is empty", func(t *testing.T) {
 		logger := zaptest.NewLogger(t)
 		transformer := NewEWMATransformer(0.7, logger)
 		scores1 := map[string]*Score{
 			"provider1": MustCreateScore(1.0, TIME1),
-			"provider2": MustCreateScore(0.0, TIME1),
 		}
 		scores2 := map[string]*Score{
 			"provider1": NewEmptyScore(),
-			"provider2": MustCreateScore(1.0, TIME1),
 		}
 
-		transformer.TransformScore("network", scores1)
+		// First call initializes previous scores
+		_, _ = transformer.TransformScore("network", scores1)
+
+		// Second call : current score is empty, previous score is valid, so the result is empty
 		transformedScores, err := transformer.TransformScore("network", scores2)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if transformedScores["provider1"].HasValue() {
-			t.Error("expected empty score")
+			t.Error("expected empty score for provider1")
 		}
+
+	})
+
+	t.Run("previous scores empty, current scores valid, then result is valid", func(t *testing.T) {
+		logger := zaptest.NewLogger(t)
+		transformer := NewEWMATransformer(0.7, logger)
+		scores1 := map[string]*Score{
+			"provider1": NewEmptyScore(),
+		}
+		scores2 := map[string]*Score{
+			"provider1": MustCreateScore(1.0, TIME1),
+		}
+
+		// First call initializes previous scores
+		_, _ = transformer.TransformScore("network", scores1)
+
+		// Second call : current score is valid, previous score is empty, so the result is valid
+		transformedScores, err := transformer.TransformScore("network", scores2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !transformedScores["provider1"].HasValue() {
+			t.Error("expected valid score for provider1")
+		}
+
 	})
 
 	t.Run("handles new providers", func(t *testing.T) {
@@ -100,16 +127,17 @@ func TestEWMATransformer(t *testing.T) {
 		}
 
 		// For provider1: 0.85 * 0.7 + 1.0 * 0.3 = 0.895
-		// For provider2: <cannot be calculated> = EmptyScore
 		expectedScore1 := 0.895
 		if transformedScores["provider1"].Value() != expectedScore1 {
 			t.Errorf("expected provider1 score to be %v, got %v", expectedScore1, transformedScores["provider1"].Value())
 		}
 
-		// For provider2 (new): Returned EmptyScore because it has no previous scores
-		if transformedScores["provider2"].HasValue() {
-			t.Errorf("expected no value for provider2")
+		// For provider2 (new): just appeared, so the result is the current score
+		expectedScore2 := 0.15
+		if transformedScores["provider2"].Value() != expectedScore2 {
+			t.Errorf("expected provider2 score to be %v, got %v", expectedScore2, transformedScores["provider2"].Value())
 		}
+
 	})
 	t.Run("handles three consecutive transformations", func(t *testing.T) {
 		logger := zaptest.NewLogger(t)


### PR DESCRIPTION
Context:  
Whenever the Watch Score logic is running and the Watcher API goes down (e.g., the last incident was due to the Cloudflare outage), the scores become invalid, which is the expected behavior. However, the issue occurs when the API recovers—the Watcher logic remains "stuck" with the invalid scores, preventing it from producing valid scores again until the process is restarted.  

This PR addresses the logic that caused the "invalid" score loop and resolves the issue.