### PR TITLE
Complete ExtractMethod for Esplora

### DIFF
--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -98,9 +99,172 @@ func (h *BitcoinEsploraHandler) ProcessRequest(req *http.Request) error {
 	return nil
 }
 
+var (
+	reTx                = regexp.MustCompile(`/tx/[^/]+$$`)
+	reTxStatus          = regexp.MustCompile(`/tx/[^/]+/status$$`)
+	reTxHex             = regexp.MustCompile(`/tx/[^/]+/hex$$`)
+	reTxRaw             = regexp.MustCompile(`/tx/[^/]+/raw$$`)
+	reTxMerkleblock     = regexp.MustCompile(`/tx/[^/]+/merkleblock-proof$$`)
+	reTxMerkle          = regexp.MustCompile(`/tx/[^/]+/merkle-proof$$`)
+	reTxOutspendVout    = regexp.MustCompile(`/tx/[^/]+/outspend/\d+$$`)
+	reTxOutspends       = regexp.MustCompile(`/tx/[^/]+/outspends$$`)
+	rePostTxBroadcast   = regexp.MustCompile(`/tx$$`)
+	rePostTxsPackage    = regexp.MustCompile(`/txs/package$$`)
+
+	// ---- Addresses / Scripthash ----
+	reAddressInfo       = regexp.MustCompile(`/address/[^/]+$$`)
+	reScripthashInfo    = regexp.MustCompile(`/scripthash/[^/]+$$`)
+	reAddressTxs        = regexp.MustCompile(`/address/[^/]+/txs$$`)
+	reScripthashTxs     = regexp.MustCompile(`/scripthash/[^/]+/txs$$`)
+	reAddressTxsChain   = regexp.MustCompile(`/address/[^/]+/txs/chain(?:/[^/]+)?$$`)
+	reScripthashTxsChain= regexp.MustCompile(`/scripthash/[^/]+/txs/chain(?:/[^/]+)?$$`)
+	reAddressTxsMempool = regexp.MustCompile(`/address/[^/]+/txs/mempool$$`)
+	reScripthashTxsMem  = regexp.MustCompile(`/scripthash/[^/]+/txs/mempool$$`)
+	reAddressUtxo       = regexp.MustCompile(`/address/[^/]+/utxo$$`)
+	reScripthashUtxo    = regexp.MustCompile(`/scripthash/[^/]+/utxo$$`)
+	reAddressPrefix     = regexp.MustCompile(`/address-prefix/[^/]+$$`)
+
+	// ---- Blocks ----
+	reBlock             = regexp.MustCompile(`/block/[^/]+$$`)
+	reBlockHeader       = regexp.MustCompile(`/block/[^/]+/header$$`)
+	reBlockStatus       = regexp.MustCompile(`/block/[^/]+/status$$`)
+	reBlockTxs          = regexp.MustCompile(`/block/[^/]+/txs(?:/\d+)?$$`)
+	reBlockTxids        = regexp.MustCompile(`/block/[^/]+/txids$$`)
+	reBlockTxidIndex    = regexp.MustCompile(`/block/[^/]+/txid/\d+$$`)
+	reBlockRaw          = regexp.MustCompile(`/block/[^/]+/raw$$`)
+	reBlockHeight       = regexp.MustCompile(`/block-height/\d+$$`)
+	reBlocks            = regexp.MustCompile(`/blocks(?:/\d+)?$$`)
+	reBlocksTipHeight   = regexp.MustCompile(`/blocks/tip/height$$`)
+	reBlocksTipHash     = regexp.MustCompile(`/blocks/tip/hash$$`)
+
+	// ---- Mempool / Fees ----
+	reMempool           = regexp.MustCompile(`/mempool$$`)
+	reMempoolTxids      = regexp.MustCompile(`/mempool/txids$$`)
+	reMempoolRecent     = regexp.MustCompile(`/mempool/recent$$`)
+	reFeeEstimates      = regexp.MustCompile(`/fee-estimates$$`)
+
+	// ---- Assets (Elements/Liquid only) ----
+	reAsset             = regexp.MustCompile(`/asset/[^/]+$$`)
+	reAssetTxs          = regexp.MustCompile(`/asset/[^/]+/txs$$`)
+	reAssetTxsMempool   = regexp.MustCompile(`/asset/[^/]+/txs/mempool$$`)
+	reAssetTxsChain     = regexp.MustCompile(`/asset/[^/]+/txs/chain(?:/[^/]+)?$$`)
+	reAssetSupply       = regexp.MustCompile(`/asset/[^/]+/supply$$`)
+	reAssetSupplyDec    = regexp.MustCompile(`/asset/[^/]+/supply/decimal$$`)
+	reAssetsRegistry    = regexp.MustCompile(`/assets/registry$$`)
+)
+
+// EndpointID maps an HTTP method + request path to a stable, unique endpoint identifier.
+//
+// Notes:
+//   - Paths below are derived from Blockstream Esplora API docs.
+//   - `path` should be the URL path only (no scheme/host/querystring), e.g. "/tx/<txid>/status".
+//   - All regexes are anchored (^...$) so partial matches won't collide.
+func EndpointID(method, path string) string {
+	switch {
+	// ---- Transactions ----
+	case method == "GET" && reTx.MatchString(path):
+		return "GET_TX"
+	case method == "GET" && reTxStatus.MatchString(path):
+		return "GET_TX_STATUS"
+	case method == "GET" && reTxHex.MatchString(path):
+		return "GET_TX_HEX"
+	case method == "GET" && reTxRaw.MatchString(path):
+		return "GET_TX_RAW"
+	case method == "GET" && reTxMerkleblock.MatchString(path):
+		return "GET_TX_MERKLEBLOCK_PROOF"
+	case method == "GET" && reTxMerkle.MatchString(path):
+		return "GET_TX_MERKLE_PROOF"
+	case method == "GET" && reTxOutspendVout.MatchString(path):
+		return "GET_TX_OUTSPEND_VOUT"
+	case method == "GET" && reTxOutspends.MatchString(path):
+		return "GET_TX_OUTSPENDS"
+	case method == "POST" && rePostTxBroadcast.MatchString(path):
+		return "POST_TX_BROADCAST"
+	case method == "POST" && rePostTxsPackage.MatchString(path):
+		return "POST_TXS_PACKAGE"
+
+	// ---- Addresses / Scripthash ----
+	case method == "GET" && reAddressInfo.MatchString(path):
+		return "GET_ADDRESS"
+	case method == "GET" && reScripthashInfo.MatchString(path):
+		return "GET_SCRIPTHASH"
+	case method == "GET" && reAddressTxs.MatchString(path):
+		return "GET_ADDRESS_TXS"
+	case method == "GET" && reScripthashTxs.MatchString(path):
+		return "GET_SCRIPTHASH_TXS"
+	case method == "GET" && reAddressTxsChain.MatchString(path):
+		return "GET_ADDRESS_TXS_CHAIN"
+	case method == "GET" && reScripthashTxsChain.MatchString(path):
+		return "GET_SCRIPTHASH_TXS_CHAIN"
+	case method == "GET" && reAddressTxsMempool.MatchString(path):
+		return "GET_ADDRESS_TXS_MEMPOOL"
+	case method == "GET" && reScripthashTxsMem.MatchString(path):
+		return "GET_SCRIPTHASH_TXS_MEMPOOL"
+	case method == "GET" && reAddressUtxo.MatchString(path):
+		return "GET_ADDRESS_UTXO"
+	case method == "GET" && reScripthashUtxo.MatchString(path):
+		return "GET_SCRIPTHASH_UTXO"
+	case method == "GET" && reAddressPrefix.MatchString(path):
+		return "GET_ADDRESS_PREFIX"
+
+	// ---- Blocks ----
+	case method == "GET" && reBlock.MatchString(path):
+		return "GET_BLOCK"
+	case method == "GET" && reBlockHeader.MatchString(path):
+		return "GET_BLOCK_HEADER"
+	case method == "GET" && reBlockStatus.MatchString(path):
+		return "GET_BLOCK_STATUS"
+	case method == "GET" && reBlockTxs.MatchString(path):
+		return "GET_BLOCK_TXS"
+	case method == "GET" && reBlockTxids.MatchString(path):
+		return "GET_BLOCK_TXIDS"
+	case method == "GET" && reBlockTxidIndex.MatchString(path):
+		return "GET_BLOCK_TXID_INDEX"
+	case method == "GET" && reBlockRaw.MatchString(path):
+		return "GET_BLOCK_RAW"
+	case method == "GET" && reBlockHeight.MatchString(path):
+		return "GET_BLOCK_HEIGHT"
+	case method == "GET" && reBlocks.MatchString(path):
+		return "GET_BLOCKS"
+	case method == "GET" && reBlocksTipHeight.MatchString(path):
+		return "GET_BLOCKS_TIP_HEIGHT"
+	case method == "GET" && reBlocksTipHash.MatchString(path):
+		return "GET_BLOCKS_TIP_HASH"
+
+	// ---- Assets (Elements/Liquid only) ----
+	case method == "GET" && reAsset.MatchString(path):
+		return "GET_ASSET"
+	case method == "GET" && reAssetTxs.MatchString(path):
+		return "GET_ASSET_TXS"
+	case method == "GET" && reAssetTxsMempool.MatchString(path):
+		return "GET_ASSET_TXS_MEMPOOL"
+	case method == "GET" && reAssetTxsChain.MatchString(path):
+		return "GET_ASSET_TXS_CHAIN"
+	case method == "GET" && reAssetSupply.MatchString(path):
+		return "GET_ASSET_SUPPLY"
+	case method == "GET" && reAssetSupplyDec.MatchString(path):
+		return "GET_ASSET_SUPPLY_DECIMAL"
+	case method == "GET" && reAssetsRegistry.MatchString(path):
+		return "GET_ASSETS_REGISTRY"
+	
+	// ---- Mempool / Fees ----
+	case method == "GET" && reMempool.MatchString(path):
+		return "GET_MEMPOOL"
+	case method == "GET" && reMempoolTxids.MatchString(path):
+		return "GET_MEMPOOL_TXIDS"
+	case method == "GET" && reMempoolRecent.MatchString(path):
+		return "GET_MEMPOOL_RECENT"
+	case method == "GET" && reFeeEstimates.MatchString(path):
+		return "GET_FEE_ESTIMATES"
+	}
+
+	return "UNKNOWN"
+}
+
+
 // ExtractMethod extracts the method name from the request for logging/metrics
 func (h *BitcoinEsploraHandler) ExtractMethod(req *http.Request, body []byte) (string, error) {
-	return "REST", nil
+	return EndpointID(req.Method, req.URL.Path), nil
 }
 
 // ConfigureRequestPath configures the request path for REST API requests

