### PR TITLE
feat(docker): fix log ingest in LGTM stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Ensure bash is used for all shell commands to guarantee cross-environment reproducibility
 SHELL := /bin/bash
 
-.PHONY: help build run test test-verbose test-coverage test-race clean secure dev-deps lint format check-deps benchmark profile docker-build docker-run
+.PHONY: help build run test test-verbose test-coverage test-race clean secure dev-deps lint format check-deps benchmark profile docker-build docker-run docker-compose
 
 # Default target
 .DEFAULT_GOAL := help
@@ -162,6 +162,10 @@ docker-build: ## Build Docker image
 docker-run: ## Run Docker container
 	@echo "$(GREEN)Running Docker container...$(NC)"
 	docker run -p 80:80 -p 8443:443 localhost/din-caddy
+
+docker-compose: ## Run Caddy monitored by the LGTM stack
+	@echo "$(GREEN)Running Docker container with LGTM stack...$(NC)"
+	UID=$(id -u) GID=$(id -g) docker-compose up -d
 
 ## Utility Commands
 clean: ## Clean build artifacts and test files

--- a/compose.yml
+++ b/compose.yml
@@ -17,6 +17,7 @@ services:
     ports:
       - 2019:2019
       - 8000:8000
+    user: "${UID}:${GID}"
     volumes:
       - ./Caddyfile.private:/etc/caddy/Caddyfile
       - ./caddy-data:/srv
@@ -42,6 +43,7 @@ services:
     networks:
       - din-network
     command: ["--config=/etc/otel/config/config.yml"]
+    user: "${UID}:${GID}"
     volumes:
       - ./services/otel-collector/config.yml:/etc/otel/config/config.yml
       - ./caddy-data:/srv


### PR DESCRIPTION
While developing the metric creation for the "Anomaly detection based error rate" requirement in "SignOz update based on Issue 1390", I noticed that log ingestion wasn't working when running Caddy with the LGTM stack.  This happens because the Caddy server, running as root, creates the `caddy.log` file with very restrictive permissions.

The solution is to run both the `din-caddy` image and the `opentelemetry-collector-contrib` image using the host OS user's `UID` and `GID`.  The syntax for running this is a little awkward to continuously type, so I also added the `docker-compose` `Make` recipe.

Now run Caddy with the LGTM stack using the following command:

```
make docker-compose
```