### PR TITLE
Add API key to loopback calls

### DIFF
--- a/modules/caddy_unmarshaller.go
+++ b/modules/caddy_unmarshaller.go
@@ -27,7 +27,7 @@ type caddyfileParser struct {
 	middleware       *DinMiddleware
 	dispenser        *caddyfile.Dispenser
 	siweSignerClient siwe.ISIWESignerClient
-	caddyPort        string
+	loopbackConfig   LoopbackConfig
 }
 
 // newCaddyfileParser creates a new parser instance
@@ -105,6 +105,8 @@ func (p *caddyfileParser) parseDirective() error {
 	switch p.dispenser.Val() {
 	case "port":
 		return p.parsePort()
+	case "loopback_api_key":
+		return p.parseLoopbackApiKey()
 	case "siwe-signer":
 		return p.parseSiweSigner()
 	case "networks":
@@ -123,14 +125,21 @@ func (p *caddyfileParser) parseDirective() error {
 	}
 }
 
+func (p *caddyfileParser) parseLoopbackApiKey() error {
+	p.dispenser.Next()
+	p.loopbackConfig.ApiKey = p.dispenser.Val()
+	p.middleware.LoopbackConfig.ApiKey = p.loopbackConfig.ApiKey
+	return nil
+}
+
 // parsePort handles port configuration
 func (p *caddyfileParser) parsePort() error {
 	p.dispenser.Next()
-	p.caddyPort = p.dispenser.Val()
-	if p.caddyPort == "" {
-		p.caddyPort = DefaultPort
+	p.loopbackConfig.Port = p.dispenser.Val()
+	if p.loopbackConfig.Port == "" {
+		p.loopbackConfig.Port = DefaultPort
 	}
-	p.middleware.CaddyPort = p.caddyPort
+	p.middleware.LoopbackConfig.Port = p.loopbackConfig.Port
 	return nil
 }
 
@@ -184,14 +193,17 @@ func (p *caddyfileParser) parseNetworks() error {
 
 // parseNetwork handles individual network configuration
 func (p *caddyfileParser) parseNetwork(networkName string, parentNesting int) error {
-	// Ensure caddyPort is set
-	if p.caddyPort == "" {
-		p.caddyPort = DefaultPort
+	// Ensure loopback config is set
+	if p.loopbackConfig.Port == "" {
+		p.loopbackConfig.Port = DefaultPort
+	}
+	if p.loopbackConfig.ApiKey == "" {
+		p.loopbackConfig.ApiKey = DefaultLoopbackApiKey
 	}
 
 	// Create network if it doesn't exist
 	if _, exists := p.middleware.Networks[networkName]; !exists {
-		newNetwork, err := NewNetwork(networkName, "", p.middleware.Env, p.caddyPort)
+		newNetwork, err := NewNetwork(networkName, "", p.middleware.Env, p.loopbackConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create network '%s': %w", networkName, err)
 		}

--- a/modules/consts.go
+++ b/modules/consts.go
@@ -64,6 +64,7 @@ const (
 
 	// General constants
 	DefaultPort = "8000"
+	DefaultLoopbackApiKey = "din-loopback-key"
 
 	// Additional Status Codes
 	StatusOriginUnreachable = 523

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -93,6 +93,11 @@ type DynamicLoadBalancingConfig struct {
 	watcherScoreSyncQuit chan struct{}
 }
 
+type LoopbackConfig struct {
+	Port string
+	ApiKey string
+}
+
 type DinMiddleware struct {
 	// A map of network paths to network objects
 	Networks map[string]*network `json:"networks"`
@@ -106,8 +111,8 @@ type DinMiddleware struct {
 	// The default siwe signer object
 	DefaultSiweSigner *siwe.SigningConfig
 
-	// The Caddy port to listen on
-	CaddyPort string
+	// Configuration for Loopback Calls
+	LoopbackConfig LoopbackConfig
 
 	// The default siwe signer client
 	SiweSignerClient siwe.ISIWESignerClient
@@ -256,8 +261,11 @@ func (d *DinMiddleware) initializeDefaults() {
 	if d.Registry.Priority == 0 {
 		d.Registry.Priority = DefaultRegistryPriority
 	}
-	if d.CaddyPort == "" {
-		d.CaddyPort = DefaultPort
+	if d.LoopbackConfig.Port == "" {
+		d.LoopbackConfig.Port = DefaultPort
+	}
+	if d.LoopbackConfig.ApiKey == "" {
+		d.LoopbackConfig.ApiKey = DefaultLoopbackApiKey
 	}
 	// Set retry defaults
 	if d.Registry.RetryMaxAttempts == 0 {

--- a/modules/din_middleware_helpers.go
+++ b/modules/din_middleware_helpers.go
@@ -154,7 +154,7 @@ func (d *DinMiddleware) processRegistryData(registryData *din.DinRegistryData) {
 func (d *DinMiddleware) addNetworkWithRegistryData(regNetwork *din.Network) error {
 	// Step 2: Create a new network without type - will be set via Caddyfile configuration
 	// Registry networks must have explicit 'type' configuration in Caddyfile like all other networks
-	network, err := NewNetwork(regNetwork.ProxyName, "", d.Env, d.CaddyPort)
+	network, err := NewNetwork(regNetwork.ProxyName, "", d.Env, d.LoopbackConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create network '%s': %w", regNetwork.ProxyName, err)
 	}

--- a/modules/din_middleware_helpers_test.go
+++ b/modules/din_middleware_helpers_test.go
@@ -213,7 +213,10 @@ func TestAddNetworkWithRegistryData(t *testing.T) {
 				Networks:    make(map[string]*network),
 				testMode:    true,
 				Env:         utils.Environment("test"),
-				CaddyPort:   "8080",
+				LoopbackConfig: LoopbackConfig{
+					Port:   "8080",
+					ApiKey: DefaultLoopbackApiKey,
+				},
 				machineID:   "test-machine-id",
 			}
 
@@ -323,7 +326,10 @@ func TestAddNetworkFromRegistryDataWorksWithDynamicLoadBalancing(t *testing.T) {
 				Networks:    make(map[string]*network),
 				testMode:    true,
 				Env:         utils.Environment("test"),
-				CaddyPort:   "8080",
+				LoopbackConfig: LoopbackConfig{
+					Port:   "8080",
+					ApiKey: DefaultLoopbackApiKey,
+				},
 				machineID:   "test-machine-id",
 				DynamicLoadBalancing: DynamicLoadBalancingConfig{
 					Enabled:             tt.dynamicLoadBalancingEnabled,
@@ -455,7 +461,10 @@ func TestUpdateNetworkWithRegistryData(t *testing.T) {
 				},
 				testMode:  true,
 				Env:       utils.Environment("test"),
-				CaddyPort: "8080",
+				LoopbackConfig: LoopbackConfig{
+					Port:   "8080",
+					ApiKey: DefaultLoopbackApiKey,
+				},
 				machineID: "test-machine-id",
 			}
 
@@ -997,7 +1006,7 @@ func TestProcessHCMethodResponseAsyncLogging(t *testing.T) {
 			loggerClient := &logger.LoggerClient{Logger: observedLogger}
 
 			// Create test network with proper handler initialization
-			network, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8080")
+			network, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8080", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			network.logger = loggerClient
 			network.Name = "test/eth" // Update name to match test expectations

--- a/modules/din_middleware_test.go
+++ b/modules/din_middleware_test.go
@@ -611,7 +611,9 @@ func TestProcessHCMethodResponseAsync(t *testing.T) {
 		{
 			name: "Successful processing",
 			setupNetwork: func(t *testing.T, netw *network) {
-				netw.CaddyPort = "8000"
+				netw.LoopbackConfig.Port = "8000"
+				netw.LoopbackConfig.ApiKey = DefaultLoopbackApiKey
+
 
 				mockCtrl := gomock.NewController(t)
 				// defer mockCtrl.Finish() // Defers in callbacks can be tricky; manage Finish in t.Run if issues arise.
@@ -643,7 +645,8 @@ func TestProcessHCMethodResponseAsync(t *testing.T) {
 		{
 			name: "HCMethod does not match",
 			setupNetwork: func(t *testing.T, netw *network) {
-				netw.CaddyPort = "8001" // Add a dummy CaddyPort to prevent nil errors if getBlockByNumber is unexpectedly called
+				netw.LoopbackConfig.Port = "8001"
+				netw.LoopbackConfig.ApiKey = DefaultLoopbackApiKey
 				// No HttpClient mock needed as getBlockByNumber ideally won't be called
 			},
 			netPath:             "test/eth",
@@ -655,7 +658,8 @@ func TestProcessHCMethodResponseAsync(t *testing.T) {
 		{
 			name: "Response body empty",
 			setupNetwork: func(t *testing.T, netw *network) {
-				netw.CaddyPort = "8002" // Add a dummy CaddyPort
+				netw.LoopbackConfig.Port = "8002"
+				netw.LoopbackConfig.ApiKey = DefaultLoopbackApiKey
 				// No HttpClient mock needed
 			},
 			netPath:             "test/eth",
@@ -667,7 +671,8 @@ func TestProcessHCMethodResponseAsync(t *testing.T) {
 		{
 			name: "Network object HCMethod empty",
 			setupNetwork: func(t *testing.T, netw *network) {
-				netw.CaddyPort = "8003" // Add a dummy CaddyPort
+				netw.LoopbackConfig.Port = "8003"
+				netw.LoopbackConfig.ApiKey = DefaultLoopbackApiKey
 				// No HttpClient mock needed since we expect early return due to method mismatch
 			},
 			netPath:             "test/eth",
@@ -715,7 +720,7 @@ func TestProcessHCMethodResponseAsync(t *testing.T) {
 			// mockCtrl and mockHttpClient setup will be handled by tt.setupNetwork for relevant cases
 
 			// Create a proper network with handler using NewNetwork
-			netw, err := NewNetwork("test", EVMHandler, utils.EnvTest, "8000")
+			netw, err := NewNetwork("test", EVMHandler, utils.EnvTest, LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			if err != nil {
 				t.Fatalf("Failed to create network: %v", err)
 			}

--- a/modules/network.go
+++ b/modules/network.go
@@ -40,13 +40,15 @@ type caddyfileConfigFlags struct {
 
 var _ json.Unmarshaler = (*network)(nil)
 
+
+
 type network struct {
 	Name             string
 	HandlerType      HandlerType `json:"handler"` // Network handler type for handler registry
 	quit             chan struct{}
 	HttpClient       din_http.IHTTPClient
 	PrometheusClient prom.IPrometheusClient
-	CaddyPort        string
+	LoopbackConfig   LoopbackConfig
 	logger           *logger.LoggerClient
 	machineID        string
 	Environment      utils.Environment
@@ -89,7 +91,7 @@ type network struct {
 // NewNetwork creates a new network with the given name and handler type
 // Only put values in the struct definition that are constant
 // Don't kick off any Background processes here
-func NewNetwork(name string, handlerType HandlerType, environment utils.Environment, caddyPort string) (*network, error) {
+func NewNetwork(name string, handlerType HandlerType, environment utils.Environment, loopbackConfig LoopbackConfig) (*network, error) {
 	n := &network{
 		Name:        name,
 		HandlerType: handlerType, // Used for handler selection
@@ -108,7 +110,7 @@ func NewNetwork(name string, handlerType HandlerType, environment utils.Environm
 		ArchiveEnabled:           DefaultArchiveEnabled,
 		Environment:              environment,
 		Providers:                make(map[string]*provider),
-		CaddyPort:                caddyPort,
+		LoopbackConfig:           loopbackConfig,
 		// Initialize Caddyfile flags tracking
 		CaddyfileFlags: &caddyfileConfigFlags{
 			// If handlerType is provided (not empty), mark it as set in Caddyfile
@@ -730,12 +732,12 @@ func (n *network) getLatestBlockEntry() *blockHistoryEntry {
 
 // checkSelfLoopbackHealth performs a health check on the router's own endpoint (loopback)
 func (n *network) checkSelfLoopbackHealth() (*getLatestBlockNumberResult, error) {
-	if n.CaddyPort == "" {
+	if n.LoopbackConfig.Port == "" {
 		return nil, errors.New("Caddy port is not set")
 	}
 
 	// Create synthetic request context for consistent logging (this is critical for logFailedAttempt)
-	providerHost := fmt.Sprintf("127.0.0.1:%s", n.CaddyPort) // Use loopback address as provider identifier
+	providerHost := fmt.Sprintf("127.0.0.1:%s", n.LoopbackConfig.Port) // Use loopback address as provider identifier
 	healthCheckMethod := n.handler.GetHealthCheckMethod()
 
 	repl, genericContext, _ := createHealthCheckRequestContext(n.Name, providerHost, healthCheckMethod, n)
@@ -750,11 +752,12 @@ func (n *network) checkSelfLoopbackHealth() (*getLatestBlockNumberResult, error)
 	}
 
 	// Use the loopback URL as the target
-	loopbackURL := fmt.Sprintf("http://127.0.0.1:%s/%s", n.CaddyPort, n.Name)
+	loopbackURL := fmt.Sprintf("http://127.0.0.1:%s/%s", n.LoopbackConfig.Port, n.Name)
 
 	// Create headers for the request
 	headers := map[string]string{
 		"Content-Type": "application/json",
+		"Din-Api-Key":  n.LoopbackConfig.ApiKey,
 	}
 
 	// Use handler's GetLatestBlockNumber method but maintain detailed logging
@@ -807,7 +810,7 @@ func (n *network) checkSelfLoopbackHealth() (*getLatestBlockNumberResult, error)
 func (n *network) getBlockByNumber(blockNumber int64) (interface{}, error) {
 	n.logger.Debug("getBlockByNumber called", zap.Int64("blockNumber", blockNumber), zap.String("networkName", n.Name))
 
-	if n.CaddyPort == "" {
+	if n.LoopbackConfig.Port == "" {
 		return nil, errors.New("Caddy port is not set")
 	}
 
@@ -823,9 +826,10 @@ func (n *network) getBlockByNumber(blockNumber int64) (interface{}, error) {
 	}
 
 	// Use loopback URL to make request through the Din middleware
-	url := fmt.Sprintf("http://127.0.0.1:%s/%s", n.CaddyPort, n.Name)
+	url := fmt.Sprintf("http://127.0.0.1:%s/%s", n.LoopbackConfig.Port, n.Name)
 	headers := map[string]string{
 		"Content-Type": "application/json",
+		"Din-Api-Key":  n.LoopbackConfig.ApiKey,
 	}
 
 	// Get the block by number method directly from the handler

--- a/modules/network_evaluate_health_test.go
+++ b/modules/network_evaluate_health_test.go
@@ -150,7 +150,7 @@ func TestEvaluateProviderHealth(t *testing.T) {
 			mockHandler := networklib.NewMockNetworkHandler(ctrl)
 
 			// Create network
-			n, err := NewNetwork("test-network", EVMHandler, utils.Environment("test"), "")
+			n, err := NewNetwork("test-network", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 
 			// Configure network

--- a/modules/network_get_block_test.go
+++ b/modules/network_get_block_test.go
@@ -47,7 +47,7 @@ func TestGetBlockByNumber(t *testing.T) {
 				statusCode := 200
 				mockHTTP.EXPECT().Post(
 					"http://127.0.0.1:8080/test-network",
-					map[string]string{"Content-Type": "application/json"},
+					map[string]string{"Content-Type": "application/json", "Din-Api-Key": DefaultLoopbackApiKey},
 					gomock.Any(),
 					nil,
 				).Return(responseBody, &statusCode, nil)
@@ -183,7 +183,7 @@ func TestGetBlockByNumber(t *testing.T) {
 			mockHTTP := din_http.NewMockIHTTPClient(ctrl)
 
 			// Create network
-			n, err := NewNetwork("test-network", EVMHandler, utils.Environment("test"), tt.caddyPort)
+			n, err := NewNetwork("test-network", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: tt.caddyPort, ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 
 			// Set dependencies
@@ -276,7 +276,7 @@ func TestGetBlockByNumberIntegration(t *testing.T) {
 			mockHTTP := din_http.NewMockIHTTPClient(ctrl)
 
 			// Create network with specific type
-			n, err := NewNetwork("test-network", HandlerType(tt.networkType), utils.Environment("test"), "8080")
+			n, err := NewNetwork("test-network", HandlerType(tt.networkType), utils.Environment("test"), LoopbackConfig{Port: "8080", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 
 			// Set dependencies

--- a/modules/network_loopback_test.go
+++ b/modules/network_loopback_test.go
@@ -154,7 +154,10 @@ func TestLoopbackHealthCheck(t *testing.T) {
 			mockProm := prom.NewMockIPrometheusClient(ctrl)
 
 			// Create network
-			n, err := NewNetwork("test-network", EVMHandler, utils.Environment("test"), tt.caddyPort)
+			n, err := NewNetwork("test-network", EVMHandler, utils.Environment("test"), LoopbackConfig{
+				Port: tt.caddyPort,
+				ApiKey: DefaultLoopbackApiKey,
+			})
 			assert.NoError(t, err)
 
 			// Set dependencies
@@ -285,7 +288,7 @@ func TestSendHealthCheckMetric(t *testing.T) {
 			mockProm := prom.NewMockIPrometheusClient(ctrl)
 
 			// Create network
-			n, err := NewNetwork("test-network", EVMHandler, utils.Environment(tt.environment), "8080")
+			n, err := NewNetwork("test-network", EVMHandler, utils.Environment(tt.environment), LoopbackConfig{Port: "8080", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 
 			// Set dependencies

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -63,7 +63,7 @@ func TestHandleErrorWithGracePeriod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			n.HCThreshold = tt.hcThreshold
 
@@ -120,7 +120,7 @@ func TestIsStalled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			n.ProviderBlockHistorySize = tt.historySize
 
@@ -228,7 +228,7 @@ func TestGetLatestHealthyBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			n.Providers = make(map[string]*provider)
 
@@ -333,7 +333,7 @@ func TestProcessBlockNumberResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork("test", "", utils.Environment("test"), "8000")
+			n, err := NewNetwork("test", "", utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			// Set handler for tests
 			config := &networklib.NetworkConfig{
@@ -458,7 +458,7 @@ func TestArchiveModeCheck(t *testing.T) {
 				networkType = string(StarknetHandler)
 			}
 
-			n, err := NewNetwork(tt.networkName, "", utils.Environment("test"), "8000")
+			n, err := NewNetwork(tt.networkName, "", utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			n.HttpClient = mockHTTPClient
 			n.RequestAttemptCount = 1
@@ -571,7 +571,7 @@ func TestHasOtherHealthyProviders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			n.Providers = make(map[string]*provider)
 
@@ -642,7 +642,7 @@ func TestBlockJumpBehavior(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+			n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			n.BlockJumpLimit = tt.blockJumpLimit
 			n.Providers = make(map[string]*provider)
@@ -757,7 +757,10 @@ func TestGetLatestBlockNumber(t *testing.T) {
 			// Create mock logger
 			mockLogger := logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
 
-			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), tt.caddyPort)
+			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), LoopbackConfig{
+				Port: tt.caddyPort,
+				ApiKey: DefaultLoopbackApiKey,
+			})
 			assert.NoError(t, err)
 			n.HttpClient = mockHTTPClient
 			n.logger = mockLogger
@@ -790,7 +793,7 @@ func TestGetLatestBlockNumber(t *testing.T) {
 func newTestNetwork(t *testing.T, name string, historySize int) *network {
 	t.Helper()
 
-	n, _ := NewNetwork(name, EVMHandler, utils.Environment("test"), "8000")
+	n, _ := NewNetwork(name, EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 	n.NetworkBlockHistorySize = historySize
 	// Initialize logger to prevent panic
 	n.logger = logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
@@ -1042,7 +1045,10 @@ func TestCheckSelfLoopbackHealth(t *testing.T) {
 					AnyTimes()
 			}
 
-			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), tt.caddyPort)
+			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), LoopbackConfig{
+				Port: tt.caddyPort,
+				ApiKey: DefaultLoopbackApiKey,
+			})
 			assert.NoError(t, err)
 			if mockHTTPClient != nil {
 				n.HttpClient = mockHTTPClient
@@ -1116,7 +1122,7 @@ func TestNewNetwork(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			network, err := NewNetwork(tt.networkName, HandlerType(tt.networkType), tt.environment, tt.caddyPort)
+			network, err := NewNetwork(tt.networkName, HandlerType(tt.networkType), tt.environment, LoopbackConfig{Port: tt.caddyPort, ApiKey: DefaultLoopbackApiKey})
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -1127,7 +1133,7 @@ func TestNewNetwork(t *testing.T) {
 				assert.Equal(t, tt.networkName, network.Name)
 				assert.Equal(t, HandlerType(tt.networkType), network.HandlerType)
 				assert.Equal(t, tt.environment, network.Environment)
-				assert.Equal(t, tt.caddyPort, network.CaddyPort)
+				assert.Equal(t, tt.caddyPort, network.LoopbackConfig.Port)
 			}
 		})
 	}
@@ -1218,7 +1224,7 @@ func TestNetwork_processBlockNumberResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork("test", "", utils.Environment("test"), "8000")
+			n, err := NewNetwork("test", "", utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			// Set handler for processBlockNumberResponse tests
 			config := &networklib.NetworkConfig{
@@ -1248,7 +1254,7 @@ func intPtr(i int) *int {
 }
 
 func TestNetwork_isStalled(t *testing.T) {
-	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 	assert.NoError(t, err)
 	n.ProviderBlockHistorySize = 3
 
@@ -1273,7 +1279,7 @@ func TestNetwork_isStalled(t *testing.T) {
 }
 
 func TestNetwork_allProvidersStalled(t *testing.T) {
-	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 	assert.NoError(t, err)
 	n.ProviderBlockHistorySize = 3
 
@@ -1303,7 +1309,7 @@ func TestNetwork_allProvidersStalled(t *testing.T) {
 }
 
 func TestNetwork_getLatestHealthyBlock(t *testing.T) {
-	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 	assert.NoError(t, err)
 
 	// Test empty providers
@@ -1328,7 +1334,7 @@ func TestNetwork_getLatestHealthyBlock(t *testing.T) {
 }
 
 func TestNetwork_hasOtherHealthyProviders(t *testing.T) {
-	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 	assert.NoError(t, err)
 
 	provider1, err := NewProvider("http://provider1.com")
@@ -1357,7 +1363,7 @@ func TestNetwork_hasOtherHealthyProviders(t *testing.T) {
 }
 
 func TestNetwork_AddNetworkBlockEntry(t *testing.T) {
-	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 	assert.NoError(t, err)
 	n.NetworkBlockHistorySize = 3
 
@@ -1380,7 +1386,7 @@ func TestNetwork_AddNetworkBlockEntry(t *testing.T) {
 }
 
 func TestNetwork_getLatestBlockEntry(t *testing.T) {
-	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), "8000")
+	n, err := NewNetwork("test", EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 	assert.NoError(t, err)
 
 	// Test empty history
@@ -1428,7 +1434,7 @@ func TestNetwork_ExtractBlockHashByNetworkType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), "8000")
+			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 
 			// Initialize logger to prevent panic
@@ -1482,7 +1488,7 @@ func TestDetermineNetworkTypeFromNetworkName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test this through NewNetwork since the detection logic is internal
-			n, err := NewNetwork(tt.networkName, HandlerType(tt.expectedType), utils.Environment("test"), "8000")
+			n, err := NewNetwork(tt.networkName, HandlerType(tt.expectedType), utils.Environment("test"), LoopbackConfig{Port: "8000", ApiKey: DefaultLoopbackApiKey})
 			assert.NoError(t, err)
 			assert.Equal(t, HandlerType(tt.expectedType), n.HandlerType)
 		})
@@ -1508,7 +1514,7 @@ func TestNetworkSetHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, err := NewNetwork("test-network", "", utils.EnvTest, "2019")
+			n, err := NewNetwork("test-network", "", utils.EnvTest, LoopbackConfig{Port: "2019", ApiKey: DefaultLoopbackApiKey})
 			require.NoError(t, err)
 
 			err = n.SetHandler(tt.handler)
@@ -1524,7 +1530,7 @@ func TestNetworkSetHandler(t *testing.T) {
 }
 
 func TestNetworkSetHandler_AvoidDuplicates(t *testing.T) {
-	n, err := NewNetwork("test-network", "", utils.EnvTest, "2019")
+	n, err := NewNetwork("test-network", "", utils.EnvTest, LoopbackConfig{Port: "2019", ApiKey: DefaultLoopbackApiKey})
 	require.NoError(t, err)
 
 	handler := networklib.NewEVMHandler(&networklib.NetworkConfig{})


### PR DESCRIPTION
We're trying to narrow down the number of api-key-less calls coming in, and at this point most of them are probably loopback calls. Because of how data gets from the caddyfile to the loopback check, this ended up being a more invasive change than I expected, but I believe I got everything and some of the existing tests needed to be updated to expect the new header, so it's definitely coming through.