### PR TITLE
Add debug_traceBlockByNumber archive check for MetaMask compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Caddyfile*
 caddy.log
+router.log
 .vscode/
 data/
 caddy
@@ -23,6 +24,10 @@ services/.DS_Store
 coverage.out
 Claude.md
 PR_DESCRIPTION.md
+
+# Planning and documentation (local only)
+plans/
+docs/din-sdk-v2/
 
 # Environment files with secrets
 .env.local

--- a/lib/network/evm_handler.go
+++ b/lib/network/evm_handler.go
@@ -479,6 +479,42 @@ func (h *EVMHandler) PerformArchiveCheck(httpUrl string, headers map[string]stri
 	)
 }
 
+// PerformTraceBlockByNumberCheck performs debug_traceBlockByNumber check for EVM chains
+// This is an additional archive mode check that verifies trace capabilities (MetaMask requirement)
+func (h *EVMHandler) PerformTraceBlockByNumberCheck(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error {
+	return PerformTraceBlockByNumberCheckViaJSONRPC(
+		httpUrl,
+		headers,
+		httpClient,
+		authClient,
+		requestAttempts,
+		blockHeight,
+		h.CreateTraceBlockByNumberPayload,
+		h.ParseTraceBlockByNumberResponse,
+	)
+}
+
+// CreateTraceBlockByNumberPayload creates the debug_traceBlockByNumber request payload
+func (h *EVMHandler) CreateTraceBlockByNumberPayload(blockHeight string) ([]byte, error) {
+	payload := fmt.Sprintf(`{"jsonrpc":"2.0","method":"debug_traceBlockByNumber","id":1,"params":["%s",{"tracer":"callTracer","timeout":"30s","onlyTopCall":true}]}`, blockHeight)
+	return []byte(payload), nil
+}
+
+// ParseTraceBlockByNumberResponse validates the debug_traceBlockByNumber response
+func (h *EVMHandler) ParseTraceBlockByNumberResponse(body []byte) error {
+	var respObject map[string]interface{}
+	if err := json.Unmarshal(body, &respObject); err != nil {
+		return fmt.Errorf("failed to unmarshal trace response: %w", err)
+	}
+
+	// Check for JSON-RPC error
+	if errField, ok := respObject["error"]; ok && errField != nil {
+		return fmt.Errorf("debug_traceBlockByNumber not supported: %v", errField)
+	}
+
+	return nil
+}
+
 // PerformGetBlockByNumber performs get block by number operation for EVM chains using JSON-RPC
 func (h *EVMHandler) PerformGetBlockByNumber(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (interface{}, error) {
 	// Use the shared JSON-RPC helper for get block by number operations

--- a/lib/network/evm_handler.go
+++ b/lib/network/evm_handler.go
@@ -489,19 +489,17 @@ func (h *EVMHandler) PerformTraceBlockByNumberCheck(httpUrl string, headers map[
 		authClient,
 		requestAttempts,
 		blockHeight,
-		h.CreateTraceBlockByNumberPayload,
-		h.ParseTraceBlockByNumberResponse,
 	)
 }
 
-// CreateTraceBlockByNumberPayload creates the debug_traceBlockByNumber request payload
-func (h *EVMHandler) CreateTraceBlockByNumberPayload(blockHeight string) ([]byte, error) {
+// createTraceBlockByNumberPayload creates the debug_traceBlockByNumber request payload
+func createTraceBlockByNumberPayload(blockHeight string) ([]byte, error) {
 	payload := fmt.Sprintf(`{"jsonrpc":"2.0","method":"debug_traceBlockByNumber","id":1,"params":["%s",{"tracer":"callTracer","timeout":"30s","onlyTopCall":true}]}`, blockHeight)
 	return []byte(payload), nil
 }
 
-// ParseTraceBlockByNumberResponse validates the debug_traceBlockByNumber response
-func (h *EVMHandler) ParseTraceBlockByNumberResponse(body []byte) error {
+// parseTraceBlockByNumberResponse validates the debug_traceBlockByNumber response
+func parseTraceBlockByNumberResponse(body []byte) error {
 	var respObject map[string]interface{}
 	if err := json.Unmarshal(body, &respObject); err != nil {
 		return fmt.Errorf("failed to unmarshal trace response: %w", err)

--- a/lib/network/evm_handler_test.go
+++ b/lib/network/evm_handler_test.go
@@ -484,11 +484,9 @@ func TestEVMHandler_ValidateRequest(t *testing.T) {
 }
 
 func TestEVMHandler_CreateTraceBlockByNumberPayload(t *testing.T) {
-	handler := NewEVMHandler(&NetworkConfig{})
-
-	payload, err := handler.CreateTraceBlockByNumberPayload("0x64")
+	payload, err := createTraceBlockByNumberPayload("0x64")
 	if err != nil {
-		t.Errorf("CreateTraceBlockByNumberPayload() error = %v", err)
+		t.Errorf("createTraceBlockByNumberPayload() error = %v", err)
 		return
 	}
 
@@ -543,8 +541,6 @@ func TestEVMHandler_CreateTraceBlockByNumberPayload(t *testing.T) {
 }
 
 func TestEVMHandler_ParseTraceBlockByNumberResponse(t *testing.T) {
-	handler := NewEVMHandler(&NetworkConfig{})
-
 	tests := []struct {
 		name        string
 		response    []byte
@@ -579,7 +575,7 @@ func TestEVMHandler_ParseTraceBlockByNumberResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handler.ParseTraceBlockByNumberResponse(tt.response)
+			err := parseTraceBlockByNumberResponse(tt.response)
 			if tt.expectError && err == nil {
 				t.Errorf("Expected error for test '%s', but got none", tt.name)
 			}

--- a/lib/network/evm_handler_test.go
+++ b/lib/network/evm_handler_test.go
@@ -482,3 +482,105 @@ func TestEVMHandler_ValidateRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestEVMHandler_CreateTraceBlockByNumberPayload(t *testing.T) {
+	handler := NewEVMHandler(&NetworkConfig{})
+
+	payload, err := handler.CreateTraceBlockByNumberPayload("0x64")
+	if err != nil {
+		t.Errorf("CreateTraceBlockByNumberPayload() error = %v", err)
+		return
+	}
+
+	// Parse the JSON payload to verify structure
+	var req map[string]interface{}
+	err = json.Unmarshal(payload, &req)
+	if err != nil {
+		t.Errorf("Failed to unmarshal trace payload: %v", err)
+		return
+	}
+
+	// Check JSONRPC version
+	if req["jsonrpc"] != "2.0" {
+		t.Errorf("Expected jsonrpc version '2.0', got %v", req["jsonrpc"])
+	}
+
+	// Check method
+	if req["method"] != "debug_traceBlockByNumber" {
+		t.Errorf("Expected method 'debug_traceBlockByNumber', got %v", req["method"])
+	}
+
+	// Check parameters
+	params, ok := req["params"].([]interface{})
+	if !ok || len(params) != 2 {
+		t.Errorf("Expected params to be array of length 2, got %v", req["params"])
+		return
+	}
+
+	// Check block number
+	if params[0] != "0x64" {
+		t.Errorf("Expected block number '0x64', got %v", params[0])
+	}
+
+	// Check tracer options
+	opts, ok := params[1].(map[string]interface{})
+	if !ok {
+		t.Errorf("Expected second param to be object, got %v", params[1])
+		return
+	}
+
+	if opts["tracer"] != "callTracer" {
+		t.Errorf("Expected tracer 'callTracer', got %v", opts["tracer"])
+	}
+
+	if opts["timeout"] != "30s" {
+		t.Errorf("Expected timeout '30s', got %v", opts["timeout"])
+	}
+
+	if opts["onlyTopCall"] != true {
+		t.Errorf("Expected onlyTopCall true, got %v", opts["onlyTopCall"])
+	}
+}
+
+func TestEVMHandler_ParseTraceBlockByNumberResponse(t *testing.T) {
+	handler := NewEVMHandler(&NetworkConfig{})
+
+	tests := []struct {
+		name        string
+		response    []byte
+		expectError bool
+	}{
+		{
+			name:        "successful response with result",
+			response:    []byte(`{"jsonrpc":"2.0","id":1,"result":[{"type":"CALL","from":"0x123","to":"0x456"}]}`),
+			expectError: false,
+		},
+		{
+			name:        "empty result array",
+			response:    []byte(`{"jsonrpc":"2.0","id":1,"result":[]}`),
+			expectError: false,
+		},
+		{
+			name:        "json-rpc error response",
+			response:    []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`),
+			expectError: true,
+		},
+		{
+			name:        "invalid json",
+			response:    []byte(`not valid json`),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.ParseTraceBlockByNumberResponse(tt.response)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error for test '%s', but got none", tt.name)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error for test '%s', but got: %v", tt.name, err)
+			}
+		})
+	}
+}

--- a/lib/network/evm_handler_test.go
+++ b/lib/network/evm_handler_test.go
@@ -566,6 +566,11 @@ func TestEVMHandler_ParseTraceBlockByNumberResponse(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "json-rpc error -32000 block pruned",
+			response:    []byte(`{"jsonrpc":"2.0","id":0,"error":{"code":-32000,"message":"block pruned: 183392636 vs 179652199"}}`),
+			expectError: true,
+		},
+		{
 			name:        "invalid json",
 			response:    []byte(`not valid json`),
 			expectError: true,

--- a/lib/network/handlers.go
+++ b/lib/network/handlers.go
@@ -90,6 +90,14 @@ type NetworkHandler interface {
 	Initialize(config *NetworkConfig) error
 }
 
+// TraceChecker is an optional interface for handlers that support trace/debug capabilities
+// Currently implemented by: EVMHandler
+type TraceChecker interface {
+	// PerformTraceBlockByNumberCheck performs debug_traceBlockByNumber check
+	// This is used for MetaMask compliance and verifies trace/debug API support
+	PerformTraceBlockByNumberCheck(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error
+}
+
 // BlockInfo represents block information across different network types
 type BlockInfo struct {
 	Number    int64                  `json:"number"`

--- a/lib/network/json_rpc_client.go
+++ b/lib/network/json_rpc_client.go
@@ -179,6 +179,56 @@ func PerformArchiveCheckViaJSONRPC(httpUrl string, headers map[string]string, ht
 	return fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
 }
 
+// PerformTraceBlockByNumberCheckViaJSONRPC performs a debug_traceBlockByNumber check via JSON-RPC
+// This is EVM-specific and verifies trace/debug capabilities for MetaMask compliance
+func PerformTraceBlockByNumberCheckViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string, createPayloadFunc func(string) ([]byte, error), parseResponseFunc func([]byte) error) error {
+	var lastErr error
+	var lastResponseStatus int
+
+	for attempt := 0; attempt < requestAttempts; attempt++ {
+		// Use the provided function to create trace payload
+		payload, err := createPayloadFunc(blockHeight)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to create trace payload: %w", err)
+			continue
+		}
+
+		// Make POST request with payload
+		resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
+		if statusCode != nil {
+			lastResponseStatus = *statusCode
+		}
+
+		if err != nil {
+			lastErr = fmt.Errorf("error sending HTTP request: %w", err)
+			continue
+		}
+
+		// Check for specific HTTP error status codes
+		if lastResponseStatus >= 400 {
+			if lastResponseStatus == 503 || lastResponseStatus == 502 {
+				lastErr = fmt.Errorf("network unavailable (status code: %d)", lastResponseStatus)
+			} else {
+				lastErr = fmt.Errorf("error status code: %d", lastResponseStatus)
+			}
+			continue
+		}
+
+		// Use the provided parse function to validate trace response
+		err = parseResponseFunc(resBytes)
+		if err != nil {
+			lastErr = fmt.Errorf("trace block check failed: %w", err)
+			continue
+		}
+
+		// Success!
+		return nil
+	}
+
+	// All attempts failed
+	return fmt.Errorf("failed after %d attempts: %w", requestAttempts, lastErr)
+}
+
 // PerformGetBlockByNumberViaJSONRPC performs a JSON-RPC get block by number request
 // This is shared logic for JSON-RPC based handlers (EVM, Starknet, Solana)
 func PerformGetBlockByNumberViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64, getSupportedMethodsFunc func() []string, createBlockRequestFunc func(string, int64, bool) ([]byte, error), parseBlockResponseFunc func([]byte) (interface{}, error)) (interface{}, error) {

--- a/lib/network/json_rpc_client.go
+++ b/lib/network/json_rpc_client.go
@@ -181,12 +181,12 @@ func PerformArchiveCheckViaJSONRPC(httpUrl string, headers map[string]string, ht
 
 // PerformTraceBlockByNumberCheckViaJSONRPC performs a debug_traceBlockByNumber check via JSON-RPC
 // This is EVM-specific and verifies trace/debug capabilities for MetaMask compliance
-func PerformTraceBlockByNumberCheckViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string, createPayloadFunc func(string) ([]byte, error), parseResponseFunc func([]byte) error) error {
+func PerformTraceBlockByNumberCheckViaJSONRPC(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error {
 	var lastErr error
 	var lastResponseStatus int
 
 	// Create payload once outside the retry loop - it's deterministic
-	payload, err := createPayloadFunc(blockHeight)
+	payload, err := createTraceBlockByNumberPayload(blockHeight)
 	if err != nil {
 		return fmt.Errorf("failed to create trace payload: %w", err)
 	}
@@ -213,8 +213,8 @@ func PerformTraceBlockByNumberCheckViaJSONRPC(httpUrl string, headers map[string
 			continue
 		}
 
-		// Use the provided parse function to validate trace response
-		err = parseResponseFunc(resBytes)
+		// Validate the trace response
+		err = parseTraceBlockByNumberResponse(resBytes)
 		if err != nil {
 			lastErr = fmt.Errorf("trace block check failed: %w", err)
 			continue

--- a/lib/network/json_rpc_client.go
+++ b/lib/network/json_rpc_client.go
@@ -185,14 +185,13 @@ func PerformTraceBlockByNumberCheckViaJSONRPC(httpUrl string, headers map[string
 	var lastErr error
 	var lastResponseStatus int
 
-	for attempt := 0; attempt < requestAttempts; attempt++ {
-		// Use the provided function to create trace payload
-		payload, err := createPayloadFunc(blockHeight)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to create trace payload: %w", err)
-			continue
-		}
+	// Create payload once outside the retry loop - it's deterministic
+	payload, err := createPayloadFunc(blockHeight)
+	if err != nil {
+		return fmt.Errorf("failed to create trace payload: %w", err)
+	}
 
+	for attempt := 0; attempt < requestAttempts; attempt++ {
 		// Make POST request with payload
 		resBytes, statusCode, err := httpClient.Post(httpUrl, headers, payload, authClient)
 		if statusCode != nil {

--- a/modules/caddy_unmarshaller.go
+++ b/modules/caddy_unmarshaller.go
@@ -229,7 +229,8 @@ func (p *caddyfileParser) parseNetworkField(networkName string, nesting int) err
 	case "healthcheck_threshold", "healthcheck_timeout", "healthcheck_interval",
 		"healthcheck_blocklag_limit", "healthcheck_blockjump_limit",
 		"healthcheck_provider_block_history_size", "network_block_history_size",
-		"max_request_payload_size_kb", "request_attempt_count", "archive_enabled":
+		"max_request_payload_size_kb", "request_attempt_count", "archive_enabled",
+		"archive_trace_block_by_number":
 		return p.parseConfigField(network, p.dispenser.Val())
 	case "custom_config":
 		return p.parseCustomConfig(network, nesting)
@@ -714,6 +715,7 @@ var configFieldMapping = map[string]struct {
 	"max_request_payload_size_kb":             {"MaxRequestPayloadSizeKB", "MaxRequestPayloadSizeKBSetInCaddyfile"},
 	"request_attempt_count":                   {"RequestAttemptCount", "RequestAttemptCountSetInCaddyfile"},
 	"archive_enabled":                         {"ArchiveEnabled", "ArchiveEnabledSetInCaddyfile"},
+	"archive_trace_block_by_number":           {"ArchiveTraceBlockByNumberEnabled", "ArchiveTraceBlockByNumberSetInCaddyfile"},
 }
 
 // parseConfigField uses reflection to parse a configuration field and automatically set the corresponding flag

--- a/modules/caddy_unmarshaller_test.go
+++ b/modules/caddy_unmarshaller_test.go
@@ -65,6 +65,29 @@ func TestReflectionBasedConfigParsing(t *testing.T) {
 			},
 		},
 		{
+			name: "Test archive_trace_block_by_number flag",
+			caddyfile: `networks {
+				eth {
+					chain_id 0x1
+					archive_enabled true
+					archive_trace_block_by_number true
+					providers {
+						http://test.com/eth {
+							priority 1
+						}
+					}
+				}
+			}`,
+			expectedValues: map[string]interface{}{
+				"ArchiveEnabled":                   true,
+				"ArchiveTraceBlockByNumberEnabled": true,
+			},
+			expectedFlags: map[string]bool{
+				"ArchiveEnabledSetInCaddyfile":                  true,
+				"ArchiveTraceBlockByNumberSetInCaddyfile":       true,
+			},
+		},
+		{
 			name: "Test partial config with defaults",
 			caddyfile: `networks {
 				eth {
@@ -146,6 +169,8 @@ func TestReflectionBasedConfigParsing(t *testing.T) {
 					assert.Equal(t, expectedValue, network.RequestAttemptCount, "Field %s", fieldName)
 				case "ArchiveEnabled":
 					assert.Equal(t, expectedValue, network.ArchiveEnabled, "Field %s", fieldName)
+				case "ArchiveTraceBlockByNumberEnabled":
+					assert.Equal(t, expectedValue, network.ArchiveTraceBlockByNumberEnabled, "Field %s", fieldName)
 				}
 			}
 
@@ -172,6 +197,8 @@ func TestReflectionBasedConfigParsing(t *testing.T) {
 					assert.Equal(t, expectedFlag, network.CaddyfileFlags.RequestAttemptCountSetInCaddyfile, "Flag %s", flagName)
 				case "ArchiveEnabledSetInCaddyfile":
 					assert.Equal(t, expectedFlag, network.CaddyfileFlags.ArchiveEnabledSetInCaddyfile, "Flag %s", flagName)
+				case "ArchiveTraceBlockByNumberSetInCaddyfile":
+					assert.Equal(t, expectedFlag, network.CaddyfileFlags.ArchiveTraceBlockByNumberSetInCaddyfile, "Flag %s", flagName)
 				}
 			}
 		})

--- a/modules/consts.go
+++ b/modules/consts.go
@@ -51,8 +51,9 @@ const (
 	DefaultBlockLagLimit           = int64(5)
 	DefaultBlockJumpLimit          = int64(100)
 	DefaultMaxRequestPayloadSizeKB = int64(4096)
-	DefaultRequestAttemptCount     = 5
-	DefaultArchiveEnabled          = false
+	DefaultRequestAttemptCount               = 5
+	DefaultArchiveEnabled                    = false
+	DefaultArchiveTraceBlockByNumberEnabled  = false
 
 	// Registry constants
 	DefaultRegistryBlockCheckIntervalSec = int64(60)

--- a/modules/network.go
+++ b/modules/network.go
@@ -35,7 +35,8 @@ type caddyfileConfigFlags struct {
 	RequestAttemptCountSetInCaddyfile      bool
 	ProviderBlockHistorySizeSetInCaddyfile bool
 	NetworkBlockHistorySizeSetInCaddyfile  bool
-	ArchiveEnabledSetInCaddyfile           bool
+	ArchiveEnabledSetInCaddyfile                   bool
+	ArchiveTraceBlockByNumberSetInCaddyfile        bool
 }
 
 var _ json.Unmarshaler = (*network)(nil)
@@ -79,8 +80,9 @@ type network struct {
 	BlockLagLimit           int64 `json:"healthcheck_blocklag_limit"`
 	BlockJumpLimit          int64 `json:"healthcheck_blockjump_limit"`
 	MaxRequestPayloadSizeKB int64 `json:"max_request_payload_size_kb"`
-	RequestAttemptCount     int   `json:"request_attempt_count"`
-	ArchiveEnabled          bool  `json:"archive_enabled"`
+	RequestAttemptCount              int   `json:"request_attempt_count"`
+	ArchiveEnabled                   bool  `json:"archive_enabled"`
+	ArchiveTraceBlockByNumberEnabled bool  `json:"archive_trace_block_by_number"`
 
 	// Custom configuration passed from Caddyfile
 	CustomConfig map[string]interface{} `json:"custom_config,omitempty"`
@@ -104,9 +106,10 @@ func NewNetwork(name string, handlerType HandlerType, environment utils.Environm
 		RequestAttemptCount:      DefaultRequestAttemptCount,
 		ProviderBlockHistorySize: DefaultProviderBlockHistorySize,
 		NetworkBlockHistorySize:  DefaultNetworkBlockHistorySize,
-		blockHistory:             list.New(),
-		ArchiveEnabled:           DefaultArchiveEnabled,
-		Environment:              environment,
+		blockHistory:                     list.New(),
+		ArchiveEnabled:                   DefaultArchiveEnabled,
+		ArchiveTraceBlockByNumberEnabled: DefaultArchiveTraceBlockByNumberEnabled,
+		Environment:                      environment,
 		Providers:                make(map[string]*provider),
 		CaddyPort:                caddyPort,
 		// Initialize Caddyfile flags tracking
@@ -444,7 +447,26 @@ func (n *network) performArchiveCheck(provider *provider, currentBlock int64) er
 	// Use handler method to format block height directly
 	quarterBlockHeightString := n.handler.FormatBlockHeight(quarterBlockHeight)
 
-	return n.handler.PerformArchiveCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), n.RequestAttemptCount, quarterBlockHeightString)
+	// Perform the primary archive check (eth_getBalance)
+	if err := n.handler.PerformArchiveCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), n.RequestAttemptCount, quarterBlockHeightString); err != nil {
+		return err
+	}
+
+	// Additional trace check (EVM-specific, MetaMask requirement)
+	// Only runs if archive_trace_block_by_number flag is enabled
+	if n.ArchiveTraceBlockByNumberEnabled {
+		// Check if handler supports trace check via type assertion (EVM-specific)
+		type traceChecker interface {
+			PerformTraceBlockByNumberCheck(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error
+		}
+		if traceHandler, ok := n.handler.(traceChecker); ok {
+			if err := traceHandler.PerformTraceBlockByNumberCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), n.RequestAttemptCount, quarterBlockHeightString); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // isStalled checks if provider's block numbers haven't changed

--- a/modules/network.go
+++ b/modules/network.go
@@ -455,11 +455,8 @@ func (n *network) performArchiveCheck(provider *provider, currentBlock int64) er
 	// Additional trace check (EVM-specific, MetaMask requirement)
 	// Only runs if archive_trace_block_by_number flag is enabled
 	if n.ArchiveTraceBlockByNumberEnabled {
-		// Check if handler supports trace check via type assertion (EVM-specific)
-		type traceChecker interface {
-			PerformTraceBlockByNumberCheck(httpUrl string, headers map[string]string, httpClient din_http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockHeight string) error
-		}
-		if traceHandler, ok := n.handler.(traceChecker); ok {
+		// Check if handler supports trace check via type assertion
+		if traceHandler, ok := n.handler.(networklib.TraceChecker); ok {
 			if err := traceHandler.PerformTraceBlockByNumberCheck(provider.HttpUrl, provider.Headers, n.HttpClient, provider.AuthClient(), n.RequestAttemptCount, quarterBlockHeightString); err != nil {
 				return err
 			}

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -492,6 +492,135 @@ func TestArchiveModeCheck(t *testing.T) {
 	}
 }
 
+func TestPerformArchiveCheck_TraceBlockByNumber(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name                      string
+		archiveEnabled            bool
+		traceEnabled              bool
+		archiveResponse           []byte
+		archiveStatusCode         int
+		traceResponse             []byte
+		traceStatusCode           int
+		expectError               bool
+		expectedErrMsg            string
+	}{
+		{
+			name:              "trace_disabled_only_archive_check_runs",
+			archiveEnabled:    true,
+			traceEnabled:      false,
+			archiveResponse:   []byte(`{"result":"0x123"}`),
+			archiveStatusCode: 200,
+			traceResponse:     nil, // Should not be called
+			traceStatusCode:   0,
+			expectError:       false,
+		},
+		{
+			name:              "both_checks_pass",
+			archiveEnabled:    true,
+			traceEnabled:      true,
+			archiveResponse:   []byte(`{"result":"0x123"}`),
+			archiveStatusCode: 200,
+			traceResponse:     []byte(`{"jsonrpc":"2.0","id":1,"result":[{"type":"CALL"}]}`),
+			traceStatusCode:   200,
+			expectError:       false,
+		},
+		{
+			name:              "archive_passes_trace_fails_with_32000_error",
+			archiveEnabled:    true,
+			traceEnabled:      true,
+			archiveResponse:   []byte(`{"result":"0x123"}`),
+			archiveStatusCode: 200,
+			traceResponse:     []byte(`{"jsonrpc":"2.0","id":0,"error":{"code":-32000,"message":"block pruned: 183392636 vs 179652199"}}`),
+			traceStatusCode:   200,
+			expectError:       true,
+			expectedErrMsg:    "trace block check failed",
+		},
+		{
+			name:              "archive_passes_trace_fails_method_not_found",
+			archiveEnabled:    true,
+			traceEnabled:      true,
+			archiveResponse:   []byte(`{"result":"0x123"}`),
+			archiveStatusCode: 200,
+			traceResponse:     []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`),
+			traceStatusCode:   200,
+			expectError:       true,
+			expectedErrMsg:    "trace block check failed",
+		},
+		{
+			name:              "archive_disabled_no_checks_run",
+			archiveEnabled:    false,
+			traceEnabled:      true, // Should be ignored when archive is disabled
+			archiveResponse:   nil,
+			archiveStatusCode: 0,
+			traceResponse:     nil,
+			traceStatusCode:   0,
+			expectError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHTTPClient := din_http.NewMockIHTTPClient(ctrl)
+
+			// Set up mock expectations based on test case
+			if tt.archiveEnabled && tt.archiveResponse != nil {
+				// First call is for archive check (eth_getBalance)
+				firstCall := mockHTTPClient.EXPECT().
+					Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(tt.archiveResponse, &tt.archiveStatusCode, nil).
+					Times(1)
+
+				// Second call is for trace check (debug_traceBlockByNumber) - only if enabled
+				if tt.traceEnabled && tt.traceResponse != nil {
+					mockHTTPClient.EXPECT().
+						Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(tt.traceResponse, &tt.traceStatusCode, nil).
+						Times(1).
+						After(firstCall)
+				}
+			}
+
+			// Create network
+			n, err := NewNetwork("ethereum", EVMHandler, utils.Environment("test"), "8000")
+			require.NoError(t, err)
+			n.HttpClient = mockHTTPClient
+			n.RequestAttemptCount = 1
+			n.ArchiveEnabled = tt.archiveEnabled
+			n.ArchiveTraceBlockByNumberEnabled = tt.traceEnabled
+			n.logger = logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
+
+			// Set the EVM handler
+			config := &networklib.NetworkConfig{
+				Name:    "ethereum",
+				Type:    string(EVMHandler),
+				ChainID: "0x1",
+			}
+			require.NoError(t, n.SetHandler(networklib.NewEVMHandler(config)))
+
+			// Create provider with enough block history
+			provider, err := NewProvider("http://test.com")
+			require.NoError(t, err)
+			provider.AddBlockEntry(400, Healthy, 5)
+			provider.AddBlockEntry(400, Healthy, 5)
+
+			// Call performArchiveCheck with currentBlock = 400 (quarterBlock = 100)
+			err = n.performArchiveCheck(provider, 400)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedErrMsg != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestHasOtherHealthyProviders(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

Adds an optional `debug_traceBlockByNumber` check to the archive health check flow for MetaMask compliance requirements. This verifies that providers support trace/debug capabilities in addition to the existing `eth_getBalance` archive check.

### New Configuration

```caddyfile
networks {
    eth {
        archive_enabled true
        archive_trace_block_by_number true
    }
}
```

### Behavior

| archive_enabled | archive_trace_block_by_number | Result |
|-----------------|-------------------------------|--------|
| false | false | No archive checks |
| false | true | No archive checks |
| true | false | Only eth_getBalance |
| true | true | eth_getBalance + debug_traceBlockByNumber |

### Request Payload

```json
{
  "jsonrpc": "2.0",
  "method": "debug_traceBlockByNumber",
  "id": 1,
  "params": ["0xBLOCK_HEX", {"tracer": "callTracer", "timeout": "30s", "onlyTopCall": true}]
}
```

### Failure Handling

- Uses same block number as existing archive check (quarter-height: `currentBlock / 4`)
- Failures return **Warning** status (not Unhealthy), keeping provider in traffic rotation
- Properly detects JSON-RPC errors (e.g., `-32000 block pruned`) even on HTTP 200 responses
- Failures logged via `logProviderWarning()` with `health_status=Warning` label

### Files Changed

- `modules/consts.go` - Added default constant
- `modules/network.go` - Added struct fields, flag tracking, trace check integration
- `modules/caddy_unmarshaller.go` - Added Caddyfile parsing
- `lib/network/json_rpc_client.go` - Added shared helper function
- `lib/network/evm_handler.go` - Added EVM-specific trace methods

