### PR TITLE
Fine-Granular lock to only shared fields 

### DIFF
--- a/lib/watcherscore/interface.go
+++ b/lib/watcherscore/interface.go
@@ -9,19 +9,27 @@ import (
 // IWatcherScoreManager defines the responsibilities of the component that computes and stores the scores for providers on a given network.
 type IWatcherScoreManager interface {
 	// ComputeScores computes the scores for all providers on all networks
+	// It is safe to call this method concurrently
+	// Note that once a computation is in progress, additional calls will be skipped and the method will return immediately
 	ComputeScores()
 	// GetScore gets the score for a given provider on a given network
+	// It is safe to call this method concurrently
 	GetScore(network string, providerID string) *Score
 	// StartPeriodicUpdates starts a background process that periodically computes the scores for all providers on all networks
 	StartPeriodicUpdates(frequency time.Duration) chan struct{}
 	// GetAllScores gets all the scores for all providers on a given network
+	// It is safe to call this method concurrently
 	GetAllScores(network string) map[string]*Score
 	// AddNetworkWithBuiltInFormula adds a network with a built-in formula that uses the default formula (see the documentation for the default formula)
+	// It is safe to call this method concurrently
 	AddNetworkWithBuiltInFormula(network string, client watcher.IWatcherAPIClient) error
 	// AddNetworkFormula adds a network with a custom formula
+	// It is safe to call this method concurrently
 	AddNetworkFormula(network string, formula ScoreFormula)
 	// RemoveNetwork removes a network
+	// It is safe to call this method concurrently
 	RemoveNetwork(network string)
 	// GetNetworkFormula gets the formula for a given network
+	// It is safe to call this method concurrently
 	GetNetworkFormula(network string) *ScoreFormula
 }

--- a/lib/watcherscore/test_utils.go
+++ b/lib/watcherscore/test_utils.go
@@ -33,6 +33,22 @@ func (m *MockWatcherAPIClient) GetLatency(params watcher.LatencyQueryParams) wat
 	return m.mockLatencyResponses[m.latencyCallsCount-1]
 }
 