--- a/lib/network/bitcoin_esplora_handler.go
+++ b/lib/network/bitcoin_esplora_handler.go
@@ -100,57 +100,57 @@ func (h *BitcoinEsploraHandler) ProcessRequest(req *http.Request) error {
 }
 
 var (
-	reTx                = regexp.MustCompile(`/tx/[^/]+$$`)
-	reTxStatus          = regexp.MustCompile(`/tx/[^/]+/status$$`)
-	reTxHex             = regexp.MustCompile(`/tx/[^/]+/hex$$`)
-	reTxRaw             = regexp.MustCompile(`/tx/[^/]+/raw$$`)
-	reTxMerkleblock     = regexp.MustCompile(`/tx/[^/]+/merkleblock-proof$$`)
-	reTxMerkle          = regexp.MustCompile(`/tx/[^/]+/merkle-proof$$`)
-	reTxOutspendVout    = regexp.MustCompile(`/tx/[^/]+/outspend/\d+$$`)
-	reTxOutspends       = regexp.MustCompile(`/tx/[^/]+/outspends$$`)
-	rePostTxBroadcast   = regexp.MustCompile(`/tx$$`)
-	rePostTxsPackage    = regexp.MustCompile(`/txs/package$$`)
+	reTx                = regexp.MustCompile(`/tx/[^/]+$`)
+	reTxStatus          = regexp.MustCompile(`/tx/[^/]+/status$`)
+	reTxHex             = regexp.MustCompile(`/tx/[^/]+/hex$`)
+	reTxRaw             = regexp.MustCompile(`/tx/[^/]+/raw$`)
+	reTxMerkleblock     = regexp.MustCompile(`/tx/[^/]+/merkleblock-proof$`)
+	reTxMerkle          = regexp.MustCompile(`/tx/[^/]+/merkle-proof$`)
+	reTxOutspendVout    = regexp.MustCompile(`/tx/[^/]+/outspend/\d+$`)
+	reTxOutspends       = regexp.MustCompile(`/tx/[^/]+/outspends$`)
+	rePostTxBroadcast   = regexp.MustCompile(`/tx$`)
+	rePostTxsPackage    = regexp.MustCompile(`/txs/package$`)
 
 	// ---- Addresses / Scripthash ----
-	reAddressInfo       = regexp.MustCompile(`/address/[^/]+$$`)
-	reScripthashInfo    = regexp.MustCompile(`/scripthash/[^/]+$$`)
-	reAddressTxs        = regexp.MustCompile(`/address/[^/]+/txs$$`)
-	reScripthashTxs     = regexp.MustCompile(`/scripthash/[^/]+/txs$$`)
-	reAddressTxsChain   = regexp.MustCompile(`/address/[^/]+/txs/chain(?:/[^/]+)?$$`)
-	reScripthashTxsChain= regexp.MustCompile(`/scripthash/[^/]+/txs/chain(?:/[^/]+)?$$`)
-	reAddressTxsMempool = regexp.MustCompile(`/address/[^/]+/txs/mempool$$`)
-	reScripthashTxsMem  = regexp.MustCompile(`/scripthash/[^/]+/txs/mempool$$`)
-	reAddressUtxo       = regexp.MustCompile(`/address/[^/]+/utxo$$`)
-	reScripthashUtxo    = regexp.MustCompile(`/scripthash/[^/]+/utxo$$`)
-	reAddressPrefix     = regexp.MustCompile(`/address-prefix/[^/]+$$`)
+	reAddressInfo       = regexp.MustCompile(`/address/[^/]+$`)
+	reScripthashInfo    = regexp.MustCompile(`/scripthash/[^/]+$`)
+	reAddressTxs        = regexp.MustCompile(`/address/[^/]+/txs$`)
+	reScripthashTxs     = regexp.MustCompile(`/scripthash/[^/]+/txs$`)
+	reAddressTxsChain   = regexp.MustCompile(`/address/[^/]+/txs/chain(?:/[^/]+)?$`)
+	reScripthashTxsChain= regexp.MustCompile(`/scripthash/[^/]+/txs/chain(?:/[^/]+)?$`)
+	reAddressTxsMempool = regexp.MustCompile(`/address/[^/]+/txs/mempool$`)
+	reScripthashTxsMem  = regexp.MustCompile(`/scripthash/[^/]+/txs/mempool$`)
+	reAddressUtxo       = regexp.MustCompile(`/address/[^/]+/utxo$`)
+	reScripthashUtxo    = regexp.MustCompile(`/scripthash/[^/]+/utxo$`)
+	reAddressPrefix     = regexp.MustCompile(`/address-prefix/[^/]+$`)
 
 	// ---- Blocks ----
-	reBlock             = regexp.MustCompile(`/block/[^/]+$$`)
-	reBlockHeader       = regexp.MustCompile(`/block/[^/]+/header$$`)
-	reBlockStatus       = regexp.MustCompile(`/block/[^/]+/status$$`)
-	reBlockTxs          = regexp.MustCompile(`/block/[^/]+/txs(?:/\d+)?$$`)
-	reBlockTxids        = regexp.MustCompile(`/block/[^/]+/txids$$`)
-	reBlockTxidIndex    = regexp.MustCompile(`/block/[^/]+/txid/\d+$$`)
-	reBlockRaw          = regexp.MustCompile(`/block/[^/]+/raw$$`)
-	reBlockHeight       = regexp.MustCompile(`/block-height/\d+$$`)
-	reBlocks            = regexp.MustCompile(`/blocks(?:/\d+)?$$`)
-	reBlocksTipHeight   = regexp.MustCompile(`/blocks/tip/height$$`)
-	reBlocksTipHash     = regexp.MustCompile(`/blocks/tip/hash$$`)
+	reBlock             = regexp.MustCompile(`/block/[^/]+$`)
+	reBlockHeader       = regexp.MustCompile(`/block/[^/]+/header$`)
+	reBlockStatus       = regexp.MustCompile(`/block/[^/]+/status$`)
+	reBlockTxs          = regexp.MustCompile(`/block/[^/]+/txs(?:/\d+)?$`)
+	reBlockTxids        = regexp.MustCompile(`/block/[^/]+/txids$`)
+	reBlockTxidIndex    = regexp.MustCompile(`/block/[^/]+/txid/\d+$`)
+	reBlockRaw          = regexp.MustCompile(`/block/[^/]+/raw$`)
+	reBlockHeight       = regexp.MustCompile(`/block-height/\d+$`)
+	reBlocks            = regexp.MustCompile(`/blocks(?:/\d+)?$`)
+	reBlocksTipHeight   = regexp.MustCompile(`/blocks/tip/height$`)
+	reBlocksTipHash     = regexp.MustCompile(`/blocks/tip/hash$`)
 
 	// ---- Mempool / Fees ----
-	reMempool           = regexp.MustCompile(`/mempool$$`)
-	reMempoolTxids      = regexp.MustCompile(`/mempool/txids$$`)
-	reMempoolRecent     = regexp.MustCompile(`/mempool/recent$$`)
-	reFeeEstimates      = regexp.MustCompile(`/fee-estimates$$`)
+	reMempool           = regexp.MustCompile(`/mempool$`)
+	reMempoolTxids      = regexp.MustCompile(`/mempool/txids$`)
+	reMempoolRecent     = regexp.MustCompile(`/mempool/recent$`)
+	reFeeEstimates      = regexp.MustCompile(`/fee-estimates$`)
 
 	// ---- Assets (Elements/Liquid only) ----
-	reAsset             = regexp.MustCompile(`/asset/[^/]+$$`)
-	reAssetTxs          = regexp.MustCompile(`/asset/[^/]+/txs$$`)
-	reAssetTxsMempool   = regexp.MustCompile(`/asset/[^/]+/txs/mempool$$`)
-	reAssetTxsChain     = regexp.MustCompile(`/asset/[^/]+/txs/chain(?:/[^/]+)?$$`)
-	reAssetSupply       = regexp.MustCompile(`/asset/[^/]+/supply$$`)
-	reAssetSupplyDec    = regexp.MustCompile(`/asset/[^/]+/supply/decimal$$`)
-	reAssetsRegistry    = regexp.MustCompile(`/assets/registry$$`)
+	reAsset             = regexp.MustCompile(`/asset/[^/]+$`)
+	reAssetTxs          = regexp.MustCompile(`/asset/[^/]+/txs$`)
+	reAssetTxsMempool   = regexp.MustCompile(`/asset/[^/]+/txs/mempool$`)
+	reAssetTxsChain     = regexp.MustCompile(`/asset/[^/]+/txs/chain(?:/[^/]+)?$`)
+	reAssetSupply       = regexp.MustCompile(`/asset/[^/]+/supply$`)
+	reAssetSupplyDec    = regexp.MustCompile(`/asset/[^/]+/supply/decimal$`)
+	reAssetsRegistry    = regexp.MustCompile(`/assets/registry$`)
 )
 
 // EndpointID maps an HTTP method + request path to a stable, unique endpoint identifier.
