### PR TITLE
Fix CI startup delays with async health checks

### DIFF
--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -415,6 +415,7 @@ func (d *DinMiddleware) validateNetworkConfiguration(networkName string, network
 
 // startBackgroundServices starts health checks and registry sync
 func (d *DinMiddleware) startBackgroundServices() error {
+	// Start health checks
 	if err := d.startHealthChecks(); err != nil {
 		return fmt.Errorf("error starting healthchecks: %w", err)
 	}

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -477,15 +476,14 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 		provider.host = d.ensureUniqueProviderHost(networkName, parsedUrl, provider.Headers)
 	}
 
-	// Initialize authentication (skip if in test mode or DIN_SKIP_AUTH is set)
-	skipAuth := d.testMode || os.Getenv("DIN_SKIP_AUTH") == "true"
-	if provider.OIDCClient != nil && !skipAuth {
+	// Initialize authentication (skip if in test mode)
+	if provider.OIDCClient != nil && !d.testMode {
 		// Initialize OIDC client
 		if err := provider.OIDCClient.Start(logger.Logger); err != nil {
 			d.logger.Error("Failed to start OIDC client", zap.String("provider", provider.HttpUrl), zap.Error(err))
 			return err
 		}
-	} else if provider.Auth != nil && !skipAuth {
+	} else if provider.Auth != nil && !d.testMode {
 		// Initialize SIWE auth
 		if err := provider.Auth.Start(logger.Logger); err != nil {
 			d.logger.Warn("Error starting authentication", zap.String("provider", provider.HttpUrl))

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -477,14 +477,14 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 		provider.host = d.ensureUniqueProviderHost(networkName, parsedUrl, provider.Headers)
 	}
 
-	// Initialize authentication (skip if in test mode)
-	if provider.OIDCClient != nil && !d.testMode {
+	// Initialize authentication
+	if provider.OIDCClient != nil {
 		// Initialize OIDC client
 		if err := provider.OIDCClient.Start(logger.Logger); err != nil {
 			d.logger.Error("Failed to start OIDC client", zap.String("provider", provider.HttpUrl), zap.Error(err))
 			return err
 		}
-	} else if provider.Auth != nil && !d.testMode {
+	} else if provider.Auth != nil {
 		// Initialize SIWE auth
 		if err := provider.Auth.Start(logger.Logger); err != nil {
 			d.logger.Warn("Error starting authentication", zap.String("provider", provider.HttpUrl))

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -917,13 +917,42 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	return nil
 }
 
-// StartHealthchecks starts a background goroutine to monitor all of the networks' overall health and the health of its providers
+// MaxConcurrentHealthChecks limits how many networks can run health checks simultaneously
+// This prevents resource exhaustion when there are many networks
+const MaxConcurrentHealthChecks = 10
+
+// StartHealthchecks starts background goroutines to monitor all networks' health
+// Health checks run asynchronously with throttled concurrency to prevent resource exhaustion
 func (d *DinMiddleware) startHealthChecks() error {
-	d.logger.Info("Starting healthchecks")
-	for _, network := range d.Networks {
-		d.logger.Info("Starting healthcheck for network", zap.String("network", network.Name))
-		network.startHealthcheck()
-	}
+	d.logger.Info("Starting healthchecks asynchronously",
+		zap.Int("network_count", len(d.Networks)),
+		zap.Int("max_concurrent", MaxConcurrentHealthChecks))
+
+	// Run all health checks in a background goroutine - don't block Provision()
+	go func() {
+		// Use a semaphore to limit concurrent health checks
+		sem := make(chan struct{}, MaxConcurrentHealthChecks)
+		var wg sync.WaitGroup
+
+		for name, net := range d.Networks {
+			wg.Add(1)
+			go func(networkName string, n *network) {
+				defer wg.Done()
+
+				// Acquire semaphore slot (blocks if at max concurrency)
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				d.logger.Debug("Starting healthcheck for network", zap.String("network", networkName))
+				n.startHealthcheck()
+			}(name, net)
+		}
+
+		// Wait for all health checks to complete their initial run
+		wg.Wait()
+		d.logger.Info("All network healthchecks initiated")
+	}()
+
 	return nil
 }
 

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -417,29 +416,8 @@ func (d *DinMiddleware) validateNetworkConfiguration(networkName string, network
 
 // startBackgroundServices starts health checks and registry sync
 func (d *DinMiddleware) startBackgroundServices() error {
-	// Check for startup delay (allows HTTP server to start before health checks begin)
-	// This is especially useful for large configs with many networks
-	startupDelay := time.Duration(0)
-	if delayStr := os.Getenv("DIN_HEALTHCHECK_DELAY_SEC"); delayStr != "" {
-		if delaySec, err := strconv.Atoi(delayStr); err == nil && delaySec > 0 {
-			startupDelay = time.Duration(delaySec) * time.Second
-		}
-	}
-
-	// Start health checks (with optional delay)
-	if startupDelay > 0 {
-		d.logger.Info("Deferring health checks to allow HTTP server to start",
-			zap.Duration("delay", startupDelay))
-		go func() {
-			time.Sleep(startupDelay)
-			if err := d.startHealthChecks(); err != nil {
-				d.logger.Error("Failed to start health checks after delay", zap.Error(err))
-			}
-		}()
-	} else {
-		if err := d.startHealthChecks(); err != nil {
-			return fmt.Errorf("error starting healthchecks: %w", err)
-		}
+	if err := d.startHealthChecks(); err != nil {
+		return fmt.Errorf("error starting healthchecks: %w", err)
 	}
 
 	// Start registry sync if enabled

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -415,9 +417,29 @@ func (d *DinMiddleware) validateNetworkConfiguration(networkName string, network
 
 // startBackgroundServices starts health checks and registry sync
 func (d *DinMiddleware) startBackgroundServices() error {
-	// Start health checks
-	if err := d.startHealthChecks(); err != nil {
-		return fmt.Errorf("error starting healthchecks: %w", err)
+	// Check for startup delay (allows HTTP server to start before health checks begin)
+	// This is especially useful for large configs with many networks
+	startupDelay := time.Duration(0)
+	if delayStr := os.Getenv("DIN_HEALTHCHECK_DELAY_SEC"); delayStr != "" {
+		if delaySec, err := strconv.Atoi(delayStr); err == nil && delaySec > 0 {
+			startupDelay = time.Duration(delaySec) * time.Second
+		}
+	}
+
+	// Start health checks (with optional delay)
+	if startupDelay > 0 {
+		d.logger.Info("Deferring health checks to allow HTTP server to start",
+			zap.Duration("delay", startupDelay))
+		go func() {
+			time.Sleep(startupDelay)
+			if err := d.startHealthChecks(); err != nil {
+				d.logger.Error("Failed to start health checks after delay", zap.Error(err))
+			}
+		}()
+	} else {
+		if err := d.startHealthChecks(); err != nil {
+			return fmt.Errorf("error starting healthchecks: %w", err)
+		}
 	}
 
 	// Start registry sync if enabled
@@ -477,14 +499,15 @@ func (d *DinMiddleware) initializeProvider(networkName string, provider *provide
 		provider.host = d.ensureUniqueProviderHost(networkName, parsedUrl, provider.Headers)
 	}
 
-	// Initialize authentication
-	if provider.OIDCClient != nil {
+	// Initialize authentication (skip if in test mode or DIN_SKIP_AUTH is set)
+	skipAuth := d.testMode || os.Getenv("DIN_SKIP_AUTH") == "true"
+	if provider.OIDCClient != nil && !skipAuth {
 		// Initialize OIDC client
 		if err := provider.OIDCClient.Start(logger.Logger); err != nil {
 			d.logger.Error("Failed to start OIDC client", zap.String("provider", provider.HttpUrl), zap.Error(err))
 			return err
 		}
-	} else if provider.Auth != nil {
+	} else if provider.Auth != nil && !skipAuth {
 		// Initialize SIWE auth
 		if err := provider.Auth.Start(logger.Logger); err != nil {
 			d.logger.Warn("Error starting authentication", zap.String("provider", provider.HttpUrl))

--- a/modules/network.go
+++ b/modules/network.go
@@ -172,7 +172,13 @@ func (n *network) UnmarshalJSON(data []byte) error {
 
 func (n *network) startHealthcheck() {
 	// Start dynamic block lag limit calculation (runs once asynchronously)
-	go n.calculateDynamicBlockLagLimit()
+	// Skip in test environment to reduce startup load and avoid timing issues
+	if n.Environment != "test" {
+		go n.calculateDynamicBlockLagLimit()
+	} else {
+		n.logger.Debug("Skipping dynamic block lag calculation in test environment",
+			zap.String("network", n.Name))
+	}
 
 	n.healthCheck()
 	ticker := time.NewTicker(time.Second * time.Duration(n.HCInterval))

--- a/modules/network.go
+++ b/modules/network.go
@@ -172,13 +172,7 @@ func (n *network) UnmarshalJSON(data []byte) error {
 
 func (n *network) startHealthcheck() {
 	// Start dynamic block lag limit calculation (runs once asynchronously)
-	// Skip in test environment to reduce startup load and avoid timing issues
-	if n.Environment != "test" {
-		go n.calculateDynamicBlockLagLimit()
-	} else {
-		n.logger.Debug("Skipping dynamic block lag calculation in test environment",
-			zap.String("network", n.Name))
-	}
+	go n.calculateDynamicBlockLagLimit()
 
 	n.healthCheck()
 	ticker := time.NewTicker(time.Second * time.Duration(n.HCInterval))


### PR DESCRIPTION
## Summary

Makes health checks fully async with throttled concurrency (max 10 concurrent) to prevent blocking `Provision()` during startup.

## Problem

With 66+ networks, synchronous health checks during `Provision()` blocked for 160+ seconds, preventing the HTTP server on port 8000 from starting. This caused CI timeouts.

## Solution

Health checks now run in background goroutines with a semaphore limiting max 10 concurrent checks. `Provision()` completes in ~5 seconds while health checks run in the background.