### PR TITLE
feat: method-level failover for JSON-RPC -32601 errors

### DIFF
--- a/lib/network/beacon_handler.go
+++ b/lib/network/beacon_handler.go
@@ -143,6 +143,11 @@ func (h *BeaconChainHandler) ParseResponse(body []byte, statusCode int) error {
 	return nil
 }
 
+func (h *BeaconChainHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	// REST APIs don't have JSON-RPC -32601 semantics
+	return false
+}
+
 func (h *BeaconChainHandler) IsRetryableError(err error, statusCode int) bool {
 	// HTTP server errors are retryable
 	if statusCode >= 500 {

--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -129,6 +129,11 @@ func (h *BitcoinEsploraHandler) ParseResponse(body []byte, statusCode int) error
 	return nil
 }
 
+func (h *BitcoinEsploraHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	// REST APIs don't have JSON-RPC -32601 semantics
+	return false
+}
+
 func (h *BitcoinEsploraHandler) IsRetryableError(err error, statusCode int) bool {
 	// Server errors and rate limits are retryable
 	if statusCode >= 500 || statusCode == 429 {

--- a/lib/network/bitcoin_handler.go
+++ b/lib/network/bitcoin_handler.go
@@ -123,6 +123,10 @@ func (h *BitcoinHandler) IsRetryableError(err error, statusCode int) bool {
 	return IsRetryableJSONRPCError(err, statusCode)
 }
 
+func (h *BitcoinHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	return IsRetryableOnDifferentProviderJSONRPCError(err, statusCode)
+}
+
 // === NEW NETWORK-SPECIFIC METHODS ===
 
 // Chain ID and Namespace methods

--- a/lib/network/evm_handler.go
+++ b/lib/network/evm_handler.go
@@ -174,6 +174,10 @@ func (h *EVMHandler) IsRetryableError(err error, statusCode int) bool {
 	return IsRetryableJSONRPCError(err, statusCode)
 }
 
+func (h *EVMHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	return IsRetryableOnDifferentProviderJSONRPCError(err, statusCode)
+}
+
 // === NEW NETWORK-SPECIFIC METHODS ===
 
 // Chain ID and Namespace methods

--- a/lib/network/handler_test.go
+++ b/lib/network/handler_test.go
@@ -64,6 +64,10 @@ func (m *MockHandler) IsRetryableError(err error, statusCode int) bool {
 	return false
 }
 
+func (m *MockHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	return false
+}
+
 // === NEW: Network-Specific Methods (Mock implementations) ===
 
 // Chain ID and Namespace

--- a/lib/network/handlers.go
+++ b/lib/network/handlers.go
@@ -34,6 +34,9 @@ type NetworkHandler interface {
 	// === Response Handling ===
 	ParseResponse(body []byte, statusCode int) error
 	IsRetryableError(err error, statusCode int) bool
+	// IsRetryableOnDifferentProvider returns true if this error should be retried
+	// on a different provider but not the same one (e.g., -32601 method not found)
+	IsRetryableOnDifferentProvider(err error, statusCode int) bool
 
 	// === Block Operations ===
 	FormatBlockHeight(blockNum int64) string

--- a/lib/network/interface_mock.go
+++ b/lib/network/interface_mock.go
@@ -18,8 +18,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-var _ NetworkHandler = (*MockNetworkHandler)(nil)
-
 // MockNetworkHandler is a mock of NetworkHandler interface.
 type MockNetworkHandler struct {
 	ctrl     *gomock.Controller
@@ -188,6 +186,21 @@ func (mr *MockNetworkHandlerMockRecorder) GetBlockInfoMethod() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockInfoMethod", reflect.TypeOf((*MockNetworkHandler)(nil).GetBlockInfoMethod))
 }
 
+// GetBlockTimestamp mocks base method.
+func (m *MockNetworkHandler) GetBlockTimestamp(httpUrl string, headers map[string]string, httpClient http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockTimestamp", httpUrl, headers, httpClient, authClient, requestAttempts, blockNumber)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockTimestamp indicates an expected call of GetBlockTimestamp.
+func (mr *MockNetworkHandlerMockRecorder) GetBlockTimestamp(httpUrl, headers, httpClient, authClient, requestAttempts, blockNumber any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockTimestamp", reflect.TypeOf((*MockNetworkHandler)(nil).GetBlockTimestamp), httpUrl, headers, httpClient, authClient, requestAttempts, blockNumber)
+}
+
 // GetChainID mocks base method.
 func (m *MockNetworkHandler) GetChainID(httpUrl string, headers map[string]string, httpClient http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int) (string, error) {
 	m.ctrl.T.Helper()
@@ -342,6 +355,20 @@ func (m *MockNetworkHandler) IsRetryableError(err error, statusCode int) bool {
 func (mr *MockNetworkHandlerMockRecorder) IsRetryableError(err, statusCode any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryableError", reflect.TypeOf((*MockNetworkHandler)(nil).IsRetryableError), err, statusCode)
+}
+
+// IsRetryableOnDifferentProvider mocks base method.
+func (m *MockNetworkHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRetryableOnDifferentProvider", err, statusCode)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsRetryableOnDifferentProvider indicates an expected call of IsRetryableOnDifferentProvider.
+func (mr *MockNetworkHandlerMockRecorder) IsRetryableOnDifferentProvider(err, statusCode any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRetryableOnDifferentProvider", reflect.TypeOf((*MockNetworkHandler)(nil).IsRetryableOnDifferentProvider), err, statusCode)
 }
 
 // ParseArchiveResponse mocks base method.
@@ -503,20 +530,6 @@ func (mr *MockNetworkHandlerMockRecorder) SupportsArchiveMode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsArchiveMode", reflect.TypeOf((*MockNetworkHandler)(nil).SupportsArchiveMode))
 }
 
-// SupportsGetBlockByNumber mocks base method.
-func (m *MockNetworkHandler) SupportsGetBlockByNumber() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportsGetBlockByNumber")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// SupportsGetBlockByNumber indicates an expected call of SupportsGetBlockByNumber.
-func (mr *MockNetworkHandlerMockRecorder) SupportsGetBlockByNumber() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsGetBlockByNumber", reflect.TypeOf((*MockNetworkHandler)(nil).SupportsGetBlockByNumber))
-}
-
 // SupportsDynamicBlockLag mocks base method.
 func (m *MockNetworkHandler) SupportsDynamicBlockLag() bool {
 	m.ctrl.T.Helper()
@@ -531,19 +544,18 @@ func (mr *MockNetworkHandlerMockRecorder) SupportsDynamicBlockLag() *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsDynamicBlockLag", reflect.TypeOf((*MockNetworkHandler)(nil).SupportsDynamicBlockLag))
 }
 
-// GetBlockTimestamp mocks base method.
-func (m *MockNetworkHandler) GetBlockTimestamp(httpUrl string, headers map[string]string, httpClient http.IHTTPClient, authClient auth.IAuthClient, requestAttempts int, blockNumber int64) (int64, error) {
+// SupportsGetBlockByNumber mocks base method.
+func (m *MockNetworkHandler) SupportsGetBlockByNumber() bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBlockTimestamp", httpUrl, headers, httpClient, authClient, requestAttempts, blockNumber)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "SupportsGetBlockByNumber")
+	ret0, _ := ret[0].(bool)
+	return ret0
 }
 
-// GetBlockTimestamp indicates an expected call of GetBlockTimestamp.
-func (mr *MockNetworkHandlerMockRecorder) GetBlockTimestamp(httpUrl, headers, httpClient, authClient, requestAttempts, blockNumber interface{}) *gomock.Call {
+// SupportsGetBlockByNumber indicates an expected call of SupportsGetBlockByNumber.
+func (mr *MockNetworkHandlerMockRecorder) SupportsGetBlockByNumber() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockTimestamp", reflect.TypeOf((*MockNetworkHandler)(nil).GetBlockTimestamp), httpUrl, headers, httpClient, authClient, requestAttempts, blockNumber)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsGetBlockByNumber", reflect.TypeOf((*MockNetworkHandler)(nil).SupportsGetBlockByNumber))
 }
 
 // ValidateChainID mocks base method.

--- a/lib/network/json_rpc_types.go
+++ b/lib/network/json_rpc_types.go
@@ -67,6 +67,13 @@ func (c *JSONRPCErrorClassifier) IsRetryable(err error, statusCode int) bool {
 		return false
 	}
 
+	// Check for -32601 (method not found) by error code — different providers use
+	// different wording (e.g., "method not found" vs "X is not supported"), so matching
+	// the error code is more reliable than text patterns alone.
+	if IsJSONRPCErrorCode(err, -32601) {
+		return false
+	}
+
 	errMsg := strings.ToLower(err.Error())
 
 	// First check for explicitly non-retryable patterns

--- a/lib/network/json_rpc_types.go
+++ b/lib/network/json_rpc_types.go
@@ -24,14 +24,15 @@ type JSONRPCError struct {
 
 // JSONRPCErrorClassifier provides error classification logic for JSON-RPC errors
 type JSONRPCErrorClassifier struct {
-	nonRetryablePatterns []string
+	nonRetryablePatterns                 []string
+	retryableOnDifferentProviderPatterns []string
 }
 
 // NewJSONRPCErrorClassifier creates a new error classifier with default patterns
 func NewJSONRPCErrorClassifier() *JSONRPCErrorClassifier {
 	return &JSONRPCErrorClassifier{
 		nonRetryablePatterns: []string{
-			"method not found",   // -32601
+			"method not found",   // -32601 (also in retryableOnDifferentProviderPatterns)
 			"invalid params",     // -32602
 			"invalid request",    // -32600
 			"parse error",        // -32700
@@ -43,6 +44,9 @@ func NewJSONRPCErrorClassifier() *JSONRPCErrorClassifier {
 			"gas",                // Gas-related errors (insufficient gas, gas estimation failed, etc.)
 			"revert",             // EVM execution reverts
 			"vm execution error", // Virtual machine execution errors
+		},
+		retryableOnDifferentProviderPatterns: []string{
+			"method not found", // -32601: provider may not support this method, but another might
 		},
 	}
 }
@@ -76,6 +80,35 @@ func (c *JSONRPCErrorClassifier) IsRetryable(err error, statusCode int) bool {
 	return true
 }
 
+// IsRetryableOnDifferentProvider returns true if this error should be retried
+// on a different provider (but NOT the same one). This covers cases like -32601
+// where one provider may not support a method but another might.
+func (c *JSONRPCErrorClassifier) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	// HTTP server errors should be retried on the same provider (standard retry)
+	if statusCode >= 500 {
+		return false
+	}
+
+	// Rate limiting should be retried on the same provider (standard retry)
+	if statusCode == 429 {
+		return false
+	}
+
+	if err == nil {
+		return false
+	}
+
+	errMsg := strings.ToLower(err.Error())
+
+	for _, pattern := range c.retryableOnDifferentProviderPatterns {
+		if strings.Contains(errMsg, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Package-level functions for backward compatibility
 
 var defaultClassifier = NewJSONRPCErrorClassifier()
@@ -84,6 +117,12 @@ var defaultClassifier = NewJSONRPCErrorClassifier()
 // This is shared logic for all JSON-RPC based handlers
 func IsRetryableJSONRPCError(err error, statusCode int) bool {
 	return defaultClassifier.IsRetryable(err, statusCode)
+}
+
+// IsRetryableOnDifferentProviderJSONRPCError checks if a JSON-RPC error should be retried
+// on a different provider. This is shared logic for all JSON-RPC based handlers.
+func IsRetryableOnDifferentProviderJSONRPCError(err error, statusCode int) bool {
+	return defaultClassifier.IsRetryableOnDifferentProvider(err, statusCode)
 }
 
 // IsJSONRPCErrorCode checks if an error matches a specific JSON-RPC error code

--- a/lib/network/json_rpc_types.go
+++ b/lib/network/json_rpc_types.go
@@ -83,6 +83,10 @@ func (c *JSONRPCErrorClassifier) IsRetryable(err error, statusCode int) bool {
 // IsRetryableOnDifferentProvider returns true if this error should be retried
 // on a different provider (but NOT the same one). This covers cases like -32601
 // where one provider may not support a method but another might.
+//
+// Matching is done by error code (-32601) rather than message text, since different
+// providers use different wording (e.g., "Method not found", "unsupported method",
+// "the method X does not exist/is not available").
 func (c *JSONRPCErrorClassifier) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
 	// HTTP server errors should be retried on the same provider (standard retry)
 	if statusCode >= 500 {
@@ -98,8 +102,13 @@ func (c *JSONRPCErrorClassifier) IsRetryableOnDifferentProvider(err error, statu
 		return false
 	}
 
-	errMsg := strings.ToLower(err.Error())
+	// Match on JSON-RPC error code -32601 (method not found) regardless of message text
+	if IsJSONRPCErrorCode(err, -32601) {
+		return true
+	}
 
+	// Also match text patterns for cases where error code isn't in the standard format
+	errMsg := strings.ToLower(err.Error())
 	for _, pattern := range c.retryableOnDifferentProviderPatterns {
 		if strings.Contains(errMsg, pattern) {
 			return true

--- a/lib/network/json_rpc_types_test.go
+++ b/lib/network/json_rpc_types_test.go
@@ -142,10 +142,16 @@ func TestIsRetryableOnDifferentProviderJSONRPCError(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name:       "the method does not exist is not supported",
+			name:       "unsupported method without error code",
 			err:        fmt.Errorf("the method debug_traceBlockByNumber is not supported"),
 			statusCode: 200,
-			expected:   false, // does not contain exact "method not found" pattern
+			expected:   false, // no -32601 code and no "method not found" pattern
+		},
+		{
+			name:       "unsupported method with -32601 error code",
+			err:        fmt.Errorf("JSON-RPC error -32601: the method debug_traceBlockByNumber is not supported"),
+			statusCode: 200,
+			expected:   true, // matches on -32601 error code regardless of message text
 		},
 		// HTTP 500 takes precedence — should use standard retry, not different-provider
 		{

--- a/lib/network/json_rpc_types_test.go
+++ b/lib/network/json_rpc_types_test.go
@@ -120,3 +120,89 @@ func TestIsRetryableJSONRPCError_GasAndRevertHandling(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRetryableOnDifferentProviderJSONRPCError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		statusCode int
+		expected   bool
+	}{
+		// Method not found should be retryable on a different provider
+		{
+			name:       "method not found with -32601",
+			err:        fmt.Errorf("JSON-RPC error -32601: method not found"),
+			statusCode: 200,
+			expected:   true,
+		},
+		{
+			name:       "method not found plain",
+			err:        fmt.Errorf("method not found"),
+			statusCode: 200,
+			expected:   true,
+		},
+		{
+			name:       "the method does not exist is not supported",
+			err:        fmt.Errorf("the method debug_traceBlockByNumber is not supported"),
+			statusCode: 200,
+			expected:   false, // does not contain exact "method not found" pattern
+		},
+		// HTTP 500 takes precedence — should use standard retry, not different-provider
+		{
+			name:       "method not found with HTTP 500",
+			err:        fmt.Errorf("method not found"),
+			statusCode: 500,
+			expected:   false,
+		},
+		// HTTP 429 takes precedence — should use standard retry
+		{
+			name:       "method not found with HTTP 429",
+			err:        fmt.Errorf("method not found"),
+			statusCode: 429,
+			expected:   false,
+		},
+		// Other non-retryable errors should NOT trigger different-provider retry
+		{
+			name:       "invalid params",
+			err:        fmt.Errorf("invalid params"),
+			statusCode: 200,
+			expected:   false,
+		},
+		{
+			name:       "revert",
+			err:        fmt.Errorf("execution reverted"),
+			statusCode: 200,
+			expected:   false,
+		},
+		{
+			name:       "insufficient funds",
+			err:        fmt.Errorf("insufficient funds"),
+			statusCode: 200,
+			expected:   false,
+		},
+		// Generic server errors should NOT trigger different-provider retry
+		{
+			name:       "generic server error",
+			err:        fmt.Errorf("json-rpc error -32000: server busy"),
+			statusCode: 200,
+			expected:   false,
+		},
+		// Nil error
+		{
+			name:       "nil error",
+			err:        nil,
+			statusCode: 200,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRetryableOnDifferentProviderJSONRPCError(tt.err, tt.statusCode)
+			if result != tt.expected {
+				t.Errorf("IsRetryableOnDifferentProviderJSONRPCError(%v, %d) = %v, expected %v",
+					tt.err, tt.statusCode, result, tt.expected)
+			}
+		})
+	}
+}

--- a/lib/network/json_rpc_types_test.go
+++ b/lib/network/json_rpc_types_test.go
@@ -108,6 +108,14 @@ func TestIsRetryableJSONRPCError_GasAndRevertHandling(t *testing.T) {
 			statusCode: 200,
 			expected:   false,
 		},
+		// -32601 with non-standard text (e.g., "is not supported" instead of "method not found")
+		// should NOT be retryable on the same provider — caught by error code check
+		{
+			name:       "-32601 with non-standard text",
+			err:        fmt.Errorf("JSON-RPC error -32601: debug_traceBlockByNumber is not supported"),
+			statusCode: 200,
+			expected:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/network/solana_handler.go
+++ b/lib/network/solana_handler.go
@@ -121,6 +121,10 @@ func (h *SolanaHandler) IsRetryableError(err error, statusCode int) bool {
 	return IsRetryableJSONRPCError(err, statusCode)
 }
 
+func (h *SolanaHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	return IsRetryableOnDifferentProviderJSONRPCError(err, statusCode)
+}
+
 // === NEW NETWORK-SPECIFIC METHODS ===
 
 // Chain ID and Namespace methods

--- a/lib/network/starknet_handler.go
+++ b/lib/network/starknet_handler.go
@@ -124,6 +124,10 @@ func (h *StarknetHandler) IsRetryableError(err error, statusCode int) bool {
 	return IsRetryableJSONRPCError(err, statusCode)
 }
 
+func (h *StarknetHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	return IsRetryableOnDifferentProviderJSONRPCError(err, statusCode)
+}
+
 // === NEW NETWORK-SPECIFIC METHODS ===
 
 // Chain ID and Namespace methods

--- a/lib/network/tron_handler.go
+++ b/lib/network/tron_handler.go
@@ -187,6 +187,11 @@ func (h *TronHandler) ParseResponse(body []byte, statusCode int) error {
 // message depending on the value of the HTTP response status code.  Per
 // the above analysis, the HTTP response body should be returned to the
 // user along with the status code.
+func (h *TronHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	// REST APIs don't have JSON-RPC -32601 semantics
+	return false
+}
+
 func (h *TronHandler) IsRetryableError(err error, statusCode int) bool {
 	// Server errors and rate limits are retryable
 	if statusCode >= 500 || statusCode == 429 {

--- a/lib/network/tron_handler.go
+++ b/lib/network/tron_handler.go
@@ -172,6 +172,11 @@ func (h *TronHandler) ParseResponse(body []byte, statusCode int) error {
 	return nil
 }
 
+func (h *TronHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
+	// REST APIs don't have JSON-RPC -32601 semantics
+	return false
+}
+
 // IsRetryableError implements the Handler interface.
 //
 // The following Tron Full Node HTTP API methods return additional fields to
@@ -187,11 +192,6 @@ func (h *TronHandler) ParseResponse(body []byte, statusCode int) error {
 // message depending on the value of the HTTP response status code.  Per
 // the above analysis, the HTTP response body should be returned to the
 // user along with the status code.
-func (h *TronHandler) IsRetryableOnDifferentProvider(err error, statusCode int) bool {
-	// REST APIs don't have JSON-RPC -32601 semantics
-	return false
-}
-
 func (h *TronHandler) IsRetryableError(err error, statusCode int) bool {
 	// Server errors and rate limits are retryable
 	if statusCode >= 500 || statusCode == 429 {

--- a/modules/consts.go
+++ b/modules/consts.go
@@ -31,6 +31,7 @@ const (
 
 	// Module Context Key constants
 	DinUpstreamsContextKey          = "din.internal.upstreams"
+	DinExcludedProvidersContextKey  = "din.internal.excluded_providers"
 	RequestProviderKey              = "request_provider"
 	RequestProviderPriorityKey      = "request_provider_priority"
 	RequestBodyKey                  = "request_body"

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -733,9 +733,28 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 				// Check if this error can be retried on a different provider (e.g., -32601 method not found)
 				if networkObj.handler.IsRetryableOnDifferentProvider(appError, rww.statusCode) {
 					// Exclude the provider that returned method-not-found
-					if failedProvider, ok := repl.Get(RequestProviderKey); ok {
-						excludedProviders[failedProvider.(string)] = struct{}{}
+					failedProvider, ok := repl.Get(RequestProviderKey)
+					if !ok {
+						// Cannot identify which provider failed; fall through to non-retryable path
+						d.logger.Warn("Method-not-found retry skipped: provider key not available in context",
+							zap.String("network", networkPath),
+							zap.Error(appError))
+						logFailedAttempt(LogFailedAttemptParams{
+							Reason:              "Non-retryable application error",
+							Logger:              d.logger,
+							NetworkPath:         networkPath,
+							FailedAttemptNumber: attempt + 1,
+							MaxAttempts:         networkObj.RequestAttemptCount,
+							StatusCodeOfFailure: rww.statusCode,
+							Error:               appError,
+							Replacer:            repl,
+							RequestMethod:       method,
+							RequestParams:       params,
+							RawResponseBody:     responseBody,
+						})
+						break
 					}
+					excludedProviders[failedProvider.(string)] = struct{}{}
 
 					// Check if all providers are now excluded — if so, stop retrying
 					if providerMap, ok := repl.Get(DinUpstreamsContextKey); ok {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -716,7 +716,10 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 				// For successful HTTP responses, check for application-level errors
 				appError = networkObj.handler.ParseResponse(responseBody, rww.statusCode)
 			} else {
-				// For non-2xx responses, create an HTTP error
+				// For non-2xx responses, create an HTTP error.
+				// NOTE: Some providers return HTTP 400 with a JSON-RPC -32601 body. In that case,
+				// the error will be "HTTP error: 400" and method-level failover won't trigger.
+				// This is a known limitation — most providers return HTTP 200 with the JSON-RPC error.
 				appError = fmt.Errorf("HTTP error: %d", rww.statusCode)
 			}
 			if appError == nil {
@@ -754,7 +757,9 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 						})
 						break
 					}
-					excludedProviders[failedProvider.(string)] = struct{}{}
+					if providerHost, ok := failedProvider.(string); ok {
+						excludedProviders[providerHost] = struct{}{}
+					}
 
 					// Check if all providers are now excluded — if so, stop retrying
 					if providerMap, ok := repl.Get(DinUpstreamsContextKey); ok {

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -666,11 +666,16 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 	// Track if we should log metrics at the end (only for final outcomes)
 	var shouldLogMetrics bool
 
+	// Track providers excluded due to method-not-found (-32601) errors.
+	// These providers are skipped on subsequent attempts so a different provider is tried.
+	excludedProviders := make(map[string]struct{})
+
 	// Retry the request if it fails up to the max attempt request count
 	// Retries occur when:
 	// 1. HTTP errors (non-200 status codes or upstream errors)
 	// 2. Retryable JSON-RPC errors (server errors, timeouts, rate limits, etc.)
-	// Non-retryable JSON-RPC errors (method not found, invalid params) will not trigger retries
+	// 3. Method-not-found errors (-32601) trigger retry on a different provider
+	// Non-retryable JSON-RPC errors (invalid params, revert, etc.) will not trigger retries
 	for attempt := 0; attempt < networkObj.RequestAttemptCount; attempt++ {
 		if err := checkRequestContext(d.logger, r, networkPath, attempt); err != nil {
 			handleContextCancellation(d.logger, d.PrometheusClient, rw, r, networkPath, attempt, err, reqStartTime, networkObj)
@@ -725,8 +730,54 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 
 			// Check if the error is retryable using the handler
 			if !networkObj.handler.IsRetryableError(appError, rww.statusCode) {
-				// Non-retryable error
-				// Log this for debugging purposes since we won't retry
+				// Check if this error can be retried on a different provider (e.g., -32601 method not found)
+				if networkObj.handler.IsRetryableOnDifferentProvider(appError, rww.statusCode) {
+					// Exclude the provider that returned method-not-found
+					if failedProvider, ok := repl.Get(RequestProviderKey); ok {
+						excludedProviders[failedProvider.(string)] = struct{}{}
+					}
+
+					// Check if all providers are now excluded — if so, stop retrying
+					if providerMap, ok := repl.Get(DinUpstreamsContextKey); ok {
+						providers := providerMap.(map[string]*provider)
+						if len(excludedProviders) >= len(providers) {
+							logFailedAttempt(LogFailedAttemptParams{
+								Reason:              "Method not supported by any provider",
+								Logger:              d.logger,
+								NetworkPath:         networkPath,
+								FailedAttemptNumber: attempt + 1,
+								MaxAttempts:         networkObj.RequestAttemptCount,
+								StatusCodeOfFailure: rww.statusCode,
+								Error:               appError,
+								Replacer:            repl,
+								RequestMethod:       method,
+								RequestParams:       params,
+								RawResponseBody:     responseBody,
+							})
+							break
+						}
+					}
+
+					// Update the context so GetUpstreams excludes failed providers on next attempt
+					repl.Set(DinExcludedProvidersContextKey, excludedProviders)
+
+					logFailedAttempt(LogFailedAttemptParams{
+						Reason:              "Method not supported by provider, trying different provider",
+						Logger:              d.logger,
+						NetworkPath:         networkPath,
+						FailedAttemptNumber: attempt + 1,
+						MaxAttempts:         networkObj.RequestAttemptCount,
+						StatusCodeOfFailure: rww.statusCode,
+						Error:               appError,
+						Replacer:            repl,
+						RequestMethod:       method,
+						RequestParams:       params,
+						RawResponseBody:     responseBody,
+					})
+					continue
+				}
+
+				// Truly non-retryable error — do not retry
 				logFailedAttempt(LogFailedAttemptParams{
 					Reason:              "Non-retryable application error",
 					Logger:              d.logger,

--- a/modules/din_middleware.go
+++ b/modules/din_middleware.go
@@ -725,6 +725,37 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 			if appError == nil {
 				// Request was successful
 				shouldLogMetrics = true
+
+				// Log if this success came after a method-level failover
+				if len(excludedProviders) > 0 {
+					successProvider := "unknown"
+					successProviderName := "unknown"
+					if v, ok := repl.Get(RequestProviderKey); ok {
+						if pStr, ok := v.(string); ok {
+							successProvider = pStr
+							if providerMap, ok := repl.Get(DinUpstreamsContextKey); ok {
+								if providers, ok := providerMap.(map[string]*provider); ok {
+									if p, ok := providers[successProvider]; ok {
+										successProviderName = p.Name
+									}
+								}
+							}
+						}
+					}
+					excludedList := make([]string, 0, len(excludedProviders))
+					for host := range excludedProviders {
+						excludedList = append(excludedList, host)
+					}
+					d.logger.Info("Request succeeded after method-level failover",
+						zap.String("network", networkPath),
+						zap.String("provider", successProvider),
+						zap.String("provider_name", successProviderName),
+						zap.String("request_method", method),
+						zap.Int("attempt", attempt+1),
+						zap.Strings("excluded_providers", excludedList),
+					)
+				}
+
 				break
 			}
 
@@ -785,19 +816,20 @@ func (d *DinMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 					// Update the context so GetUpstreams excludes failed providers on next attempt
 					repl.Set(DinExcludedProvidersContextKey, excludedProviders)
 
-					logFailedAttempt(LogFailedAttemptParams{
-						Reason:              "Method not supported by provider, trying different provider",
-						Logger:              d.logger,
-						NetworkPath:         networkPath,
-						FailedAttemptNumber: attempt + 1,
-						MaxAttempts:         networkObj.RequestAttemptCount,
-						StatusCodeOfFailure: rww.statusCode,
-						Error:               appError,
-						Replacer:            repl,
-						RequestMethod:       method,
-						RequestParams:       params,
-						RawResponseBody:     responseBody,
-					})
+					// Log at INFO level since this is expected behavior — the request will be
+					// retried on a different provider and is likely to succeed.
+					excludedList := make([]string, 0, len(excludedProviders))
+					for host := range excludedProviders {
+						excludedList = append(excludedList, host)
+					}
+					d.logger.Info("Method not supported by provider, trying different provider",
+						zap.String("network", networkPath),
+						zap.String("request_method", method),
+						zap.Int("attempt", attempt+1),
+						zap.Int("max_attempts", networkObj.RequestAttemptCount),
+						zap.Error(appError),
+						zap.Strings("excluded_providers", excludedList),
+					)
 					continue
 				}
 

--- a/modules/din_upstreams.go
+++ b/modules/din_upstreams.go
@@ -86,8 +86,14 @@ func (d *DinUpstreams) GetUpstreams(r *http.Request) ([]*reverseproxy.Upstream, 
 		providers = networkConfig.Providers
 	}
 
+	// Check for providers excluded due to method-not-found errors on prior attempts
+	var excludedProviders map[string]struct{}
+	if v, ok := repl.Get(DinExcludedProvidersContextKey); ok {
+		excludedProviders = v.(map[string]struct{})
+	}
+
 	// Convert providers to upstreams based on priority and health status
-	upstreamPool := d.buildUpstreamPool(providers)
+	upstreamPool := d.buildUpstreamPool(providers, excludedProviders)
 
 	return upstreamPool, nil
 }
@@ -113,13 +119,17 @@ func (d *DinUpstreams) extractNetworkName(path string) string {
 	return networkName
 }
 
-// buildUpstreamPool converts providers to upstreams with priority + health based selection
-func (d *DinUpstreams) buildUpstreamPool(providers map[string]*provider) []*reverseproxy.Upstream {
+// buildUpstreamPool converts providers to upstreams with priority + health based selection.
+// excludedProviders contains hosts to skip (e.g., from method-not-found retries). May be nil.
+func (d *DinUpstreams) buildUpstreamPool(providers map[string]*provider, excludedProviders map[string]struct{}) []*reverseproxy.Upstream {
 	upstreamPool := make([]*reverseproxy.Upstream, 0)
 
 	// Select upstream based on priority. If no upstreams are available, pass along all upstreams
 	for priority := 0; priority < MaxPriority; priority++ {
 		for _, p := range providers {
+			if _, excluded := excludedProviders[p.host]; excluded {
+				continue
+			}
 			if p.Priority == priority && p.Available() {
 				upstreamPool = append(upstreamPool, p.upstream)
 			}
@@ -134,6 +144,9 @@ func (d *DinUpstreams) buildUpstreamPool(providers map[string]*provider) []*reve
 	if len(upstreamPool) == 0 {
 		for priority := 0; priority < MaxPriority; priority++ {
 			for _, p := range providers {
+				if _, excluded := excludedProviders[p.host]; excluded {
+					continue
+				}
 				if p.Priority == priority && p.IsAvailableWithWarning() {
 					upstreamPool = append(upstreamPool, p.upstream)
 				}

--- a/modules/din_upstreams_test.go
+++ b/modules/din_upstreams_test.go
@@ -365,3 +365,122 @@ func TestGetDinUpstreams(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDinUpstreams_WithExcludedProviders(t *testing.T) {
+	testNetwork := &network{
+		Name:      "ethereum",
+		Providers: make(map[string]*provider),
+	}
+	globalNetworkMutex.Lock()
+	globalNetworkRegistry["ethereum"] = testNetwork
+	globalNetworkMutex.Unlock()
+	defer func() {
+		globalNetworkMutex.Lock()
+		delete(globalNetworkRegistry, "ethereum")
+		globalNetworkMutex.Unlock()
+	}()
+
+	dinUpstreams := new(DinUpstreams)
+
+	upstream1 := &reverseproxy.Upstream{Dial: "provider-a:8000"}
+	upstream2 := &reverseproxy.Upstream{Dial: "provider-b:8001"}
+	upstream3 := &reverseproxy.Upstream{Dial: "provider-c:8002"}
+
+	healthyHistory := func() *list.List {
+		l := list.New()
+		l.PushBack(blockHistoryEntry{blockNumber: 100, healthStatus: Healthy})
+		return l
+	}
+
+	tests := []struct {
+		name              string
+		providers         map[string]*provider
+		excludedProviders map[string]struct{}
+		expectedCount     int
+		expectedDials     []string
+	}{
+		{
+			name: "exclude one provider, other remains",
+			providers: map[string]*provider{
+				"provider-a:8000": {upstream: upstream1, Priority: 0, host: "provider-a:8000", blockHistory: healthyHistory()},
+				"provider-b:8001": {upstream: upstream2, Priority: 0, host: "provider-b:8001", blockHistory: healthyHistory()},
+			},
+			excludedProviders: map[string]struct{}{"provider-a:8000": {}},
+			expectedCount:     1,
+			expectedDials:     []string{"provider-b:8001"},
+		},
+		{
+			name: "exclude priority 0 provider, fall through to priority 1",
+			providers: map[string]*provider{
+				"provider-a:8000": {upstream: upstream1, Priority: 0, host: "provider-a:8000", blockHistory: healthyHistory()},
+				"provider-b:8001": {upstream: upstream2, Priority: 1, host: "provider-b:8001", blockHistory: healthyHistory()},
+			},
+			excludedProviders: map[string]struct{}{"provider-a:8000": {}},
+			expectedCount:     1,
+			expectedDials:     []string{"provider-b:8001"},
+		},
+		{
+			name: "no exclusions, all providers returned",
+			providers: map[string]*provider{
+				"provider-a:8000": {upstream: upstream1, Priority: 0, host: "provider-a:8000", blockHistory: healthyHistory()},
+				"provider-b:8001": {upstream: upstream2, Priority: 0, host: "provider-b:8001", blockHistory: healthyHistory()},
+			},
+			excludedProviders: nil,
+			expectedCount:     2,
+			expectedDials:     []string{"provider-a:8000", "provider-b:8001"},
+		},
+		{
+			name: "all providers excluded, empty pool",
+			providers: map[string]*provider{
+				"provider-a:8000": {upstream: upstream1, Priority: 0, host: "provider-a:8000", blockHistory: healthyHistory()},
+				"provider-b:8001": {upstream: upstream2, Priority: 0, host: "provider-b:8001", blockHistory: healthyHistory()},
+			},
+			excludedProviders: map[string]struct{}{"provider-a:8000": {}, "provider-b:8001": {}},
+			expectedCount:     0,
+			expectedDials:     []string{},
+		},
+		{
+			name: "exclude two of three, one remains",
+			providers: map[string]*provider{
+				"provider-a:8000": {upstream: upstream1, Priority: 0, host: "provider-a:8000", blockHistory: healthyHistory()},
+				"provider-b:8001": {upstream: upstream2, Priority: 0, host: "provider-b:8001", blockHistory: healthyHistory()},
+				"provider-c:8002": {upstream: upstream3, Priority: 1, host: "provider-c:8002", blockHistory: healthyHistory()},
+			},
+			excludedProviders: map[string]struct{}{"provider-a:8000": {}, "provider-b:8001": {}},
+			expectedCount:     1,
+			expectedDials:     []string{"provider-c:8002"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			globalNetworkMutex.Lock()
+			testNetwork.Providers = tt.providers
+			globalNetworkMutex.Unlock()
+
+			req := &http.Request{URL: &url.URL{Path: "/ethereum/eth_blockNumber"}}
+			req = req.WithContext(context.WithValue(req.Context(), caddy.ReplacerCtxKey, caddy.NewReplacer()))
+			repl := req.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+			repl.Set(DinUpstreamsContextKey, tt.providers)
+			if tt.excludedProviders != nil {
+				repl.Set(DinExcludedProvidersContextKey, tt.excludedProviders)
+			}
+
+			upstreams, _ := dinUpstreams.GetUpstreams(req)
+			if len(upstreams) != tt.expectedCount {
+				t.Errorf("GetUpstreams() returned %d upstreams, want %d", len(upstreams), tt.expectedCount)
+				return
+			}
+
+			actualDials := make(map[string]bool)
+			for _, u := range upstreams {
+				actualDials[u.Dial] = true
+			}
+			for _, dial := range tt.expectedDials {
+				if !actualDials[dial] {
+					t.Errorf("GetUpstreams() missing expected upstream: %v", dial)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- When a provider returns a JSON-RPC -32601 "method not found" error, the router now excludes that provider and retries on a different one
- Previously, -32601 was treated as non-retryable — the error was returned to the client immediately, even if another provider supported the method
- Matching uses the -32601 error code (provider-agnostic) with text pattern fallback
- Only applies to JSON-RPC handlers (EVM, Starknet, Solana, Bitcoin); REST handlers are unaffected
- If all providers return -32601, the original error is returned to the client

## Context

Raised by Iris — MegaETH's Alchemy provider didn't support `eth_getBlockReceipts` but QuickNode did. The router returned an error instead of failing over because `"method not found"` was classified as non-retryable.

Slack thread: https://consensys.slack.com/archives/C0A0XJB8NAH/p1770655485440739

## Known Limitations

- **HTTP 400 + -32601 body**: Some providers return HTTP 400 with a JSON-RPC -32601 body. The middleware classifies non-2xx responses as `"HTTP error: 400"` without parsing the body, so method-level failover won't trigger in this case. Most providers return HTTP 200 with the JSON-RPC error.
- **Batch JSON-RPC**: Batch responses with mixed errors are not individually classified (existing limitation).