@@ -158,7 +158,6 @@ var (
 // Notes:
 //   - Paths below are derived from Blockstream Esplora API docs.
 //   - `path` should be the URL path only (no scheme/host/querystring), e.g. "/tx/<txid>/status".
-//   - All regexes are anchored (^...$) so partial matches won't collide.
 func EndpointID(method, path string) string {
 	switch {
 	// ---- Transactions ----

--- a/lib/network/bitcoin_esplora_handler_test.go
+++ b/lib/network/bitcoin_esplora_handler_test.go
@@ -293,3 +293,87 @@ func TestBitcoinEsploraHandler_ChainID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "bitcoin:mainnet", chainID)
 }
+
+
+func TestEndpointID_CoversAllRegexRoutes(t *testing.T) {
+	// All cases use a non-empty prefix to assert we match by suffix (…$) not exact-path.
+	prefix := "/api/v1/esplora"
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		// ---- Transactions ----
+		{"GET_TX", "GET", prefix + "/tx/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "GET_TX"},
+		{"GET_TX_STATUS", "GET", prefix + "/tx/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/status", "GET_TX_STATUS"},
+		{"GET_TX_HEX", "GET", prefix + "/tx/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc/hex", "GET_TX_HEX"},
+		{"GET_TX_RAW", "GET", prefix + "/tx/dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd/raw", "GET_TX_RAW"},
+		{"GET_TX_MERKLEBLOCK_PROOF", "GET", prefix + "/tx/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/merkleblock-proof", "GET_TX_MERKLEBLOCK_PROOF"},
+		{"GET_TX_MERKLE_PROOF", "GET", prefix + "/tx/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff/merkle-proof", "GET_TX_MERKLE_PROOF"},
+		{"GET_TX_OUTSPEND_VOUT", "GET", prefix + "/tx/1111111111111111111111111111111111111111111111111111111111111111/outspend/0", "GET_TX_OUTSPEND_VOUT"},
+		{"GET_TX_OUTSPENDS", "GET", prefix + "/tx/2222222222222222222222222222222222222222222222222222222222222222/outspends", "GET_TX_OUTSPENDS"},
+		{"POST_TX_BROADCAST", "POST", prefix + "/tx", "POST_TX_BROADCAST"},
+		{"POST_TXS_PACKAGE", "POST", prefix + "/txs/package", "POST_TXS_PACKAGE"},
+
+		// ---- Addresses / Scripthash ----
+		{"GET_ADDRESS", "GET", prefix + "/address/bc1qexampleaddress0000000000000000000000000000000000", "GET_ADDRESS"},
+		{"GET_SCRIPTHASH", "GET", prefix + "/scripthash/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "GET_SCRIPTHASH"},
+		{"GET_ADDRESS_TXS", "GET", prefix + "/address/bc1qexampleaddress0000000000000000000000000000000000/txs", "GET_ADDRESS_TXS"},
+		{"GET_SCRIPTHASH_TXS", "GET", prefix + "/scripthash/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/txs", "GET_SCRIPTHASH_TXS"},
+		{"GET_ADDRESS_TXS_CHAIN", "GET", prefix + "/address/bc1qexampleaddress0000000000000000000000000000000000/txs/chain", "GET_ADDRESS_TXS_CHAIN"},
+		{"GET_ADDRESS_TXS_CHAIN_PAGINATED", "GET", prefix + "/address/bc1qexampleaddress0000000000000000000000000000000000/txs/chain/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "GET_ADDRESS_TXS_CHAIN"},
+		{"GET_SCRIPTHASH_TXS_CHAIN", "GET", prefix + "/scripthash/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/txs/chain", "GET_SCRIPTHASH_TXS_CHAIN"},
+		{"GET_SCRIPTHASH_TXS_CHAIN_PAGINATED", "GET", prefix + "/scripthash/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/txs/chain/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "GET_SCRIPTHASH_TXS_CHAIN"},
+		{"GET_ADDRESS_TXS_MEMPOOL", "GET", prefix + "/address/bc1qexampleaddress0000000000000000000000000000000000/txs/mempool", "GET_ADDRESS_TXS_MEMPOOL"},
+		{"GET_SCRIPTHASH_TXS_MEMPOOL", "GET", prefix + "/scripthash/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/txs/mempool", "GET_SCRIPTHASH_TXS_MEMPOOL"},
+		{"GET_ADDRESS_UTXO", "GET", prefix + "/address/bc1qexampleaddress0000000000000000000000000000000000/utxo", "GET_ADDRESS_UTXO"},
+		{"GET_SCRIPTHASH_UTXO", "GET", prefix + "/scripthash/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/utxo", "GET_SCRIPTHASH_UTXO"},
+		{"GET_ADDRESS_PREFIX", "GET", prefix + "/address-prefix/bc1q", "GET_ADDRESS_PREFIX"},
+
+		// ---- Blocks ----
+		{"GET_BLOCK", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000", "GET_BLOCK"},
+		{"GET_BLOCK_HEADER", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000/header", "GET_BLOCK_HEADER"},
+		{"GET_BLOCK_STATUS", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000/status", "GET_BLOCK_STATUS"},
+		{"GET_BLOCK_TXS", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000/txs", "GET_BLOCK_TXS"},
+		{"GET_BLOCK_TXS_PAGINATED", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000/txs/25", "GET_BLOCK_TXS"},
+		{"GET_BLOCK_TXIDS", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000/txids", "GET_BLOCK_TXIDS"},
+		{"GET_BLOCK_TXID_INDEX", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000/txid/7", "GET_BLOCK_TXID_INDEX"},
+		{"GET_BLOCK_RAW", "GET", prefix + "/block/0000000000000000000000000000000000000000000000000000000000000000/raw", "GET_BLOCK_RAW"},
+		{"GET_BLOCK_HEIGHT", "GET", prefix + "/block-height/840000", "GET_BLOCK_HEIGHT"},
+		{"GET_BLOCKS", "GET", prefix + "/blocks", "GET_BLOCKS"},
+		{"GET_BLOCKS_START", "GET", prefix + "/blocks/839000", "GET_BLOCKS"},
+		{"GET_BLOCKS_TIP_HEIGHT", "GET", prefix + "/blocks/tip/height", "GET_BLOCKS_TIP_HEIGHT"},
+		{"GET_BLOCKS_TIP_HASH", "GET", prefix + "/blocks/tip/hash", "GET_BLOCKS_TIP_HASH"},
+
+		// ---- Mempool / Fees ----
+		{"GET_MEMPOOL", "GET", prefix + "/mempool", "GET_MEMPOOL"},
+		{"GET_MEMPOOL_TXIDS", "GET", prefix + "/mempool/txids", "GET_MEMPOOL_TXIDS"},
+		{"GET_MEMPOOL_RECENT", "GET", prefix + "/mempool/recent", "GET_MEMPOOL_RECENT"},
+		{"GET_FEE_ESTIMATES", "GET", prefix + "/fee-estimates", "GET_FEE_ESTIMATES"},
+
+		// ---- Assets (Elements/Liquid only) ----
+		{"GET_ASSET", "GET", prefix + "/asset/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "GET_ASSET"},
+		{"GET_ASSET_TXS", "GET", prefix + "/asset/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/txs", "GET_ASSET_TXS"},
+		{"GET_ASSET_TXS_MEMPOOL", "GET", prefix + "/asset/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/txs/mempool", "GET_ASSET_TXS_MEMPOOL"},
+		{"GET_ASSET_TXS_CHAIN", "GET", prefix + "/asset/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/txs/chain", "GET_ASSET_TXS_CHAIN"},
+		{"GET_ASSET_TXS_CHAIN_PAGINATED", "GET", prefix + "/asset/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/txs/chain/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "GET_ASSET_TXS_CHAIN"},
+		{"GET_ASSET_SUPPLY", "GET", prefix + "/asset/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/supply", "GET_ASSET_SUPPLY"},
+		{"GET_ASSET_SUPPLY_DECIMAL", "GET", prefix + "/asset/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/supply/decimal", "GET_ASSET_SUPPLY_DECIMAL"},
+		{"GET_ASSETS_REGISTRY", "GET", prefix + "/assets/registry", "GET_ASSETS_REGISTRY"},
+
+		// ---- Unknown ----
+		{"UNKNOWN", "GET", prefix + "/nope/not-a-route", "UNKNOWN"},
+		{"UNKNOWN_wrong_method", "PUT", prefix + "/tx", "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EndpointID(tt.method, tt.path); got != tt.want {
+				t.Fatalf("EndpointID(%q, %q) = %q, want %q", tt.method, tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements ExtractMethod for documented esplora paths, reducing them to a single method identifier per path pattern.