+// DelayedProviderMetricGenerator is a mock implementation of the ProviderMetricGenerator interface to be used in tests
+// It is used to simulate a long-running computation
+type DelayedProviderMetricGenerator struct {
+	ProviderMetricGenerator ProviderMetricGenerator
+	Delay                   time.Duration
+}
+
+func (d *DelayedProviderMetricGenerator) GenerateMetrics(network string) ([]*ProviderMetric, error) {
+	time.Sleep(d.Delay)
+	return d.ProviderMetricGenerator.GenerateMetrics(network)
+}
+
+func (d *DelayedProviderMetricGenerator) MetricID() string {
+	return d.ProviderMetricGenerator.MetricID()
+}
+
 // Mock data for check response API
 var OK_CHECK_RESPONSE_ONE_PROVIDER_GOOD_SCORE = watcher.Ok(watcher.CheckResponse{
 	Providers: []watcher.CheckProviderData{

--- a/lib/watcherscore/watcherscore_manager.go
+++ b/lib/watcherscore/watcherscore_manager.go
@@ -1,6 +1,7 @@
 package watcherscore
 
 import (
+	"maps"
 	"sync"
 	"time"
 
@@ -22,18 +23,20 @@ type ScoreFormula struct {
 // WatcherScoreManager is responsible for computing watcher scores for providers across networks
 // and providing a way to get the score for a specific provider on a specific network
 type WatcherScoreManager struct {
-	scores   map[string]map[string]*Score // map[network]map[providerID]*WatcherScore
-	formulas map[string]ScoreFormula      // map[network]ScoreFormula
-	logger   *zap.Logger
-	mu       sync.RWMutex
+	scores             map[string]map[string]*Score // map[network]map[providerID]*WatcherScore
+	formulas           map[string]ScoreFormula      // map[network]ScoreFormula
+	logger             *zap.Logger
+	mu                 sync.RWMutex
+	pendingComputation bool
 }
 
 func NewEmpty(logger *zap.Logger) *WatcherScoreManager {
 	return &WatcherScoreManager{
-		scores:   make(map[string]map[string]*Score),
-		formulas: make(map[string]ScoreFormula),
-		logger:   logger,
-		mu:       sync.RWMutex{},
+		scores:             make(map[string]map[string]*Score),
+		formulas:           make(map[string]ScoreFormula),
+		logger:             logger,
+		mu:                 sync.RWMutex{},
+		pendingComputation: false,
 	}
 }
 
@@ -56,13 +59,35 @@ func NewWithBuiltInFormula(networks []string, client watcher.IWatcherAPIClient, 
 }
 
 func (rm *WatcherScoreManager) ComputeScores() {
+	// Acquire a read lock to safely check if a computation is already in progress
+	rm.mu.RLock()
+	pendingComputation := rm.pendingComputation
+	rm.mu.RUnlock()
+
+	if pendingComputation {
+		rm.logger.Info("[WATCHER_SCORE] Watcher score computation is already in progress, skipping...")
+		return
+	}
+
+	// Acquire a write lock to update the pending computation flag and prevent multiple computations from happening concurrently
 	rm.mu.Lock()
-	defer rm.mu.Unlock()
+	rm.pendingComputation = true
+	rm.mu.Unlock()
 
 	rm.logger.Info("[WATCHER_SCORE] Computing watcher scores...")
 
+	// Acquire a read lock to safely copy the formulas map then release it immediately
+	// a formula item is immutable, so we can safely use it without worrying about concurrent access
+	rm.mu.RLock()
+	formulasMap := make(map[string]ScoreFormula)
+	maps.Copy(formulasMap, rm.formulas)
+	rm.mu.RUnlock()
+
+	//Initialize a new map of scores for the network/provider pairs
+	newScores := make(map[string]map[string]*Score)
+
 	// Process each formula that defines how to compute the score for a network
-	for _, formula := range rm.formulas {
+	for _, formula := range formulasMap {
 		network := formula.network
 
 		// A score may be composed of multiple metrics, so we need to collect all metrics for each provider
@@ -117,12 +142,12 @@ func (rm *WatcherScoreManager) ComputeScores() {
 			continue
 		}
 
-		// Finally, update the manager with the new scores
+		// Finally, we create a new map of scores for the network and add the scores to it
 		for providerID, score := range transformedScores {
 
 			// Initialize the scores map for the network if it doesn't exist
-			if _, networkExists := rm.scores[network]; !networkExists {
-				rm.scores[network] = make(map[string]*Score)
+			if _, networkExists := newScores[network]; !networkExists {
+				newScores[network] = make(map[string]*Score)
 			}
 
 			// Add the final score to the scores map
@@ -132,9 +157,16 @@ func (rm *WatcherScoreManager) ComputeScores() {
 				zap.Bool("isValid", score.HasValue()),
 				zap.Float64("score", score.Value()),
 				zap.Time("lastUpdated", score.LastUpdated()))
-			rm.scores[network][providerID] = score
+			newScores[network][providerID] = score
 		}
 	}
+
+	// Acquire a write lock to update the scores map with the new brand new scores
+	// and release the pending computation flag
+	rm.mu.Lock()
+	rm.scores = newScores
+	rm.pendingComputation = false
+	rm.mu.Unlock()
 }
 
 func (rm *WatcherScoreManager) GetScore(network string, providerID string) *Score {
@@ -231,6 +263,10 @@ func (rm *WatcherScoreManager) AddNetworkFormula(network string, formula ScoreFo
 }
 
 func (rm *WatcherScoreManager) GetNetworkFormula(network string) *ScoreFormula {
+	// Acquire a read lock to prevent race condition when reading formulas
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
 	if formula, exists := rm.formulas[network]; exists {
 		return &formula
 	}

--- a/lib/watcherscore/watcherscore_manager_test.go
+++ b/lib/watcherscore/watcherscore_manager_test.go
@@ -1,10 +1,12 @@
 package watcherscore
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/DIN-center/din-sc/apps/din-go/lib/watcher"
+	gomock "go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -537,5 +539,51 @@ func TestWatcherScoreManager(t *testing.T) {
 		if scoreNoProvidersNetwork.HasValue() {
 			t.Errorf("expected no score for network with no providers, got %f", scoreNoProvidersNetwork.Value())
 		}
+	})
+
+	t.Run("manager prevents multiple computations from happening concurrently", func(t *testing.T) {
+		logger := zaptest.NewLogger(t)
+		rm := NewEmpty(logger)
+
+		mockCtrl := gomock.NewController(t)
+		mockWatcherClient := watcher.NewMockIWatcherAPIClient(mockCtrl)
+
+		rm.AddNetworkFormula("slow-network", ScoreFormula{
+			network: "slow-network",
+			metricGenerators: []ProviderMetricGenerator{
+				// Add a metric generator that will simulate a long-running computation
+				&DelayedProviderMetricGenerator{
+					ProviderMetricGenerator: &WatcherBlockNumberConsistency{
+						WatcherClient: mockWatcherClient,
+						Logger:        logger,
+					},
+					Delay: 1 * time.Second,
+				},
+			},
+			metricCombiner: MustCreateWeightedCombiner(map[string]float64{
+				BlockNumberConsistencyMetricID: 1.0,
+			}, logger),
+			scoreTransformer: NewDefaultHighPassThroughTransformer(logger),
+		})
+
+		// Set up expectations for the mock watcher client
+		mockWatcherClient.EXPECT().GetCheck(gomock.Any()).Return(OK_CHECK_RESPONSE_ONE_PROVIDER_GOOD_SCORE).Times(1)
+
+		// Launch first ComputeScores in a separate goroutine this should be long running
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rm.ComputeScores()
+		}()
+
+		// Call a concurrent computation, it should return immediately (second computation suppressed)
+		rm.ComputeScores()
+
+		// Wait for the first computation to finish
+		wg.Wait()
+
+		// Verify expectations, only one call to GetCheck should be made
+		mockCtrl.Finish()
 	})
 }

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -959,6 +959,9 @@ func (d *DinMiddleware) startWatcherScoreSync() chan struct{} {
 	syncQuit := make(chan struct{})
 
 	// Do immediate initial sync
+	// Note that syncing watcher scores immediately here may be a bit early if the score computation is not yet complete,
+	// but it's ok because the watcher score manager will return empty scores until the computation is complete
+	// and the middleware will not use these empty scores for load balancing
 	d.SyncMiddlewareWithLatestScores()
 
 	go func() {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -530,6 +530,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	// This means that DIN Registry cannot be enabled without a refactor of the middleware to protect the shared state at the granular level
 	d.mu.RLock()
 	networkObj, ok := d.Networks[networkPath]
+	d.mu.RUnlock()
 	if !ok {
 		// If the network is not defined, return a 404.
 		rw.WriteHeader(http.StatusNotFound)
@@ -537,7 +538,6 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 
 		return fmt.Errorf("network undefined: %w", err)
 	}
-	d.mu.RUnlock()
 
 	// Ensure handler is available
 	if networkObj.handler == nil {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -492,7 +492,7 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 	provider.logger = d.logger
 
 	// Initialize the score for the provider with an empty score
-	provider.Score = ws.EmptyScore
+	provider.SafeUpdateScore(ws.NewEmptyScore())
 
 	d.logger.Debug("Provider provisioned", zap.String("Provider", provider.HttpUrl), zap.String("Host", provider.host), zap.String("Name", provider.Name), zap.Int("Priority", provider.Priority), zap.Any("Headers", provider.Headers), zap.Any("Auth", provider.Auth), zap.Any("Upstream", provider.upstream), zap.Any("Path", provider.path))
 
@@ -507,8 +507,6 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 // ServeHTTP is the main handler for the middleware that is ran for every request.
 // It checks if the network path is defined in the networks map and sets the provider in the context.
 func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error { //nolint:gocyclo
-	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	// Caddy replacer is used to set the context for the request
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
@@ -526,6 +524,11 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 		return err
 	}
 
+	// Safely access the networks map for guaranteed consistency
+	// It assumes that the network object is immutable after the lock is released or that any internal shared state is protected by the lock
+	// IMPORTANT NOTE: network objects are modified by the DIN Registry (e.g. adding/removing providers, methods, etc.)
+	// This means that DIN Registry cannot be enabled without a refactor of the middleware to protect the shared state at the granular level
+	d.mu.RLock()
 	networkObj, ok := d.Networks[networkPath]
 	if !ok {
 		// If the network is not defined, return a 404.
@@ -534,6 +537,7 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 
 		return fmt.Errorf("network undefined: %w", err)
 	}
+	d.mu.RUnlock()
 
 	// Ensure handler is available
 	if networkObj.handler == nil {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -525,7 +525,8 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	}
 
 	// Safely access the networks map for guaranteed consistency
-	// It assumes that the network object is immutable after the lock is released or that any internal shared state is protected by the lock
+	// It assumes that the network object is immutable after the lock is released or
+	// that any internal shared state in the network object is protected by a granular lock (at the shared state level)
 	// IMPORTANT NOTE: network objects are modified by the DIN Registry (e.g. adding/removing providers, methods, etc.)
 	// This means that DIN Registry cannot be enabled without a refactor of the middleware to protect the shared state at the granular level
 	d.mu.RLock()

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -799,6 +799,8 @@ func (d *DinMiddleware) GetOrCreateWatcherClient() watcher.IWatcherAPIClient {
 }
 
 // Fetches the latest score from the watcher score manager and updates the provider score for all active networks
+// Scores are already precomputed and stored in the watcher score manager internal state,
+// so this function is just a way to move the scores to the middleware object for use in the load balancing logic.
 func (d *DinMiddleware) SyncMiddlewareWithLatestScores() {
 
 	// Keep track of the last time the scores were synced to the middleware
@@ -807,12 +809,13 @@ func (d *DinMiddleware) SyncMiddlewareWithLatestScores() {
 	// Lock (read)the middleware object to prevent race condition when looping through the networks/providers map
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+
 	d.logger.Info("[DYNAMIC_LB] Syncing watcher scores to the middleware")
 	for _, network := range d.Networks {
 		for _, provider := range network.Providers {
 			newScore := d.DynamicLoadBalancing.watcherScoreManager.GetScore(network.Name, provider.host)
 			if newScore.HasValue() {
-				// As the name suggests, SafeUpdateScore is safe to use because it is protected by a write lock to only protect the score object (very granular locking)
+				// As the name suggests, SafeUpdateScore is safe to use because it is protected by a write lock to only protect the score object (very fine-granular locking)
 				provider.SafeUpdateScore(newScore)
 				d.logger.Info("[DYNAMIC_LB] Synced watcher score",
 					zap.String("network", network.Name),

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -800,20 +800,20 @@ func (d *DinMiddleware) GetOrCreateWatcherClient() watcher.IWatcherAPIClient {
 
 // Fetches the latest score from the watcher score manager and updates the provider score for all active networks
 func (d *DinMiddleware) SyncMiddlewareWithLatestScores() {
-	// Lock the middleware object to prevent race condition when updating provider scores
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	// Keep track of the last time the scores were synced to the middleware
 	d.DynamicLoadBalancing.WatcherScoreLastSyncTime = time.Now().UTC()
 
+	// Lock (read)the middleware object to prevent race condition when looping through the networks/providers map
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	d.logger.Info("[DYNAMIC_LB] Syncing watcher scores to the middleware")
 	for _, network := range d.Networks {
 		for _, provider := range network.Providers {
 			newScore := d.DynamicLoadBalancing.watcherScoreManager.GetScore(network.Name, provider.host)
-
 			if newScore.HasValue() {
-				provider.Score = newScore
+				// As the name suggests, SafeUpdateScore is safe to use because it is protected by a write lock to only protect the score object (very granular locking)
+				provider.SafeUpdateScore(newScore)
 				d.logger.Info("[DYNAMIC_LB] Synced watcher score",
 					zap.String("network", network.Name),
 					zap.String("provider", provider.host),

--- a/modules/din_middleware_test.go
+++ b/modules/din_middleware_test.go
@@ -262,8 +262,8 @@ func TestInitialize(t *testing.T) {
 						assert.NotNil(t, provider.upstream)
 
 						// Assert provider score is initialized
-						assert.NotNil(t, provider.Score)
-						assert.Equal(t, ws.EmptyScore, provider.Score)
+						assert.NotNil(t, provider.SafeGetScore())
+						assert.Equal(t, ws.EmptyScore, provider.SafeGetScore())
 					}
 				}
 
@@ -285,7 +285,7 @@ func TestInitializeProvider(t *testing.T) {
 			provider: &provider{
 				HttpUrl: "http://example2.com",
 				Auth:    nil,
-				Score:   ws.EmptyScore,
+				score:   ws.EmptyScore,
 			},
 			httpClient: &din_http.HTTPClient{},
 			wantErr:    false,
@@ -295,7 +295,7 @@ func TestInitializeProvider(t *testing.T) {
 			provider: &provider{
 				HttpUrl: "https://example3.com",
 				Auth:    nil,
-				Score:   ws.EmptyScore,
+				score:   ws.EmptyScore,
 			},
 			httpClient: &din_http.HTTPClient{},
 			wantErr:    false,
@@ -307,7 +307,7 @@ func TestInitializeProvider(t *testing.T) {
 				Auth: &siwe.SIWEClientAuth{
 					ProviderURL: "http://auth.example.com",
 				},
-				Score: ws.EmptyScore,
+				score: ws.EmptyScore,
 			},
 			httpClient: &din_http.HTTPClient{},
 			wantErr:    false,
@@ -325,7 +325,7 @@ func TestInitializeProvider(t *testing.T) {
 			}
 			err := dinMiddleware.initializeProvider("test-network", tt.provider, tt.httpClient, logger)
 			// Assert provider score is set to the empty score
-			assert.Equal(t, ws.EmptyScore, tt.provider.Score)
+			assert.Equal(t, ws.EmptyScore, tt.provider.SafeGetScore())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DinMiddleware.initializeProvider() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1228,15 +1228,15 @@ func TestSyncMiddlewareWithLatestScores(t *testing.T) {
 				Providers: map[string]*provider{
 					"provider1": {
 						host:  "provider1",
-						Score: ws.MustCreateScore(0.8, time.Now()),
+						score: ws.MustCreateScore(0.8, time.Now()),
 					},
 					"provider2": {
 						host:  "provider2",
-						Score: ws.MustCreateScore(0.2, time.Now()),
+						score: ws.MustCreateScore(0.2, time.Now()),
 					},
 					"non-monitored-provider": {
 						host:  "non-monitored-provider",
-						Score: markerForNonMonitoredProvider,
+						score: markerForNonMonitoredProvider,
 					},
 				},
 			},
@@ -1256,10 +1256,10 @@ func TestSyncMiddlewareWithLatestScores(t *testing.T) {
 	mockMiddleware.SyncMiddlewareWithLatestScores()
 
 	//Verify if scores are updated correctly in the middleware
-	assert.Equal(t, 0.75, mockMiddleware.Networks["network1"].Providers["provider1"].Score.Value())
-	assert.Equal(t, 0.25, mockMiddleware.Networks["network1"].Providers["provider2"].Score.Value())
+	assert.Equal(t, 0.75, mockMiddleware.Networks["network1"].Providers["provider1"].SafeGetScore().Value())
+	assert.Equal(t, 0.25, mockMiddleware.Networks["network1"].Providers["provider2"].SafeGetScore().Value())
 	//assert memory address is the same
-	if markerForNonMonitoredProvider != mockMiddleware.Networks["network1"].Providers["non-monitored-provider"].Score {
+	if markerForNonMonitoredProvider != mockMiddleware.Networks["network1"].Providers["non-monitored-provider"].SafeGetScore() {
 		t.Errorf("Non-monitored provider score should be the same as the marker")
 	}
 }

--- a/modules/din_scorebased_selector.go
+++ b/modules/din_scorebased_selector.go
@@ -102,7 +102,7 @@ func (s *DinScoreBasedSelector) Select(pool reverseproxy.UpstreamPool, r *http.R
 				if provider, exists := mapUpstreamProviders[upstream]; exists {
 
 					providerHost = provider.host
-					providerScore = provider.Score
+					providerScore = provider.SafeGetScore()
 
 					if providerScore.HasValue() {
 						s.logger.Debug("[DYNAMIC_LB] Score found for provider",
@@ -110,13 +110,13 @@ func (s *DinScoreBasedSelector) Select(pool reverseproxy.UpstreamPool, r *http.R
 							zap.Any("score", providerScore))
 
 						graceTimeStart := time.Now().UTC().Add(-StaleScoreGracePeriod)
-						if provider.Score.LastUpdated().After(graceTimeStart) {
+						if providerScore.LastUpdated().After(graceTimeStart) {
 							// If the score has a valid value and is not stale, we can use it to weight the selection
-							weight = int(provider.Score.Value() * ScoreBasedSelectionWeightBase)
+							weight = int(providerScore.Value() * ScoreBasedSelectionWeightBase)
 						} else {
 							//Score is stale, so we gradually pull the weight towards the default weight
-							timeSinceStale := graceTimeStart.Sub(provider.Score.LastUpdated())
-							staleScore := provider.Score.Value()
+							timeSinceStale := graceTimeStart.Sub(providerScore.LastUpdated())
+							staleScore := providerScore.Value()
 							adjustedStaleScore, err := ws.ExponentialPullToMidpoint(staleScore,
 								timeSinceStale,
 								StaleScoreConvergencePeriod,
@@ -128,7 +128,7 @@ func (s *DinScoreBasedSelector) Select(pool reverseproxy.UpstreamPool, r *http.R
 							weight = int(adjustedStaleScore * ScoreBasedSelectionWeightBase)
 							s.logger.Debug("[DYNAMIC_LB] Score is stale for provider, adjusted towards default weight",
 								zap.String("provider", providerHost),
-								zap.String("score_updated_at", provider.Score.LastUpdated().Format(time.RFC3339)),
+								zap.String("score_updated_at", providerScore.LastUpdated().Format(time.RFC3339)),
 								zap.String("grace_time_start", graceTimeStart.Format(time.RFC3339)),
 								zap.Float64("stale_score", staleScore),
 								zap.Float64("adjusted_stale_score", adjustedStaleScore),

--- a/modules/din_scorebased_selector_test.go
+++ b/modules/din_scorebased_selector_test.go
@@ -126,7 +126,7 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.NewEmptyScore(), // foo has no score, score will use default weight
+					score:    ws.NewEmptyScore(), // foo has no score, score will use default weight
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -140,7 +140,7 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(1.0, time.Now().UTC()),
+					score:    ws.MustCreateScore(1.0, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -154,7 +154,7 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.0, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.0, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -168,11 +168,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.0, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.0, time.Now().UTC()),
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.MustCreateScore(0.0, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.0, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -186,11 +186,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.8, time.Now().UTC()),
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.8, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -204,11 +204,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.92, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.92, time.Now().UTC()),
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.MustCreateScore(0.67, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.67, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -223,11 +223,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.92, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.92, time.Now().UTC()),
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.NewEmptyScore(), // foo has no score, score will be defaulted to 0.5
+					score:    ws.NewEmptyScore(), // foo has no score, score will be defaulted to 0.5
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -242,11 +242,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.NewEmptyScore(), // bar has no score, score will be defaulted to 0.5
+					score:    ws.NewEmptyScore(), // bar has no score, score will be defaulted to 0.5
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.NewEmptyScore(), // foo has no score, score will be defaulted to 0.5
+					score:    ws.NewEmptyScore(), // foo has no score, score will be defaulted to 0.5
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -261,11 +261,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC().Add(-StaleScoreGracePeriod+(1*time.Minute))), // bar stale and grace period is not expired yet
+					score:    ws.MustCreateScore(0.8, time.Now().UTC().Add(-StaleScoreGracePeriod+(1*time.Minute))), // bar stale and grace period is not expired yet
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.8, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -280,11 +280,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC().Add(-StaleScoreGracePeriod-(10*time.Minute))), // bar stale and elapsed time since grace period finished is 10 minutes ago
+					score:    ws.MustCreateScore(0.8, time.Now().UTC().Add(-StaleScoreGracePeriod-(10*time.Minute))), // bar stale and elapsed time since grace period finished is 10 minutes ago
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.8, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,
@@ -299,11 +299,11 @@ func TestDinScoreBasedSelectorSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC().Add(-StaleScoreGracePeriod-StaleScoreConvergencePeriod)), // bar stale and elapsed time since grace period finished is 70 minutes ago
+					score:    ws.MustCreateScore(0.8, time.Now().UTC().Add(-StaleScoreGracePeriod-StaleScoreConvergencePeriod)), // bar stale and elapsed time since grace period finished is 70 minutes ago
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.MustCreateScore(0.8, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.8, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,

--- a/modules/din_select_test.go
+++ b/modules/din_select_test.go
@@ -113,11 +113,11 @@ func TestDinSelectSelect(t *testing.T) {
 			providers: map[string]*provider{
 				"bar": {
 					upstream: upstream_bar,
-					Score:    ws.MustCreateScore(0.92, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.92, time.Now().UTC()),
 				},
 				"foo": {
 					upstream: upstream_foo,
-					Score:    ws.MustCreateScore(0.67, time.Now().UTC()),
+					score:    ws.MustCreateScore(0.67, time.Now().UTC()),
 				},
 			},
 			dynamicLoadBalancingEnabled: true,

--- a/modules/provider.go
+++ b/modules/provider.go
@@ -38,7 +38,8 @@ type provider struct {
 	authClient auth.IAuthClient
 
 	// Watcher Score
-	Score *ws.Score
+	score   *ws.Score    // Immutable score object
+	scoreMu sync.RWMutex // Mutex to protect the access to the score object
 
 	consecutiveUnhealthyChecks int
 	blockHistory               *list.List
@@ -77,7 +78,7 @@ func NewProvider(urlStr string) (*provider, error) {
 		Name:         safeExtractMainDomainWithPSL(url),
 		Headers:      make(map[string]string),
 		blockHistory: list.New(),
-		Score:        ws.EmptyScore,
+		score:        ws.EmptyScore,
 	}
 	return p, nil
 }
@@ -243,4 +244,18 @@ func (p *provider) getLatestBlockEntry() *blockHistoryEntry {
 
 	entry := p.blockHistory.Back().Value.(blockHistoryEntry)
 	return &entry
+}
+
+// SafeGetScore returns the current score for the provider with a read lock to prevent reading while writing.
+func (p *provider) SafeGetScore() *ws.Score {
+	p.scoreMu.RLock()
+	defer p.scoreMu.RUnlock()
+	return p.score
+}
+
+// SafeUpdateScore updates the score for the provider with a write lock to prevent writing while reading.
+func (p *provider) SafeUpdateScore(score *ws.Score) {
+	p.scoreMu.Lock()
+	defer p.scoreMu.Unlock()
+	p.score = score
 }

--- a/modules/provider_test.go
+++ b/modules/provider_test.go
@@ -92,8 +92,8 @@ func TestNewProvider(t *testing.T) {
 				if p != nil && len(p.Headers) != 0 {
 					t.Errorf("expected empty headers, but got %v", p.Headers)
 				}
-				if p != nil && p.Score != ws.EmptyScore {
-					t.Errorf("expected to be empty score, but got %v", p.Score)
+				if p != nil && p.SafeGetScore() != ws.EmptyScore {
+					t.Errorf("expected to be empty score, but got %v", p.SafeGetScore())
 				}
 			}
 		})


### PR DESCRIPTION
This pull request addresses issue #164 by narrowing the scope of locks to only include shared resources. Previously, we had a global lock at the middleware level, but for Watcher syncing scores, we only update a single score at the provider level.

This code takes a very granular approach by protecting only the score field being updated. Please note that this fix does not address the issues with the DIN Registry code, which is more complex and involves changes to the `network` map (DIN Registry may add or remove networks or providers). A separate pull request will be created to address those broader concerns with a comprehensive solution. This fix specifically addresses the Watcher sync score and its interaction with the global lock in `ServeHTTP` that was previously  being held for too long. 

EDIT:
I've also revamped the computation logic for the watcher manager to utilize the same approach with fine-grained locks. Additionally, I've ensured that computations don't stack up if the `ComputeScores()` method is called multiple times by concurrent threads.  I added tests to verify that the concurrency in score computation works as intended.