### PR TITLE
feat(ai): retry-aware failover, multimodal, and tool-call translation

### DIFF
--- a/docs/ai-smart-routing.md
+++ b/docs/ai-smart-routing.md
@@ -143,6 +143,16 @@ X-DIN-Optimize: cost
 {
   "model": "ignored",
   "messages": [{"role": "user", "content": "Hello"}],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "lookup_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+      }
+    }
+  ],
+  "tool_choice": "auto",
   "stream": true,
   "temperature": 0.7,
   "top_p": 0.9,
@@ -160,6 +170,10 @@ X-DIN-Optimize: cost
 | `X-DIN-Optimize` | No | `latency` | Provider selection strategy within a tier: `latency` (TTFT-weighted), `cost` (inverse-cost-weighted), or `balanced` (combined 60/40 cost/latency). Session stickiness takes priority when `X-DIN-Session-Id` is present |
 
 The `model` field in the request body is overwritten with the selected provider's configured model. Clients don't need to know which model they're talking to.
+
+`messages[*].content` supports both OpenAI forms:
+- string content (backward compatible)
+- array content parts (`text` and `image_url`)
 
 Request body limit is **10MB**. Bodies exceeding this return `413 Request Entity Too Large`.
 
@@ -193,7 +207,7 @@ Requests are routed to a tier based on the `X-DIN-Tier` header (default: `balanc
    - `cost`: Inverse-cost-weighted random selection. Cheaper providers get more traffic. See [Cost optimization](#cost-optimization).
    - `balanced`: Combined cost + latency scoring (60/40 weighting). See [Balanced mode scoring](#balanced-mode-scoring).
 
-3. **Failover** — If a provider fails, the next untried provider is selected (respecting the same optimization mode). The middleware retries up to `request_attempt_count` times (default: 3, capped at available provider count).
+3. **Failover** — On retryable upstream statuses (`429`, `503`), the middleware retries the same provider once using `Retry-After` (delta-seconds or HTTP-date, capped) and then fails over to the next untried provider if needed. Total request attempts are bounded by `request_attempt_count` (default: 3).
 
 ### TTFT-weighted selection
 
@@ -227,7 +241,7 @@ Each provider's weight is `1 / AvgTTFT`. Faster providers (lower TTFT) get highe
 
 #### Zero-measurement providers
 
-Providers with no TTFT measurements (newly added or just recovered) are assigned a very high weight (`1e9`), causing nearly all traffic to route to them until measurements accumulate. This is a known limitation — see [Known Limitations](#known-limitations).
+Providers with no TTFT measurements (newly added or just recovered) use a sane default TTFT baseline to avoid thundering-herd behavior while still receiving bootstrap traffic.
 
 ### Cost optimization
 
@@ -369,14 +383,17 @@ The Anthropic adapter translates between OpenAI chat completion format and Anthr
 | `stop` sequences | Supported (string or array converted to `stop_sequences`) |
 | Streaming (SSE) | Supported (full event sequence translation) |
 | Non-streaming | Supported |
+| Multimodal input | Supported (`text` and `image_url`, including base64 data URLs) |
+| Tool definitions / tool_choice | Supported |
+| Tool result messages (`role: tool`) | Supported |
+| Tool use translation (response + streaming deltas) | Supported |
 
-### What's not supported (MVP)
+### What's not supported
 
 | Feature | Behavior |
 |---------|----------|
-| Tool use / function calling | Response-only tool_use blocks: error if no text present, text returned with tool calls dropped if mixed |
 | Extended thinking | Thinking blocks dropped |
-| Image / PDF input | Fails at unmarshal (content is string-only) |
+| Image / PDF input beyond OpenAI `image_url` | Not translated |
 | `top_k` parameter | Not forwarded |
 
 ### Streaming translation
@@ -386,8 +403,10 @@ Anthropic uses a stateful multi-event SSE protocol. The adapter tracks event seq
 ```
 Anthropic                          → OpenAI
 message_start                      → {"choices":[{"delta":{"role":"assistant"}}]}
+content_block_start (tool_use)     → {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"...","function":{"name":"..."}}]}}]}
+content_block_delta (input_json_delta) → {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"..."}}]}}]}
 content_block_delta (text_delta)   → {"choices":[{"delta":{"content":"..."}}]}
-message_delta (stop_reason)        → {"choices":[{"finish_reason":"stop"}]}
+message_delta (stop_reason)        → {"choices":[{"finish_reason":"stop|length|tool_calls"}]}
 message_stop                       → [DONE]
 ```
 
@@ -455,10 +474,8 @@ Both use: ticker-based scheduling, quit channel signaling, `sync.Once` cleanup, 
 ## Known Limitations
 
 - **120s flat timeout** — Same HTTP client timeout for streaming, non-streaming, and health checks. Long streams are killed at 120s. Needs separate clients with appropriate timeouts.
-- **New provider thundering herd** — Providers with zero TTFT measurements get very high selection weight (`1e9`), causing nearly all traffic to route to them until measurements accumulate.
 - **No authentication** — MVP has no caller auth on the AI endpoint.
 - **No rate limiting** — No per-user or per-key rate limits at the gateway level.
-- **String-only content** — `ChatMessage.Content` is `string`, not supporting OpenAI's array-of-content-parts format for multimodal input.
 
 ## Open Issues (Tech Debt)
 
@@ -470,8 +487,6 @@ These are tracked in the [code review document](https://github.com/DIN-center/di
 - O3: Double JSON parse on every request
 - O4: Missing `context.Context` propagation to non-streaming upstream calls
 - O5: `Tier` struct missing JSON tags (only Caddyfile works, not JSON API)
-- O6: `ChatMessage.Content` string-only (no multimodal)
-- O7: New providers get near-100% traffic (zero TTFT weight)
 - O8: `Cleanup()` panics on nil logger if called before `Provision()`
 - O9: `writeErrorResponse` ignores `json.Marshal` error
 - O10: `w.Write()` return values ignored
@@ -495,18 +510,15 @@ These are tracked in the [code review document](https://github.com/DIN-center/di
 - Default TTFT for new providers (prevent thundering herd)
 - Authentication/authorization on the AI endpoint
 - `Tier` struct JSON tags for Caddy JSON API support
-- Multimodal content support (`content` as string or array)
 - Concurrency limit for health check goroutines
 
 ### Medium-term
 - Rate limiting per provider (token bucket or sliding window)
 - Budget enforcement and spend limits per tier/API key
 - Model passthrough mode (user specifies exact model)
-- Tool calling / function calling translation for Anthropic
 - Extended thinking support for Anthropic
 - Circuit breaker pattern (replace threshold-based health)
 - Configurable timeouts per provider
-- Retry-After header respect from 429 responses
 - Request/response logging (opt-in debugging)
 
 ### Long-term (see RFP roadmap)

--- a/lib/ai/adapter_anthropic.go
+++ b/lib/ai/adapter_anthropic.go
@@ -540,6 +540,8 @@ func mapOpenAIToolChoiceToAnthropic(choice any) any {
 				}
 			}
 		}
+		// Unrecognized object shape — pass through for forward compatibility.
+		return v
 	}
 	return nil
 }

--- a/lib/ai/adapter_anthropic.go
+++ b/lib/ai/adapter_anthropic.go
@@ -156,6 +156,9 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 					Arguments: string(argsBytes),
 				},
 			})
+		} else if block.Type == "thinking" {
+			// No OpenAI equivalent; intentionally skip.
+			continue
 		} else {
 			unsupportedTypes = append(unsupportedTypes, block.Type)
 		}
@@ -464,6 +467,21 @@ func mapOpenAIContentPartsToAnthropic(parts []ChatMessageContentPart) ([]Anthrop
 			if part.ImageURL == nil || part.ImageURL.URL == "" {
 				return nil, fmt.Errorf("image_url part must include a non-empty url")
 			}
+			if strings.HasPrefix(part.ImageURL.URL, "data:") {
+				mediaType, data, err := parseBase64DataURL(part.ImageURL.URL)
+				if err != nil {
+					return nil, err
+				}
+				blocks = append(blocks, AnthropicRequestContentBlock{
+					Type: "image",
+					Source: &AnthropicImageSource{
+						Type:      "base64",
+						MediaType: mediaType,
+						Data:      data,
+					},
+				})
+				continue
+			}
 			blocks = append(blocks, AnthropicRequestContentBlock{
 				Type: "image",
 				Source: &AnthropicImageSource{
@@ -614,4 +632,26 @@ func (a *AnthropicAdapter) buildOpenAIToolDelta(index int, id, name, partialArgs
 		},
 	}
 	return json.Marshal(chunk)
+}
+
+func parseBase64DataURL(dataURL string) (string, string, error) {
+	comma := strings.Index(dataURL, ",")
+	if comma < 0 {
+		return "", "", fmt.Errorf("invalid image data URL format")
+	}
+	prefix := dataURL[:comma]
+	data := dataURL[comma+1:]
+
+	if !strings.Contains(prefix, ";base64") {
+		return "", "", fmt.Errorf("image data URL must be base64 encoded")
+	}
+
+	mediaType := strings.TrimPrefix(strings.Split(prefix, ";")[0], "data:")
+	if mediaType == "" {
+		mediaType = "image/png"
+	}
+	if data == "" {
+		return "", "", fmt.Errorf("image data URL payload is empty")
+	}
+	return mediaType, data, nil
 }

--- a/lib/ai/adapter_anthropic.go
+++ b/lib/ai/adapter_anthropic.go
@@ -273,11 +273,10 @@ func (a *AnthropicAdapter) TransformStreamEvent(eventType string, data []byte) (
 			return a.buildOpenAIDelta("", delta.Delta.Text, nil)
 		}
 		if delta.Delta.Type == "input_json_delta" {
-			toolState, ok := a.toolCalls[delta.Index]
-			if !ok {
+			if _, ok := a.toolCalls[delta.Index]; !ok {
 				return nil, nil
 			}
-			return a.buildOpenAIToolDelta(delta.Index, toolState.ID, toolState.Name, delta.Delta.PartialJSON)
+			return a.buildOpenAIToolDelta(delta.Index, "", "", delta.Delta.PartialJSON)
 		}
 		return nil, nil // skip non-text deltas
 
@@ -607,6 +606,15 @@ func mergeAssistantToolCalls(msg ChatMessage, anthropicContent any) (any, error)
 
 func (a *AnthropicAdapter) buildOpenAIToolDelta(index int, id, name, partialArgs string) ([]byte, error) {
 	idx := index
+	tc := ToolCall{
+		Index:    &idx,
+		Function: ToolCallFunction{Arguments: partialArgs},
+	}
+	if id != "" {
+		tc.ID = id
+		tc.Type = "function"
+		tc.Function.Name = name
+	}
 	chunk := ChatCompletionResponse{
 		ID:      a.messageID,
 		Object:  "chat.completion.chunk",
@@ -615,19 +623,7 @@ func (a *AnthropicAdapter) buildOpenAIToolDelta(index int, id, name, partialArgs
 		Choices: []ChatCompletionChoice{
 			{
 				Index: 0,
-				Delta: &ChatMessage{
-					ToolCalls: []ToolCall{
-						{
-							Index: &idx,
-							ID:    id,
-							Type:  "function",
-							Function: ToolCallFunction{
-								Name:      name,
-								Arguments: partialArgs,
-							},
-						},
-					},
-				},
+				Delta: &ChatMessage{ToolCalls: []ToolCall{tc}},
 			},
 		},
 	}

--- a/lib/ai/adapter_anthropic.go
+++ b/lib/ai/adapter_anthropic.go
@@ -167,7 +167,7 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 	// return an error rather than silently dropping the content.
 	// When text IS present alongside unsupported types, the text is returned and unsupported
 	// blocks (tool calls, thinking) are intentionally dropped — full tool-call translation is out of scope.
-	if len(contentParts) == 0 && len(unsupportedTypes) > 0 {
+	if len(contentParts) == 0 && len(toolCalls) == 0 && len(unsupportedTypes) > 0 {
 		return nil, fmt.Errorf("anthropic response contains only unsupported content types: %v", unsupportedTypes)
 	}
 	content := ""

--- a/lib/ai/adapter_anthropic.go
+++ b/lib/ai/adapter_anthropic.go
@@ -56,7 +56,13 @@ func (a *AnthropicAdapter) TransformRequest(body []byte) ([]byte, map[string]str
 		anthropicReq.Tools = mapOpenAIToolsToAnthropic(req.Tools)
 	}
 	if req.ToolChoice != nil {
-		anthropicReq.ToolChoice = mapOpenAIToolChoiceToAnthropic(req.ToolChoice)
+		mapped := mapOpenAIToolChoiceToAnthropic(req.ToolChoice)
+		if mapped != nil {
+			anthropicReq.ToolChoice = mapped
+		} else {
+			// "none" — omit tools entirely so Anthropic won't call any.
+			anthropicReq.Tools = nil
+		}
 	}
 
 	// Convert OpenAI stop field to Anthropic stop_sequences.
@@ -518,6 +524,8 @@ func mapOpenAIToolChoiceToAnthropic(choice any) any {
 			return map[string]any{"type": "any"}
 		case "auto":
 			return map[string]any{"type": "auto"}
+		case "none":
+			return nil // caller omits tool_choice and tools
 		default:
 			return map[string]any{"type": "auto"}
 		}

--- a/lib/ai/adapter_anthropic.go
+++ b/lib/ai/adapter_anthropic.go
@@ -66,12 +66,20 @@ func (a *AnthropicAdapter) TransformRequest(body []byte) ([]byte, map[string]str
 	var systemParts []string
 	for _, msg := range req.Messages {
 		if msg.Role == "system" {
-			systemParts = append(systemParts, msg.Content)
+			text, err := extractSystemText(msg.Content)
+			if err != nil {
+				return nil, nil, err
+			}
+			systemParts = append(systemParts, text)
 			continue
+		}
+		anthropicContent, err := toAnthropicContent(msg.Content)
+		if err != nil {
+			return nil, nil, err
 		}
 		anthropicReq.Messages = append(anthropicReq.Messages, AnthropicMessage{
 			Role:    msg.Role,
-			Content: msg.Content,
+			Content: anthropicContent,
 		})
 	}
 	if len(systemParts) > 0 {
@@ -266,4 +274,105 @@ func mapAnthropicStopReason(reason *string) *string {
 		mapped = *reason
 	}
 	return &mapped
+}
+
+func extractSystemText(content any) (string, error) {
+	switch v := content.(type) {
+	case string:
+		return v, nil
+	case []any:
+		parts, err := normalizeOpenAIContentParts(v)
+		if err != nil {
+			return "", err
+		}
+		var sb strings.Builder
+		for _, part := range parts {
+			if part.Type != "text" {
+				return "", fmt.Errorf("unsupported system content part type: %s", part.Type)
+			}
+			sb.WriteString(part.Text)
+		}
+		return sb.String(), nil
+	default:
+		return "", fmt.Errorf("unsupported system content type: %T", content)
+	}
+}
+
+func toAnthropicContent(content any) (any, error) {
+	switch v := content.(type) {
+	case string:
+		return v, nil
+	case []any:
+		parts, err := normalizeOpenAIContentParts(v)
+		if err != nil {
+			return nil, err
+		}
+		return mapOpenAIContentPartsToAnthropic(parts)
+	default:
+		return nil, fmt.Errorf("unsupported OpenAI message content type: %T", content)
+	}
+}
+
+func normalizeOpenAIContentParts(rawParts []any) ([]ChatMessageContentPart, error) {
+	parts := make([]ChatMessageContentPart, 0, len(rawParts))
+	for _, rawPart := range rawParts {
+		partMap, ok := rawPart.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unsupported content part shape: %T", rawPart)
+		}
+		partType, _ := partMap["type"].(string)
+		switch partType {
+		case "text":
+			text, _ := partMap["text"].(string)
+			parts = append(parts, ChatMessageContentPart{
+				Type: "text",
+				Text: text,
+			})
+		case "image_url":
+			imageMap, ok := partMap["image_url"].(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("image_url part must include image_url object")
+			}
+			imageURL, _ := imageMap["url"].(string)
+			if imageURL == "" {
+				return nil, fmt.Errorf("image_url part must include a non-empty url")
+			}
+			parts = append(parts, ChatMessageContentPart{
+				Type: "image_url",
+				ImageURL: &ChatMessageImageURLValue{
+					URL: imageURL,
+				},
+			})
+		default:
+			return nil, fmt.Errorf("unsupported content part type: %s", partType)
+		}
+	}
+	return parts, nil
+}
+
+func mapOpenAIContentPartsToAnthropic(parts []ChatMessageContentPart) ([]AnthropicRequestContentBlock, error) {
+	blocks := make([]AnthropicRequestContentBlock, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case "text":
+			blocks = append(blocks, AnthropicRequestContentBlock{
+				Type: "text",
+				Text: part.Text,
+			})
+		case "image_url":
+			if part.ImageURL == nil || part.ImageURL.URL == "" {
+				return nil, fmt.Errorf("image_url part must include a non-empty url")
+			}
+			blocks = append(blocks, AnthropicRequestContentBlock{
+				Type: "image",
+				Source: &AnthropicImageSource{
+					Type: "url",
+					URL:  part.ImageURL.URL,
+				},
+			})
+		default:
+			return nil, fmt.Errorf("unsupported content part type: %s", part.Type)
+		}
+	}
+	return blocks, nil
 }

--- a/lib/ai/adapter_anthropic.go
+++ b/lib/ai/adapter_anthropic.go
@@ -16,10 +16,18 @@ type AnthropicAdapter struct {
 	// Streaming state — tracks the current message context.
 	messageID string
 	model     string
+	toolCalls map[int]toolStreamState
+}
+
+type toolStreamState struct {
+	ID   string
+	Name string
 }
 
 func NewAnthropicAdapter() *AnthropicAdapter {
-	return &AnthropicAdapter{}
+	return &AnthropicAdapter{
+		toolCalls: make(map[int]toolStreamState),
+	}
 }
 
 func (a *AnthropicAdapter) Name() string {
@@ -43,6 +51,12 @@ func (a *AnthropicAdapter) TransformRequest(body []byte) ([]byte, map[string]str
 
 	if req.MaxTokens != nil {
 		anthropicReq.MaxTokens = *req.MaxTokens
+	}
+	if len(req.Tools) > 0 {
+		anthropicReq.Tools = mapOpenAIToolsToAnthropic(req.Tools)
+	}
+	if req.ToolChoice != nil {
+		anthropicReq.ToolChoice = mapOpenAIToolChoiceToAnthropic(req.ToolChoice)
 	}
 
 	// Convert OpenAI stop field to Anthropic stop_sequences.
@@ -73,7 +87,28 @@ func (a *AnthropicAdapter) TransformRequest(body []byte) ([]byte, map[string]str
 			systemParts = append(systemParts, text)
 			continue
 		}
+		if msg.Role == "tool" {
+			toolContent, err := extractToolResultContent(msg.Content)
+			if err != nil {
+				return nil, nil, err
+			}
+			anthropicReq.Messages = append(anthropicReq.Messages, AnthropicMessage{
+				Role: "user",
+				Content: []AnthropicRequestContentBlock{
+					{
+						Type:      "tool_result",
+						ToolUseID: msg.ToolCallID,
+						Content:   toolContent,
+					},
+				},
+			})
+			continue
+		}
 		anthropicContent, err := toAnthropicContent(msg.Content)
+		if err != nil {
+			return nil, nil, err
+		}
+		anthropicContent, err = mergeAssistantToolCalls(msg, anthropicContent)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -103,10 +138,24 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 
 	// Build content from content blocks.
 	var contentParts []string
+	var toolCalls []ToolCall
 	var unsupportedTypes []string
 	for _, block := range resp.Content {
 		if block.Type == "text" {
 			contentParts = append(contentParts, block.Text)
+		} else if block.Type == "tool_use" {
+			argsBytes, err := json.Marshal(block.Input)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal tool_use input: %w", err)
+			}
+			toolCalls = append(toolCalls, ToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: ToolCallFunction{
+					Name:      block.Name,
+					Arguments: string(argsBytes),
+				},
+			})
 		} else {
 			unsupportedTypes = append(unsupportedTypes, block.Type)
 		}
@@ -136,8 +185,9 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 			{
 				Index: 0,
 				Message: &ChatMessage{
-					Role:    resp.Role,
-					Content: content,
+					Role:      resp.Role,
+					Content:   content,
+					ToolCalls: toolCalls,
 				},
 				FinishReason: finishReason,
 			},
@@ -177,16 +227,54 @@ func (a *AnthropicAdapter) TransformStreamEvent(eventType string, data []byte) (
 		}
 		a.messageID = evt.Message.ID
 		a.model = evt.Message.Model
+		a.toolCalls = make(map[int]toolStreamState)
 		// Emit an initial role chunk like OpenAI does.
 		return a.buildOpenAIDelta("assistant", "", nil)
 
+	case "content_block_start":
+		var start struct {
+			Type         string `json:"type"`
+			Index        int    `json:"index"`
+			ContentBlock struct {
+				Type string `json:"type"`
+				ID   string `json:"id,omitempty"`
+				Name string `json:"name,omitempty"`
+			} `json:"content_block"`
+		}
+		if err := json.Unmarshal(data, &start); err != nil {
+			return nil, fmt.Errorf("failed to parse content_block_start: %w", err)
+		}
+		if start.ContentBlock.Type == "tool_use" {
+			a.toolCalls[start.Index] = toolStreamState{
+				ID:   start.ContentBlock.ID,
+				Name: start.ContentBlock.Name,
+			}
+			return a.buildOpenAIToolDelta(start.Index, start.ContentBlock.ID, start.ContentBlock.Name, "")
+		}
+		return nil, nil
+
 	case "content_block_delta":
-		var delta AnthropicContentBlockDelta
+		var delta struct {
+			Type  string `json:"type"`
+			Index int    `json:"index"`
+			Delta struct {
+				Type        string `json:"type"`
+				Text        string `json:"text,omitempty"`
+				PartialJSON string `json:"partial_json,omitempty"`
+			} `json:"delta"`
+		}
 		if err := json.Unmarshal(data, &delta); err != nil {
 			return nil, fmt.Errorf("failed to parse content_block_delta: %w", err)
 		}
 		if delta.Delta.Type == "text_delta" {
 			return a.buildOpenAIDelta("", delta.Delta.Text, nil)
+		}
+		if delta.Delta.Type == "input_json_delta" {
+			toolState, ok := a.toolCalls[delta.Index]
+			if !ok {
+				return nil, nil
+			}
+			return a.buildOpenAIToolDelta(delta.Index, toolState.ID, toolState.Name, delta.Delta.PartialJSON)
 		}
 		return nil, nil // skip non-text deltas
 
@@ -201,7 +289,7 @@ func (a *AnthropicAdapter) TransformStreamEvent(eventType string, data []byte) (
 	case "message_stop":
 		return []byte("[DONE]"), nil
 
-	case "content_block_start", "content_block_stop", "ping":
+	case "content_block_stop", "ping":
 		// Skip metadata events — no OpenAI equivalent.
 		return nil, nil
 
@@ -270,6 +358,8 @@ func mapAnthropicStopReason(reason *string) *string {
 		mapped = "length"
 	case "stop_sequence":
 		mapped = "stop"
+	case "tool_use":
+		mapped = "tool_calls"
 	default:
 		mapped = *reason
 	}
@@ -280,6 +370,15 @@ func extractSystemText(content any) (string, error) {
 	switch v := content.(type) {
 	case string:
 		return v, nil
+	case []ChatMessageContentPart:
+		var sb strings.Builder
+		for _, part := range v {
+			if part.Type != "text" {
+				return "", fmt.Errorf("unsupported system content part type: %s", part.Type)
+			}
+			sb.WriteString(part.Text)
+		}
+		return sb.String(), nil
 	case []any:
 		parts, err := normalizeOpenAIContentParts(v)
 		if err != nil {
@@ -302,6 +401,8 @@ func toAnthropicContent(content any) (any, error) {
 	switch v := content.(type) {
 	case string:
 		return v, nil
+	case []ChatMessageContentPart:
+		return mapOpenAIContentPartsToAnthropic(v)
 	case []any:
 		parts, err := normalizeOpenAIContentParts(v)
 		if err != nil {
@@ -375,4 +476,142 @@ func mapOpenAIContentPartsToAnthropic(parts []ChatMessageContentPart) ([]Anthrop
 		}
 	}
 	return blocks, nil
+}
+
+func mapOpenAIToolsToAnthropic(tools []OpenAITool) []AnthropicTool {
+	result := make([]AnthropicTool, 0, len(tools))
+	for _, tool := range tools {
+		if tool.Type != "function" {
+			continue
+		}
+		result = append(result, AnthropicTool{
+			Name:        tool.Function.Name,
+			Description: tool.Function.Description,
+			InputSchema: tool.Function.Parameters,
+		})
+	}
+	return result
+}
+
+func mapOpenAIToolChoiceToAnthropic(choice any) any {
+	switch v := choice.(type) {
+	case string:
+		switch v {
+		case "required":
+			return map[string]any{"type": "any"}
+		case "auto":
+			return map[string]any{"type": "auto"}
+		default:
+			return map[string]any{"type": "auto"}
+		}
+	case map[string]any:
+		if v["type"] == "function" {
+			if fn, ok := v["function"].(map[string]any); ok {
+				if name, ok := fn["name"].(string); ok && name != "" {
+					return map[string]any{
+						"type": "tool",
+						"name": name,
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func extractToolResultContent(content any) (string, error) {
+	switch v := content.(type) {
+	case string:
+		return v, nil
+	case []ChatMessageContentPart:
+		var sb strings.Builder
+		for _, part := range v {
+			if part.Type != "text" {
+				return "", fmt.Errorf("tool result supports only text content parts")
+			}
+			sb.WriteString(part.Text)
+		}
+		return sb.String(), nil
+	case []any:
+		parts, err := normalizeOpenAIContentParts(v)
+		if err != nil {
+			return "", err
+		}
+		var sb strings.Builder
+		for _, part := range parts {
+			if part.Type != "text" {
+				return "", fmt.Errorf("tool result supports only text content parts")
+			}
+			sb.WriteString(part.Text)
+		}
+		return sb.String(), nil
+	default:
+		return "", fmt.Errorf("unsupported tool result content type: %T", content)
+	}
+}
+
+func mergeAssistantToolCalls(msg ChatMessage, anthropicContent any) (any, error) {
+	if len(msg.ToolCalls) == 0 {
+		return anthropicContent, nil
+	}
+
+	blocks := []AnthropicRequestContentBlock{}
+	switch v := anthropicContent.(type) {
+	case string:
+		if v != "" {
+			blocks = append(blocks, AnthropicRequestContentBlock{
+				Type: "text",
+				Text: v,
+			})
+		}
+	case []AnthropicRequestContentBlock:
+		blocks = append(blocks, v...)
+	default:
+		return nil, fmt.Errorf("unsupported assistant content container for tool calls: %T", anthropicContent)
+	}
+
+	for _, tc := range msg.ToolCalls {
+		var input map[string]any
+		if tc.Function.Arguments != "" {
+			if err := json.Unmarshal([]byte(tc.Function.Arguments), &input); err != nil {
+				return nil, fmt.Errorf("invalid tool call arguments for %s: %w", tc.Function.Name, err)
+			}
+		}
+		blocks = append(blocks, AnthropicRequestContentBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+	return blocks, nil
+}
+
+func (a *AnthropicAdapter) buildOpenAIToolDelta(index int, id, name, partialArgs string) ([]byte, error) {
+	idx := index
+	chunk := ChatCompletionResponse{
+		ID:      a.messageID,
+		Object:  "chat.completion.chunk",
+		Created: time.Now().Unix(),
+		Model:   a.model,
+		Choices: []ChatCompletionChoice{
+			{
+				Index: 0,
+				Delta: &ChatMessage{
+					ToolCalls: []ToolCall{
+						{
+							Index: &idx,
+							ID:    id,
+							Type:  "function",
+							Function: ToolCallFunction{
+								Name:      name,
+								Arguments: partialArgs,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return json.Marshal(chunk)
 }

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -258,6 +258,34 @@ func TestAnthropicAdapterTransformRequest(t *testing.T) {
 		assert.Equal(t, "https://example.com/cat.png", source["url"])
 	})
 
+	t.Run("multimodal image_url base64 data URL", func(t *testing.T) {
+		input := `{
+			"model":"claude-sonnet-4-20250514",
+			"messages":[
+				{
+					"role":"user",
+					"content":[
+						{"type":"image_url","image_url":{"url":"data:image/png;base64,aGVsbG8="}}
+					]
+				}
+			]
+		}`
+		out, _, err := a.TransformRequest([]byte(input))
+		require.NoError(t, err)
+
+		var result AnthropicRequest
+		require.NoError(t, json.Unmarshal(out, &result))
+		blocks, ok := result.Messages[0].Content.([]interface{})
+		require.True(t, ok)
+		block, ok := blocks[0].(map[string]interface{})
+		require.True(t, ok)
+		source, ok := block["source"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "base64", source["type"])
+		assert.Equal(t, "image/png", source["media_type"])
+		assert.Equal(t, "aGVsbG8=", source["data"])
+	})
+
 	t.Run("unsupported multimodal content part returns error", func(t *testing.T) {
 		input := `{
 			"model":"claude-sonnet-4-20250514",

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -197,6 +197,83 @@ func TestAnthropicAdapterTransformRequest(t *testing.T) {
 		_, _, err := a.TransformRequest([]byte(`not json`))
 		assert.Error(t, err)
 	})
+
+	t.Run("multimodal text-only content array", func(t *testing.T) {
+		input := `{
+			"model":"claude-sonnet-4-20250514",
+			"messages":[
+				{
+					"role":"user",
+					"content":[
+						{"type":"text","text":"hello"},
+						{"type":"text","text":" world"}
+					]
+				}
+			]
+		}`
+		out, _, err := a.TransformRequest([]byte(input))
+		require.NoError(t, err)
+
+		var result AnthropicRequest
+		require.NoError(t, json.Unmarshal(out, &result))
+		require.Len(t, result.Messages, 1)
+		blocks, ok := result.Messages[0].Content.([]interface{})
+		require.True(t, ok)
+		require.Len(t, blocks, 2)
+		first, ok := blocks[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "text", first["type"])
+		assert.Equal(t, "hello", first["text"])
+	})
+
+	t.Run("multimodal mixed text and image_url", func(t *testing.T) {
+		input := `{
+			"model":"claude-sonnet-4-20250514",
+			"messages":[
+				{
+					"role":"user",
+					"content":[
+						{"type":"text","text":"describe image"},
+						{"type":"image_url","image_url":{"url":"https://example.com/cat.png"}}
+					]
+				}
+			]
+		}`
+		out, _, err := a.TransformRequest([]byte(input))
+		require.NoError(t, err)
+
+		var result AnthropicRequest
+		require.NoError(t, json.Unmarshal(out, &result))
+		require.Len(t, result.Messages, 1)
+		blocks, ok := result.Messages[0].Content.([]interface{})
+		require.True(t, ok)
+		require.Len(t, blocks, 2)
+
+		second, ok := blocks[1].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "image", second["type"])
+		source, ok := second["source"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "url", source["type"])
+		assert.Equal(t, "https://example.com/cat.png", source["url"])
+	})
+
+	t.Run("unsupported multimodal content part returns error", func(t *testing.T) {
+		input := `{
+			"model":"claude-sonnet-4-20250514",
+			"messages":[
+				{
+					"role":"user",
+					"content":[
+						{"type":"audio_url","audio_url":{"url":"https://example.com/a.mp3"}}
+					]
+				}
+			]
+		}`
+		_, _, err := a.TransformRequest([]byte(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported content part type")
+	})
 }
 
 func TestAnthropicAdapterTransformResponse(t *testing.T) {

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -274,6 +274,36 @@ func TestAnthropicAdapterTransformRequest(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported content part type")
 	})
+
+	t.Run("maps tools and function tool_choice", func(t *testing.T) {
+		input := `{
+			"model":"claude-sonnet-4-20250514",
+			"messages":[{"role":"user","content":"weather?"}],
+			"tools":[
+				{
+					"type":"function",
+					"function":{
+						"name":"get_weather",
+						"description":"Get weather for a city",
+						"parameters":{"type":"object","properties":{"city":{"type":"string"}}}
+					}
+				}
+			],
+			"tool_choice":{"type":"function","function":{"name":"get_weather"}}
+		}`
+		out, _, err := a.TransformRequest([]byte(input))
+		require.NoError(t, err)
+
+		var result AnthropicRequest
+		require.NoError(t, json.Unmarshal(out, &result))
+		require.Len(t, result.Tools, 1)
+		assert.Equal(t, "get_weather", result.Tools[0].Name)
+
+		choice, ok := result.ToolChoice.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "tool", choice["type"])
+		assert.Equal(t, "get_weather", choice["name"])
+	})
 }
 
 func TestAnthropicAdapterTransformResponse(t *testing.T) {
@@ -563,30 +593,37 @@ func TestAnthropicAdapterSingleSystemMessage(t *testing.T) {
 func TestAnthropicAdapterToolUseContentBlocks(t *testing.T) {
 	a := NewAnthropicAdapter()
 
-	// Response with only tool_use blocks (no text).
+	// Response with only tool_use blocks should map to OpenAI tool_calls.
 	stopReason := "tool_use"
 	anthropicResp := AnthropicResponse{
 		ID:   "msg_456",
 		Type: "message",
 		Role: "assistant",
 		Content: []AnthropicContent{
-			{Type: "tool_use", Text: ""},
+			{Type: "tool_use", ID: "toolu_123", Name: "lookup", Input: map[string]any{"city": "SF"}},
 		},
 		Model:      "claude-sonnet-4-20250514",
 		StopReason: &stopReason,
 	}
 	body, _ := json.Marshal(anthropicResp)
 
-	_, err := a.TransformResponse(body)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported content types")
-	assert.Contains(t, err.Error(), "tool_use")
+	out, err := a.TransformResponse(body)
+	require.NoError(t, err)
+
+	var result ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(out, &result))
+	require.Len(t, result.Choices, 1)
+	require.NotNil(t, result.Choices[0].Message)
+	require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+	assert.Equal(t, "toolu_123", result.Choices[0].Message.ToolCalls[0].ID)
+	assert.Equal(t, "lookup", result.Choices[0].Message.ToolCalls[0].Function.Name)
+	assert.Equal(t, "tool_calls", *result.Choices[0].FinishReason)
 }
 
 func TestAnthropicAdapterMixedContentBlocks(t *testing.T) {
 	a := NewAnthropicAdapter()
 
-	// Response with text + tool_use blocks — text should be returned, tool_use dropped.
+	// Response with text + tool_use blocks should return text and tool calls.
 	stopReason := "end_turn"
 	anthropicResp := AnthropicResponse{
 		ID:   "msg_789",
@@ -594,7 +631,7 @@ func TestAnthropicAdapterMixedContentBlocks(t *testing.T) {
 		Role: "assistant",
 		Content: []AnthropicContent{
 			{Type: "text", Text: "I'll help with that."},
-			{Type: "tool_use", Text: ""},
+			{Type: "tool_use", ID: "tool_use", Name: "lookup", Input: map[string]any{"city": "SF"}},
 		},
 		Model:      "claude-sonnet-4-20250514",
 		StopReason: &stopReason,
@@ -607,6 +644,8 @@ func TestAnthropicAdapterMixedContentBlocks(t *testing.T) {
 	var result ChatCompletionResponse
 	require.NoError(t, json.Unmarshal(out, &result))
 	assert.Equal(t, "I'll help with that.", result.Choices[0].Message.Content)
+	require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+	assert.Equal(t, "tool_use", result.Choices[0].Message.ToolCalls[0].ID)
 }
 
 func TestAnthropicAdapterEmptyContentResponse(t *testing.T) {
@@ -732,6 +771,32 @@ func TestAnthropicAdapterTransformStreamEvent_MalformedMessageStart(t *testing.T
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse message_start")
 	assert.Nil(t, out)
+}
+
+func TestAnthropicAdapterTransformStreamEvent_ToolCallDeltas(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	_, err := a.TransformStreamEvent("message_start", []byte(`{"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-20250514","role":"assistant"}}`))
+	require.NoError(t, err)
+
+	startChunk, err := a.TransformStreamEvent("content_block_start", []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup_weather"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, startChunk)
+
+	deltaChunk, err := a.TransformStreamEvent("content_block_delta", []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"SF\"}"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, deltaChunk)
+
+	var startResp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(startChunk, &startResp))
+	require.Len(t, startResp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "toolu_1", startResp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.Equal(t, "lookup_weather", startResp.Choices[0].Delta.ToolCalls[0].Function.Name)
+
+	var deltaResp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(deltaChunk, &deltaResp))
+	require.Len(t, deltaResp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "{\"city\":\"SF\"}", deltaResp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
 }
 
 // Verify interface compliance at compile time.

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -334,6 +334,35 @@ func TestAnthropicAdapterTransformRequest(t *testing.T) {
 	})
 }
 
+func TestAnthropicAdapterTransformRequest_ToolChoiceNone(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	input := `{
+		"model":"claude-sonnet-4-20250514",
+		"messages":[{"role":"user","content":"hello"}],
+		"tools":[
+			{
+				"type":"function",
+				"function":{
+					"name":"get_weather",
+					"description":"Get weather",
+					"parameters":{"type":"object","properties":{"city":{"type":"string"}}}
+				}
+			}
+		],
+		"tool_choice":"none"
+	}`
+	out, _, err := a.TransformRequest([]byte(input))
+	require.NoError(t, err)
+
+	var result AnthropicRequest
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	// "none" should omit both tools and tool_choice from the request.
+	assert.Nil(t, result.Tools, "tools should be omitted when tool_choice is none")
+	assert.Nil(t, result.ToolChoice, "tool_choice should be omitted when none")
+}
+
 func TestAnthropicAdapterTransformResponse(t *testing.T) {
 	a := NewAnthropicAdapter()
 

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -363,6 +363,65 @@ func TestAnthropicAdapterTransformRequest_ToolChoiceNone(t *testing.T) {
 	assert.Nil(t, result.ToolChoice, "tool_choice should be omitted when none")
 }
 
+func TestAnthropicAdapterTransformRequest_ToolChoiceUnrecognizedPassthrough(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	t.Run("unrecognized object shape passes through", func(t *testing.T) {
+		input := `{
+			"model":"claude-sonnet-4-20250514",
+			"messages":[{"role":"user","content":"hello"}],
+			"tools":[
+				{
+					"type":"function",
+					"function":{
+						"name":"get_weather",
+						"description":"Get weather",
+						"parameters":{"type":"object","properties":{"city":{"type":"string"}}}
+					}
+				}
+			],
+			"tool_choice":{"type":"new_type","data":"value"}
+		}`
+		out, _, err := a.TransformRequest([]byte(input))
+		require.NoError(t, err)
+
+		var result AnthropicRequest
+		require.NoError(t, json.Unmarshal(out, &result))
+
+		choice, ok := result.ToolChoice.(map[string]interface{})
+		require.True(t, ok, "unrecognized tool_choice should be passed through")
+		assert.Equal(t, "new_type", choice["type"])
+		assert.Equal(t, "value", choice["data"])
+	})
+
+	t.Run("malformed function object passes through", func(t *testing.T) {
+		input := `{
+			"model":"claude-sonnet-4-20250514",
+			"messages":[{"role":"user","content":"hello"}],
+			"tools":[
+				{
+					"type":"function",
+					"function":{
+						"name":"get_weather",
+						"description":"Get weather",
+						"parameters":{"type":"object","properties":{"city":{"type":"string"}}}
+					}
+				}
+			],
+			"tool_choice":{"type":"function"}
+		}`
+		out, _, err := a.TransformRequest([]byte(input))
+		require.NoError(t, err)
+
+		var result AnthropicRequest
+		require.NoError(t, json.Unmarshal(out, &result))
+
+		choice, ok := result.ToolChoice.(map[string]interface{})
+		require.True(t, ok, "malformed function tool_choice should be passed through")
+		assert.Equal(t, "function", choice["type"])
+	})
+}
+
 func TestAnthropicAdapterTransformResponse(t *testing.T) {
 	a := NewAnthropicAdapter()
 

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -861,6 +861,18 @@ func TestAnthropicAdapterTransformStreamEvent_MalformedMessageStart(t *testing.T
 	assert.Nil(t, out)
 }
 
+func TestAnthropicAdapterTransformStreamEvent_ContentBlockStartText(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	_, err := a.TransformStreamEvent("message_start", []byte(`{"type":"message_start","message":{"id":"msg_t","model":"claude-sonnet-4-20250514","role":"assistant"}}`))
+	require.NoError(t, err)
+
+	// content_block_start with type "text" should return nil (no chunk to emit).
+	out, err := a.TransformStreamEvent("content_block_start", []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`))
+	assert.NoError(t, err)
+	assert.Nil(t, out, "content_block_start with text type should not emit a chunk")
+}
+
 func TestAnthropicAdapterTransformStreamEvent_ToolCallDeltas(t *testing.T) {
 	a := NewAnthropicAdapter()
 

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -361,6 +362,51 @@ func TestAnthropicAdapterTransformRequest_ToolChoiceNone(t *testing.T) {
 	// "none" should omit both tools and tool_choice from the request.
 	assert.Nil(t, result.Tools, "tools should be omitted when tool_choice is none")
 	assert.Nil(t, result.ToolChoice, "tool_choice should be omitted when none")
+}
+
+func TestAnthropicAdapterTransformRequest_ToolChoiceStringMappings(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	tests := []struct {
+		name         string
+		toolChoice   string
+		expectedType string
+	}{
+		{"auto maps to auto", "auto", "auto"},
+		{"required maps to any", "required", "any"},
+		{"unknown string defaults to auto", "foobar", "auto"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(`{
+				"model":"claude-sonnet-4-20250514",
+				"messages":[{"role":"user","content":"hello"}],
+				"tools":[
+					{
+						"type":"function",
+						"function":{
+							"name":"get_weather",
+							"description":"Get weather",
+							"parameters":{"type":"object","properties":{"city":{"type":"string"}}}
+						}
+					}
+				],
+				"tool_choice":"%s"
+			}`, tt.toolChoice)
+
+			out, _, err := a.TransformRequest([]byte(input))
+			require.NoError(t, err)
+
+			var result AnthropicRequest
+			require.NoError(t, json.Unmarshal(out, &result))
+
+			assert.NotNil(t, result.Tools, "tools should be preserved for %s", tt.toolChoice)
+			choice, ok := result.ToolChoice.(map[string]interface{})
+			require.True(t, ok, "tool_choice should be an object for %s", tt.toolChoice)
+			assert.Equal(t, tt.expectedType, choice["type"])
+		})
+	}
 }
 
 func TestAnthropicAdapterTransformRequest_ToolChoiceUnrecognizedPassthrough(t *testing.T) {

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -582,6 +582,7 @@ func TestAnthropicStopReasonMapping(t *testing.T) {
 		{"end_turn", "stop"},
 		{"max_tokens", "length"},
 		{"stop_sequence", "stop"},
+		{"tool_use", "tool_calls"},
 		{"unknown_reason", "unknown_reason"},
 	}
 
@@ -891,6 +892,121 @@ func TestAnthropicAdapterTransformStreamEvent_ToolCallDeltas(t *testing.T) {
 	assert.Empty(t, deltaTC.ID, "continuation delta must omit id")
 	assert.Empty(t, deltaTC.Type, "continuation delta must omit type")
 	assert.Empty(t, deltaTC.Function.Name, "continuation delta must omit function name")
+}
+
+func TestAnthropicAdapterTransformRequest_MultiTurnToolConversation(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	// Full multi-turn: system → user → assistant (with tool_calls) → tool (result) → user
+	input := ChatCompletionRequest{
+		Model: "claude-sonnet-4-20250514",
+		Messages: []ChatMessage{
+			{Role: "system", Content: "You are a helpful assistant."},
+			{Role: "user", Content: "What's the weather in SF?"},
+			{
+				Role:    "assistant",
+				Content: "Let me check the weather.",
+				ToolCalls: []ToolCall{
+					{
+						ID:   "call_abc123",
+						Type: "function",
+						Function: ToolCallFunction{
+							Name:      "get_weather",
+							Arguments: `{"city":"San Francisco"}`,
+						},
+					},
+				},
+			},
+			{
+				Role:       "tool",
+				Content:    `{"temperature":65,"condition":"foggy"}`,
+				ToolCallID: "call_abc123",
+			},
+			{Role: "user", Content: "Thanks!"},
+		},
+	}
+	body, _ := json.Marshal(input)
+
+	out, _, err := a.TransformRequest(body)
+	require.NoError(t, err)
+
+	var result AnthropicRequest
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	assert.Equal(t, "You are a helpful assistant.", result.System)
+	require.Len(t, result.Messages, 4) // user, assistant (with tool_use), user (tool_result), user
+
+	// Assistant message should have text + tool_use content blocks.
+	assistantMsg := result.Messages[1]
+	assert.Equal(t, "assistant", assistantMsg.Role)
+	contentBlocks, ok := assistantMsg.Content.([]any)
+	require.True(t, ok, "assistant content should be an array")
+	require.Len(t, contentBlocks, 2, "should have text + tool_use blocks")
+
+	// Tool result message should be a user message with tool_result block.
+	toolResultMsg := result.Messages[2]
+	assert.Equal(t, "user", toolResultMsg.Role)
+}
+
+func TestAnthropicAdapterTransformStreamEvent_ConcurrentToolCalls(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	// Initialize streaming state.
+	_, err := a.TransformStreamEvent("message_start", []byte(`{"type":"message_start","message":{"id":"msg_2","model":"claude-sonnet-4-20250514","role":"assistant"}}`))
+	require.NoError(t, err)
+
+	// Start tool A at index 0.
+	startA, err := a.TransformStreamEvent("content_block_start", []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"get_weather"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, startA)
+
+	// Start tool B at index 1.
+	startB, err := a.TransformStreamEvent("content_block_start", []byte(`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_b","name":"get_time"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, startB)
+
+	// Interleaved deltas for both tools.
+	deltaA1, err := a.TransformStreamEvent("content_block_delta", []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\""}}`))
+	require.NoError(t, err)
+	require.NotNil(t, deltaA1)
+
+	deltaB1, err := a.TransformStreamEvent("content_block_delta", []byte(`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"tz\""}}`))
+	require.NoError(t, err)
+	require.NotNil(t, deltaB1)
+
+	deltaA2, err := a.TransformStreamEvent("content_block_delta", []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"SF\"}"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, deltaA2)
+
+	// Verify start chunks have id/type/name.
+	var startAResp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(startA, &startAResp))
+	assert.Equal(t, "toolu_a", startAResp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.Equal(t, "get_weather", startAResp.Choices[0].Delta.ToolCalls[0].Function.Name)
+
+	var startBResp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(startB, &startBResp))
+	assert.Equal(t, "toolu_b", startBResp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.Equal(t, "get_time", startBResp.Choices[0].Delta.ToolCalls[0].Function.Name)
+
+	// Verify delta chunks target correct indices.
+	var deltaA1Resp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(deltaA1, &deltaA1Resp))
+	require.NotNil(t, deltaA1Resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, 0, *deltaA1Resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, `{"city"`, deltaA1Resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	var deltaB1Resp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(deltaB1, &deltaB1Resp))
+	require.NotNil(t, deltaB1Resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, 1, *deltaB1Resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, `{"tz"`, deltaB1Resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	var deltaA2Resp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(deltaA2, &deltaA2Resp))
+	require.NotNil(t, deltaA2Resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, 0, *deltaA2Resp.Choices[0].Delta.ToolCalls[0].Index)
+	assert.Equal(t, `:"SF"}`, deltaA2Resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
 }
 
 // Verify interface compliance at compile time.

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -648,6 +648,36 @@ func TestAnthropicAdapterToolUseContentBlocks(t *testing.T) {
 	assert.Equal(t, "tool_calls", *result.Choices[0].FinishReason)
 }
 
+func TestAnthropicAdapterTransformResponse_ToolUseWithUnknownType(t *testing.T) {
+	a := NewAnthropicAdapter()
+
+	// Response with tool_use + unknown block type should succeed, not error.
+	stopReason := "tool_use"
+	anthropicResp := AnthropicResponse{
+		ID:   "msg_unknown",
+		Type: "message",
+		Role: "assistant",
+		Content: []AnthropicContent{
+			{Type: "tool_use", ID: "toolu_abc", Name: "search", Input: map[string]any{"q": "test"}},
+			{Type: "server_tool_result", Text: "some unknown block type"},
+		},
+		Model:      "claude-sonnet-4-20250514",
+		StopReason: &stopReason,
+	}
+	body, _ := json.Marshal(anthropicResp)
+
+	out, err := a.TransformResponse(body)
+	require.NoError(t, err, "should not error when tool_use blocks exist alongside unknown types")
+
+	var result ChatCompletionResponse
+	require.NoError(t, json.Unmarshal(out, &result))
+	require.Len(t, result.Choices, 1)
+	require.NotNil(t, result.Choices[0].Message)
+	require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+	assert.Equal(t, "toolu_abc", result.Choices[0].Message.ToolCalls[0].ID)
+	assert.Equal(t, "search", result.Choices[0].Message.ToolCalls[0].Function.Name)
+}
+
 func TestAnthropicAdapterMixedContentBlocks(t *testing.T) {
 	a := NewAnthropicAdapter()
 

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -1126,6 +1126,79 @@ func TestAnthropicAdapterTransformStreamEvent_ConcurrentToolCalls(t *testing.T) 
 	assert.Equal(t, `:"SF"}`, deltaA2Resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
 }
 
+func TestParseBase64DataURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantMedia   string
+		wantData    string
+		wantErrMsg  string
+	}{
+		{
+			name:       "no comma separator",
+			input:      "data:image/png;base64",
+			wantErrMsg: "invalid image data URL format",
+		},
+		{
+			name:       "not base64 encoded",
+			input:      "data:image/png;charset=utf-8,hello",
+			wantErrMsg: "must be base64 encoded",
+		},
+		{
+			name:       "empty data payload",
+			input:      "data:image/png;base64,",
+			wantErrMsg: "payload is empty",
+		},
+		{
+			name:      "no explicit media type defaults to image/png",
+			input:     "data:;base64,aGVsbG8=",
+			wantMedia: "image/png",
+			wantData:  "aGVsbG8=",
+		},
+		{
+			name:      "valid jpeg data URL",
+			input:     "data:image/jpeg;base64,/9j/4AAQ",
+			wantMedia: "image/jpeg",
+			wantData:  "/9j/4AAQ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mediaType, data, err := parseBase64DataURL(tt.input)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMedia, mediaType)
+			assert.Equal(t, tt.wantData, data)
+		})
+	}
+}
+
+func TestExtractSystemText_ArrayContentParts(t *testing.T) {
+	t.Run("array of text parts concatenated", func(t *testing.T) {
+		content := []any{
+			map[string]any{"type": "text", "text": "Hello "},
+			map[string]any{"type": "text", "text": "world"},
+		}
+		result, err := extractSystemText(content)
+		require.NoError(t, err)
+		assert.Equal(t, "Hello world", result)
+	})
+
+	t.Run("array with unsupported part type returns error", func(t *testing.T) {
+		content := []any{
+			map[string]any{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/img.png"}},
+		}
+		_, err := extractSystemText(content)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported")
+	})
+}
+
 // Verify interface compliance at compile time.
 var (
 	_ ProviderAdapter = (*OpenAIAdapter)(nil)

--- a/lib/ai/adapter_test.go
+++ b/lib/ai/adapter_test.go
@@ -818,13 +818,20 @@ func TestAnthropicAdapterTransformStreamEvent_ToolCallDeltas(t *testing.T) {
 	var startResp ChatCompletionResponse
 	require.NoError(t, json.Unmarshal(startChunk, &startResp))
 	require.Len(t, startResp.Choices[0].Delta.ToolCalls, 1)
-	assert.Equal(t, "toolu_1", startResp.Choices[0].Delta.ToolCalls[0].ID)
-	assert.Equal(t, "lookup_weather", startResp.Choices[0].Delta.ToolCalls[0].Function.Name)
+	startTC := startResp.Choices[0].Delta.ToolCalls[0]
+	assert.Equal(t, "toolu_1", startTC.ID, "content_block_start must include tool id")
+	assert.Equal(t, "function", startTC.Type, "content_block_start must include type")
+	assert.Equal(t, "lookup_weather", startTC.Function.Name, "content_block_start must include function name")
 
 	var deltaResp ChatCompletionResponse
 	require.NoError(t, json.Unmarshal(deltaChunk, &deltaResp))
 	require.Len(t, deltaResp.Choices[0].Delta.ToolCalls, 1)
-	assert.Equal(t, "{\"city\":\"SF\"}", deltaResp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+	deltaTC := deltaResp.Choices[0].Delta.ToolCalls[0]
+	assert.Equal(t, "{\"city\":\"SF\"}", deltaTC.Function.Arguments)
+	// Continuation deltas must NOT include id, type, or name per OpenAI streaming spec.
+	assert.Empty(t, deltaTC.ID, "continuation delta must omit id")
+	assert.Empty(t, deltaTC.Type, "continuation delta must omit type")
+	assert.Empty(t, deltaTC.Function.Name, "continuation delta must omit function name")
 }
 
 // Verify interface compliance at compile time.

--- a/lib/ai/interface.go
+++ b/lib/ai/interface.go
@@ -11,7 +11,7 @@ import (
 type IStreamingHTTPClient interface {
 	// Post sends a request and returns the full response body.
 	// Used for non-streaming requests.
-	Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error)
+	Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error)
 
 	// PostStream sends a request and returns the raw http.Response.
 	// Used for streaming requests where the caller reads the body incrementally.

--- a/lib/ai/types.go
+++ b/lib/ai/types.go
@@ -131,6 +131,11 @@ type AnthropicMessage struct {
 }
 
 // AnthropicRequestContentBlock represents one content block in Anthropic request messages.
+// Field usage by block type:
+//   - "text": Text
+//   - "image": Source
+//   - "tool_use": ID, Name, Input
+//   - "tool_result": ToolUseID, Content (the tool's output string)
 type AnthropicRequestContentBlock struct {
 	Type      string                `json:"type"`
 	Text      string                `json:"text,omitempty"`

--- a/lib/ai/types.go
+++ b/lib/ai/types.go
@@ -13,12 +13,17 @@ type ChatCompletionRequest struct {
 	Stop             any           `json:"stop,omitempty"`
 	N                *int          `json:"n,omitempty"`
 	User             string        `json:"user,omitempty"`
+	Tools            []OpenAITool  `json:"tools,omitempty"`
+	ToolChoice       any           `json:"tool_choice,omitempty"`
 }
 
 // ChatMessage represents a single message in a conversation.
 type ChatMessage struct {
-	Role    string `json:"role"`
-	Content any    `json:"content"`
+	Role       string     `json:"role"`
+	Content    any        `json:"content"`
+	Name       string     `json:"name,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 }
 
 // ChatMessageContentPart represents one OpenAI multimodal content part.
@@ -45,10 +50,37 @@ type ChatCompletionResponse struct {
 
 // ChatCompletionChoice represents a single choice in a completion response.
 type ChatCompletionChoice struct {
-	Index        int         `json:"index"`
+	Index        int          `json:"index"`
 	Message      *ChatMessage `json:"message,omitempty"`
 	Delta        *ChatMessage `json:"delta,omitempty"`
-	FinishReason *string     `json:"finish_reason,omitempty"`
+	FinishReason *string      `json:"finish_reason,omitempty"`
+}
+
+// OpenAITool represents one OpenAI tool definition.
+type OpenAITool struct {
+	Type     string         `json:"type"`
+	Function OpenAIFunction `json:"function"`
+}
+
+// OpenAIFunction is the schema for OpenAI function tools.
+type OpenAIFunction struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+// ToolCall represents OpenAI tool call payloads for non-streaming and streaming deltas.
+type ToolCall struct {
+	Index    *int             `json:"index,omitempty"`
+	ID       string           `json:"id,omitempty"`
+	Type     string           `json:"type,omitempty"`
+	Function ToolCallFunction `json:"function,omitempty"`
+}
+
+// ToolCallFunction contains function-call name/arguments.
+type ToolCallFunction struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
 }
 
 // UsageInfo tracks token consumption for a request.
@@ -88,6 +120,8 @@ type AnthropicRequest struct {
 	Temperature   *float64           `json:"temperature,omitempty"`
 	TopP          *float64           `json:"top_p,omitempty"`
 	StopSequences []string           `json:"stop_sequences,omitempty"`
+	Tools         []AnthropicTool    `json:"tools,omitempty"`
+	ToolChoice    any                `json:"tool_choice,omitempty"`
 }
 
 // AnthropicMessage represents a message in the Anthropic format.
@@ -98,9 +132,14 @@ type AnthropicMessage struct {
 
 // AnthropicRequestContentBlock represents one content block in Anthropic request messages.
 type AnthropicRequestContentBlock struct {
-	Type   string                `json:"type"`
-	Text   string                `json:"text,omitempty"`
-	Source *AnthropicImageSource `json:"source,omitempty"`
+	Type      string                `json:"type"`
+	Text      string                `json:"text,omitempty"`
+	Source    *AnthropicImageSource `json:"source,omitempty"`
+	ID        string                `json:"id,omitempty"`
+	Name      string                `json:"name,omitempty"`
+	Input     map[string]any        `json:"input,omitempty"`
+	ToolUseID string                `json:"tool_use_id,omitempty"`
+	Content   string                `json:"content,omitempty"`
 }
 
 // AnthropicImageSource defines Anthropic image source payload.
@@ -124,8 +163,18 @@ type AnthropicResponse struct {
 
 // AnthropicContent represents a content block in an Anthropic response.
 type AnthropicContent struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
+	Type  string         `json:"type"`
+	Text  string         `json:"text,omitempty"`
+	ID    string         `json:"id,omitempty"`
+	Name  string         `json:"name,omitempty"`
+	Input map[string]any `json:"input,omitempty"`
+}
+
+// AnthropicTool represents one Anthropic tool definition.
+type AnthropicTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"input_schema,omitempty"`
 }
 
 // AnthropicUsage represents token usage in the Anthropic format.

--- a/lib/ai/types.go
+++ b/lib/ai/types.go
@@ -18,7 +18,19 @@ type ChatCompletionRequest struct {
 // ChatMessage represents a single message in a conversation.
 type ChatMessage struct {
 	Role    string `json:"role"`
-	Content string `json:"content"`
+	Content any    `json:"content"`
+}
+
+// ChatMessageContentPart represents one OpenAI multimodal content part.
+type ChatMessageContentPart struct {
+	Type     string                    `json:"type"`
+	Text     string                    `json:"text,omitempty"`
+	ImageURL *ChatMessageImageURLValue `json:"image_url,omitempty"`
+}
+
+// ChatMessageImageURLValue is the payload for image_url content parts.
+type ChatMessageImageURLValue struct {
+	URL string `json:"url"`
 }
 
 // ChatCompletionResponse represents an OpenAI-compatible chat completion response.
@@ -81,7 +93,21 @@ type AnthropicRequest struct {
 // AnthropicMessage represents a message in the Anthropic format.
 type AnthropicMessage struct {
 	Role    string `json:"role"`
-	Content string `json:"content"`
+	Content any    `json:"content"`
+}
+
+// AnthropicRequestContentBlock represents one content block in Anthropic request messages.
+type AnthropicRequestContentBlock struct {
+	Type   string                `json:"type"`
+	Text   string                `json:"text,omitempty"`
+	Source *AnthropicImageSource `json:"source,omitempty"`
+}
+
+// AnthropicImageSource defines Anthropic image source payload.
+type AnthropicImageSource struct {
+	Type string `json:"type"`
+	URL  string `json:"url,omitempty"`
+	Data string `json:"data,omitempty"`
 }
 
 // AnthropicResponse represents an Anthropic Messages API response.

--- a/lib/ai/types.go
+++ b/lib/ai/types.go
@@ -144,9 +144,10 @@ type AnthropicRequestContentBlock struct {
 
 // AnthropicImageSource defines Anthropic image source payload.
 type AnthropicImageSource struct {
-	Type string `json:"type"`
-	URL  string `json:"url,omitempty"`
-	Data string `json:"data,omitempty"`
+	Type      string `json:"type"`
+	URL       string `json:"url,omitempty"`
+	Data      string `json:"data,omitempty"`
+	MediaType string `json:"media_type,omitempty"`
 }
 
 // AnthropicResponse represents an Anthropic Messages API response.

--- a/modules/ai/healthcheck.go
+++ b/modules/ai/healthcheck.go
@@ -121,7 +121,7 @@ func checkProvider(
 
 	startTime := time.Now()
 
-	respBody, statusCode, err := client.Post(ctx, provider.HttpUrl, headers, transformedBody)
+	respBody, statusCode, _, err := client.Post(ctx, provider.HttpUrl, headers, transformedBody)
 	if err != nil {
 		logger.Warn("health check failed",
 			zap.String("provider", provider.Name),

--- a/modules/ai/healthcheck_test.go
+++ b/modules/ai/healthcheck_test.go
@@ -41,7 +41,7 @@ func (m *mockHealthCheckClient) PostStream(ctx context.Context, url string, head
 }
 
 func TestCheckProvider_Success(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 	provider := newTestProvider("test-openai", Healthy)
 	provider.ModelID = "gpt-4o-mini"
 	provider.AdapterType = AdapterOpenAI
@@ -59,7 +59,7 @@ func TestCheckProvider_Success(t *testing.T) {
 }
 
 func TestCheckProvider_Failure(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 	provider := newTestProvider("test-openai", Healthy)
 	provider.ModelID = "gpt-4o-mini"
 	provider.AdapterType = AdapterOpenAI
@@ -80,7 +80,7 @@ func TestCheckProvider_Failure(t *testing.T) {
 }
 
 func TestCheckProvider_RateLimited(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 	provider := newTestProvider("test-openai", Healthy)
 	provider.ModelID = "gpt-4o-mini"
 	provider.AdapterType = AdapterOpenAI
@@ -97,7 +97,7 @@ func TestCheckProvider_RateLimited(t *testing.T) {
 }
 
 func TestCheckProvider_NetworkError(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 	provider := newTestProvider("test-openai", Healthy)
 	provider.ModelID = "gpt-4o-mini"
 	provider.AdapterType = AdapterOpenAI
@@ -116,7 +116,7 @@ func TestCheckProvider_NetworkError(t *testing.T) {
 }
 
 func TestCheckProvider_AnthropicAdapter(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 	provider := newTestProvider("test-anthropic", Healthy)
 	provider.ModelID = "claude-haiku-4-5-20251001"
 	provider.AdapterType = AdapterAnthropic
@@ -134,7 +134,7 @@ func TestCheckProvider_AnthropicAdapter(t *testing.T) {
 }
 
 func TestRunHealthChecks_StopsOnQuit(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 	tiers := map[string]*Tier{
 		TierFast: {
 			Name: TierFast,
@@ -190,7 +190,7 @@ func TestGetAdapterForType(t *testing.T) {
 }
 
 func TestCheckProvider_WithOverrides(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 
 	// Track what the mock server receives.
 	var receivedBody []byte
@@ -224,7 +224,7 @@ func TestCheckProvider_WithOverrides(t *testing.T) {
 }
 
 func TestCheckProvider_DefaultMaxTokens(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 
 	// Track what the mock server receives.
 	var receivedBody []byte
@@ -256,7 +256,7 @@ func TestCheckProvider_DefaultMaxTokens(t *testing.T) {
 }
 
 func TestCheckProvider_CancelledContext(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 	provider := newTestProvider("test-openai", Healthy)
 	provider.ModelID = "gpt-4o-mini"
 	provider.AdapterType = AdapterOpenAI
@@ -280,7 +280,7 @@ func TestCheckProvider_CancelledContext(t *testing.T) {
 }
 
 func TestCheckProvider_OverridesPreserveMaxTokens(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 
 	var receivedBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -311,7 +311,7 @@ func TestCheckProvider_OverridesPreserveMaxTokens(t *testing.T) {
 }
 
 func TestCheckProvider_OverridesCanOverrideMaxTokens(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 
 	var receivedBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -340,7 +340,7 @@ func TestCheckProvider_OverridesCanOverrideMaxTokens(t *testing.T) {
 }
 
 func TestRunHealthChecks_BoundsGoroutines(t *testing.T) {
-	ensureMetricsRegistered(t)
+
 
 	// Track concurrent goroutine count to verify bounding.
 	var running int32

--- a/modules/ai/healthcheck_test.go
+++ b/modules/ai/healthcheck_test.go
@@ -23,11 +23,11 @@ type mockHealthCheckClient struct {
 	err        error
 }
 
-func (m *mockHealthCheckClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+func (m *mockHealthCheckClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 	if m.err != nil {
-		return nil, 0, m.err
+		return nil, 0, nil, m.err
 	}
-	return []byte(m.body), m.statusCode, nil
+	return []byte(m.body), m.statusCode, nil, nil
 }
 
 func (m *mockHealthCheckClient) PostStream(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {
@@ -348,7 +348,7 @@ func TestRunHealthChecks_BoundsGoroutines(t *testing.T) {
 
 	// Create a slow mock that takes 500ms per check and tracks concurrency.
 	slowMock := &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 			cur := atomic.AddInt32(&running, 1)
 			defer atomic.AddInt32(&running, -1)
 
@@ -361,7 +361,7 @@ func TestRunHealthChecks_BoundsGoroutines(t *testing.T) {
 			}
 
 			time.Sleep(500 * time.Millisecond)
-			return []byte(`{}`), 200, nil
+			return []byte(`{}`), 200, nil, nil
 		},
 	}
 

--- a/modules/ai/integration_test.go
+++ b/modules/ai/integration_test.go
@@ -20,7 +20,6 @@ import (
 // skipIfNoKey skips the test if the given env var is not set.
 func skipIfNoKey(t *testing.T, envVar string) string {
 	t.Helper()
-	ensureMetricsRegistered(t)
 	key := os.Getenv(envVar)
 	if key == "" {
 		t.Skipf("Skipping: %s not set", envVar)
@@ -42,7 +41,6 @@ func setDefaultCost(p *AIProvider) {
 // This eliminates the repeated ~15-line setup pattern across many test functions.
 func newSingleProviderMiddleware(t *testing.T, name, url, model, adapterType string, headers map[string]string) *DinAIMiddleware {
 	t.Helper()
-	ensureMetricsRegistered(t)
 	client := newDefaultStreamingClient()
 	logger := zap.NewNop()
 	p, err := NewAIProvider(name, url)
@@ -71,7 +69,6 @@ func newSingleProviderMiddleware(t *testing.T, name, url, model, adapterType str
 // Providers are set up based on which env vars are available.
 func newLiveMiddleware(t *testing.T) *DinAIMiddleware {
 	t.Helper()
-	ensureMetricsRegistered(t)
 
 	client := newDefaultStreamingClient()
 	logger := zap.NewNop()
@@ -687,8 +684,6 @@ func TestIntegration_ResponseHeaders(t *testing.T) {
 // --- Mock Server Integration Tests (no API key required) ---
 
 func TestIntegration_MockServer_NonStreaming(t *testing.T) {
-	ensureMetricsRegistered(t)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var req libai.ChatCompletionRequest
@@ -727,7 +722,6 @@ func TestIntegration_MockServer_NonStreaming(t *testing.T) {
 }
 
 func TestIntegration_MockServer_Streaming(t *testing.T) {
-	ensureMetricsRegistered(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -772,8 +766,6 @@ func TestIntegration_MockServer_Streaming(t *testing.T) {
 }
 
 func TestIntegration_MockServer_Failover(t *testing.T) {
-	ensureMetricsRegistered(t)
-
 	// Bad server returns 500
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
@@ -834,7 +826,6 @@ func TestIntegration_MockServer_Failover(t *testing.T) {
 }
 
 func TestIntegration_MockServer_AllFail_503(t *testing.T) {
-	ensureMetricsRegistered(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)

--- a/modules/ai/integration_test.go
+++ b/modules/ai/integration_test.go
@@ -38,6 +38,35 @@ func setDefaultCost(p *AIProvider) {
 	}
 }
 
+// newSingleProviderMiddleware creates a middleware with a single provider for integration tests.
+// This eliminates the repeated ~15-line setup pattern across many test functions.
+func newSingleProviderMiddleware(t *testing.T, name, url, model, adapterType string, headers map[string]string) *DinAIMiddleware {
+	t.Helper()
+	ensureMetricsRegistered(t)
+	client := newDefaultStreamingClient()
+	logger := zap.NewNop()
+	p, err := NewAIProvider(name, url)
+	require.NoError(t, err)
+	p.ModelID = model
+	p.AdapterType = adapterType
+	for k, v := range headers {
+		p.Headers[k] = v
+	}
+	p.httpClient = client
+	p.logger = logger
+	setDefaultCost(p)
+	return &DinAIMiddleware{
+		Tiers: map[string]*Tier{
+			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
+		},
+		RequestAttemptCount: DefaultRequestAttemptCount,
+		logger:              logger,
+		quit:                make(chan struct{}),
+		client:              client,
+		testMode:            true,
+	}
+}
+
 // newLiveMiddleware creates a DinAIMiddleware configured to talk to real AI APIs.
 // Providers are set up based on which env vars are available.
 func newLiveMiddleware(t *testing.T) *DinAIMiddleware {
@@ -212,28 +241,11 @@ func TestIntegration_NonStreaming_OpenAI(t *testing.T) {
 func TestIntegration_NonStreaming_Anthropic(t *testing.T) {
 	skipIfNoKey(t, "ANTHROPIC_API_KEY")
 
-	// Single-provider middleware to guarantee hitting Anthropic
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("anthropic-haiku", "https://api.anthropic.com/v1/messages")
-	p.ModelID = "claude-haiku-4-5-20251001"
-	p.AdapterType = AdapterAnthropic
-	p.Headers["x-api-key"] = os.Getenv("ANTHROPIC_API_KEY")
-	p.Headers["anthropic-version"] = "2023-06-01"
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "anthropic-haiku", "https://api.anthropic.com/v1/messages",
+		"claude-haiku-4-5-20251001", AdapterAnthropic, map[string]string{
+			"x-api-key":         os.Getenv("ANTHROPIC_API_KEY"),
+			"anthropic-version": "2023-06-01",
+		})
 
 	body := `{"messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -255,32 +267,16 @@ func TestIntegration_NonStreaming_Anthropic(t *testing.T) {
 func TestIntegration_NonStreaming_Mistral(t *testing.T) {
 	skipIfNoKey(t, "MISTRAL_API_KEY")
 
-	// Create a middleware with ONLY Mistral to guarantee we hit it
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("mistral-small", "https://api.mistral.ai/v1/chat/completions")
-	p.ModelID = "mistral-small-latest"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("MISTRAL_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-
-	m2 := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "mistral-small", "https://api.mistral.ai/v1/chat/completions",
+		"mistral-small-latest", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("MISTRAL_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
 	w := httptest.NewRecorder()
 
-	err := m2.ServeHTTP(w, r, noopHandler)
+	err := m.ServeHTTP(w, r, noopHandler)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "mistral-small", w.Header().Get("X-DIN-Provider"))
@@ -293,26 +289,13 @@ func TestIntegration_NonStreaming_Mistral(t *testing.T) {
 func TestIntegration_NonStreaming_DeepSeek(t *testing.T) {
 	skipIfNoKey(t, "DEEPSEEK_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("deepseek-chat", "https://api.deepseek.com/chat/completions")
-	p.ModelID = "deepseek-chat"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("DEEPSEEK_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierBalanced: {Name: TierBalanced, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "deepseek-chat", "https://api.deepseek.com/chat/completions",
+		"deepseek-chat", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("DEEPSEEK_API_KEY"),
+		})
+	// Override tier to balanced for this test.
+	m.Tiers[TierBalanced] = m.Tiers[TierFast]
+	delete(m.Tiers, TierFast)
 
 	body := `{"messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "balanced"})
@@ -328,26 +311,10 @@ func TestIntegration_NonStreaming_DeepSeek(t *testing.T) {
 func TestIntegration_NonStreaming_Grok(t *testing.T) {
 	skipIfNoKey(t, "GROK_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("grok-mini", "https://api.x.ai/v1/chat/completions")
-	p.ModelID = "grok-3-mini"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("GROK_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "grok-mini", "https://api.x.ai/v1/chat/completions",
+		"grok-3-mini", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("GROK_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -362,26 +329,10 @@ func TestIntegration_NonStreaming_Grok(t *testing.T) {
 func TestIntegration_NonStreaming_Moonshot(t *testing.T) {
 	skipIfNoKey(t, "MOONSHOT_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("moonshot-8k", "https://api.moonshot.ai/v1/chat/completions")
-	p.ModelID = "moonshot-v1-8k"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("MOONSHOT_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "moonshot-8k", "https://api.moonshot.ai/v1/chat/completions",
+		"moonshot-v1-8k", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("MOONSHOT_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -398,26 +349,10 @@ func TestIntegration_NonStreaming_Moonshot(t *testing.T) {
 func TestIntegration_Streaming_OpenAI(t *testing.T) {
 	skipIfNoKey(t, "OPENAI_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("openai-nano", "https://api.openai.com/v1/chat/completions")
-	p.ModelID = "gpt-4.1-nano"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("OPENAI_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "openai-nano", "https://api.openai.com/v1/chat/completions",
+		"gpt-4.1-nano", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("OPENAI_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Count to 3"}],"stream":true,"max_tokens":20}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -438,27 +373,11 @@ func TestIntegration_Streaming_OpenAI(t *testing.T) {
 func TestIntegration_Streaming_Anthropic(t *testing.T) {
 	skipIfNoKey(t, "ANTHROPIC_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("anthropic-haiku", "https://api.anthropic.com/v1/messages")
-	p.ModelID = "claude-haiku-4-5-20251001"
-	p.AdapterType = AdapterAnthropic
-	p.Headers["x-api-key"] = os.Getenv("ANTHROPIC_API_KEY")
-	p.Headers["anthropic-version"] = "2023-06-01"
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "anthropic-haiku", "https://api.anthropic.com/v1/messages",
+		"claude-haiku-4-5-20251001", AdapterAnthropic, map[string]string{
+			"x-api-key":         os.Getenv("ANTHROPIC_API_KEY"),
+			"anthropic-version": "2023-06-01",
+		})
 
 	body := `{"messages":[{"role":"user","content":"Count to 3"}],"stream":true,"max_tokens":20}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -480,26 +399,10 @@ func TestIntegration_Streaming_Anthropic(t *testing.T) {
 func TestIntegration_Streaming_Grok(t *testing.T) {
 	skipIfNoKey(t, "GROK_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("grok-mini", "https://api.x.ai/v1/chat/completions")
-	p.ModelID = "grok-3-mini"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("GROK_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "grok-mini", "https://api.x.ai/v1/chat/completions",
+		"grok-3-mini", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("GROK_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Count to 3"}],"stream":true,"max_tokens":20}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -519,26 +422,10 @@ func TestIntegration_Streaming_Grok(t *testing.T) {
 func TestIntegration_Streaming_Mistral(t *testing.T) {
 	skipIfNoKey(t, "MISTRAL_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("mistral-small", "https://api.mistral.ai/v1/chat/completions")
-	p.ModelID = "mistral-small-latest"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("MISTRAL_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "mistral-small", "https://api.mistral.ai/v1/chat/completions",
+		"mistral-small-latest", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("MISTRAL_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Count to 3"}],"stream":true,"max_tokens":20}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -558,26 +445,10 @@ func TestIntegration_Streaming_Mistral(t *testing.T) {
 func TestIntegration_Streaming_Moonshot(t *testing.T) {
 	skipIfNoKey(t, "MOONSHOT_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("moonshot-8k", "https://api.moonshot.ai/v1/chat/completions")
-	p.ModelID = "moonshot-v1-8k"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("MOONSHOT_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "moonshot-8k", "https://api.moonshot.ai/v1/chat/completions",
+		"moonshot-v1-8k", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("MOONSHOT_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Count to 3"}],"stream":true,"max_tokens":20}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})
@@ -597,26 +468,13 @@ func TestIntegration_Streaming_Moonshot(t *testing.T) {
 func TestIntegration_Streaming_DeepSeek(t *testing.T) {
 	skipIfNoKey(t, "DEEPSEEK_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("deepseek-chat", "https://api.deepseek.com/chat/completions")
-	p.ModelID = "deepseek-chat"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("DEEPSEEK_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierBalanced: {Name: TierBalanced, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "deepseek-chat", "https://api.deepseek.com/chat/completions",
+		"deepseek-chat", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("DEEPSEEK_API_KEY"),
+		})
+	// Override tier to balanced for this test.
+	m.Tiers[TierBalanced] = m.Tiers[TierFast]
+	delete(m.Tiers, TierFast)
 
 	body := `{"messages":[{"role":"user","content":"Count to 3"}],"stream":true,"max_tokens":20}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "balanced"})
@@ -799,26 +657,10 @@ func TestIntegration_StreamingFailover_FirstChunkError(t *testing.T) {
 func TestIntegration_ResponseHeaders(t *testing.T) {
 	skipIfNoKey(t, "OPENAI_API_KEY")
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("openai-nano", "https://api.openai.com/v1/chat/completions")
-	p.ModelID = "gpt-4.1-nano"
-	p.AdapterType = AdapterOpenAI
-	p.Headers["Authorization"] = "Bearer " + os.Getenv("OPENAI_API_KEY")
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "openai-nano", "https://api.openai.com/v1/chat/completions",
+		"gpt-4.1-nano", AdapterOpenAI, map[string]string{
+			"Authorization": "Bearer " + os.Getenv("OPENAI_API_KEY"),
+		})
 
 	body := `{"messages":[{"role":"user","content":"Hi"}],"max_tokens":3}`
 	r := makeIntegrationRequest(t, body, map[string]string{
@@ -864,25 +706,11 @@ func TestIntegration_MockServer_NonStreaming(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("mock-provider", server.URL)
-	p.ModelID = "mock-model"
-	p.AdapterType = AdapterOpenAI
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierBalanced: {Name: TierBalanced, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "mock-provider", server.URL,
+		"mock-model", AdapterOpenAI, nil)
+	// Override tier to balanced for this test.
+	m.Tiers[TierBalanced] = m.Tiers[TierFast]
+	delete(m.Tiers, TierFast)
 
 	body := `{"messages":[{"role":"user","content":"Hi"}],"max_tokens":5}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "balanced"})
@@ -925,25 +753,8 @@ func TestIntegration_MockServer_Streaming(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newDefaultStreamingClient()
-	logger := zap.NewNop()
-	p, _ := NewAIProvider("mock-stream", server.URL)
-	p.ModelID = "mock-model"
-	p.AdapterType = AdapterOpenAI
-	p.httpClient = client
-	p.logger = logger
-	setDefaultCost(p)
-
-	m := &DinAIMiddleware{
-		Tiers: map[string]*Tier{
-			TierFast: {Name: TierFast, Providers: []*AIProvider{p}},
-		},
-		RequestAttemptCount: 3,
-		logger:              logger,
-		quit:                make(chan struct{}),
-		client:              client,
-		testMode:            true,
-	}
+	m := newSingleProviderMiddleware(t, "mock-stream", server.URL,
+		"mock-model", AdapterOpenAI, nil)
 
 	body := `{"messages":[{"role":"user","content":"Hi"}],"stream":true,"max_tokens":10}`
 	r := makeIntegrationRequest(t, body, map[string]string{"X-DIN-Tier": "fast"})

--- a/modules/ai/metrics.go
+++ b/modules/ai/metrics.go
@@ -98,11 +98,16 @@ func registerAIMetricsOnce() {
 
 // RecordRequest records an AI request metric.
 func RecordRequest(tier, provider, model, statusCode string) {
-	DinAIRequestCount.WithLabelValues(tier, provider, model, statusCode).Inc()
+	if DinAIRequestCount != nil {
+		DinAIRequestCount.WithLabelValues(tier, provider, model, statusCode).Inc()
+	}
 }
 
 // RecordTokens records token usage metrics.
 func RecordTokens(tier, provider, model string, promptTokens, completionTokens int) {
+	if DinAITokensTotal == nil {
+		return
+	}
 	if promptTokens > 0 {
 		DinAITokensTotal.WithLabelValues(tier, provider, model, "prompt").Add(float64(promptTokens))
 	}
@@ -113,6 +118,9 @@ func RecordTokens(tier, provider, model string, promptTokens, completionTokens i
 
 // RecordCost records an estimated cost metric in USD.
 func RecordCost(tier, provider, model string, costUSD float64) {
+	if DinAICostTotal == nil {
+		return
+	}
 	if costUSD > 0 {
 		DinAICostTotal.WithLabelValues(tier, provider, model).Add(costUSD)
 	}
@@ -120,5 +128,7 @@ func RecordCost(tier, provider, model string, costUSD float64) {
 
 // RecordHealthCheck records a health check metric.
 func RecordHealthCheck(provider, statusCode, healthStatus string) {
-	DinAIHealthCheckCount.WithLabelValues(provider, statusCode, healthStatus).Inc()
+	if DinAIHealthCheckCount != nil {
+		DinAIHealthCheckCount.WithLabelValues(provider, statusCode, healthStatus).Inc()
+	}
 }

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -226,20 +227,17 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 
 	// Attempt to serve the request with retry.
 	maxAttempts := m.RequestAttemptCount
-	if maxAttempts > len(available) {
-		maxAttempts = len(available)
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultRequestAttemptCount
 	}
 
 	var lastErr error
 	tried := make(map[string]bool)
+	attemptCount := 0
+	provider := m.selectUntried(tier, sessionID, tried, optimizeMode)
+	retriedCurrentProvider := false
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		// Select provider.
-		provider := m.selectUntried(tier, sessionID, tried, optimizeMode)
-		if provider == nil {
-			break
-		}
-		tried[provider.Name] = true
+	for attemptCount < maxAttempts && provider != nil {
 
 		adapter := getAdapterForType(provider.AdapterType)
 
@@ -247,6 +245,13 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 		modifiedBody, err := overwriteModel(body, provider.ModelID)
 		if err != nil {
 			lastErr = err
+			attemptCount++
+			if attemptCount >= maxAttempts {
+				break
+			}
+			tried[provider.Name] = true
+			provider = m.selectUntried(tier, sessionID, tried, optimizeMode)
+			retriedCurrentProvider = false
 			continue
 		}
 
@@ -256,9 +261,30 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 				provider.MarkPingWarning()
 				m.logger.Warn("streaming attempt failed",
 					zap.String("provider", provider.Name),
-					zap.Int("attempt", attempt+1),
+					zap.Int("attempt", attemptCount+1),
 					zap.Error(err))
 				lastErr = err
+				attemptCount++
+
+				if attemptCount >= maxAttempts {
+					break
+				}
+
+				if shouldRetrySameProviderForStream(err, retriedCurrentProvider) {
+					retriedCurrentProvider = true
+					retryAfter := streamRetryAfter(err)
+					if retryAfter > 0 {
+						if sleepErr := sleepWithContext(r.Context(), retryAfter); sleepErr != nil {
+							lastErr = sleepErr
+							break
+						}
+					}
+					continue
+				}
+
+				tried[provider.Name] = true
+				provider = m.selectUntried(tier, sessionID, tried, optimizeMode)
+				retriedCurrentProvider = false
 				continue
 			}
 
@@ -308,20 +334,49 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 		}
 
 		// Non-streaming request.
-		respBody, statusCode, provider, err := m.attemptNonStreaming(r.Context(), provider, adapter, modifiedBody)
+		var respBody []byte
+		var statusCode int
+		var respHeaders http.Header
+		respBody, statusCode, respHeaders, provider, err = m.attemptNonStreaming(r.Context(), provider, adapter, modifiedBody)
 		if err != nil {
 			provider.MarkPingWarning()
 			m.logger.Warn("non-streaming attempt failed",
 				zap.String("provider", provider.Name),
-				zap.Int("attempt", attempt+1),
+				zap.Int("attempt", attemptCount+1),
 				zap.Error(err))
 			lastErr = err
+			attemptCount++
+			if attemptCount >= maxAttempts {
+				break
+			}
+			tried[provider.Name] = true
+			provider = m.selectUntried(tier, sessionID, tried, optimizeMode)
+			retriedCurrentProvider = false
 			continue
 		}
 
 		if statusCode != http.StatusOK {
 			provider.MarkPingWarning()
 			lastErr = fmt.Errorf("provider %s returned HTTP %d", provider.Name, statusCode)
+			attemptCount++
+			if attemptCount >= maxAttempts {
+				break
+			}
+
+			if isRetryableStatus(statusCode) && !retriedCurrentProvider {
+				retriedCurrentProvider = true
+				if retryAfter, ok := retryDelayFromHeaders(respHeaders); ok {
+					if sleepErr := sleepWithContext(r.Context(), retryAfter); sleepErr != nil {
+						lastErr = sleepErr
+						break
+					}
+				}
+				continue
+			}
+
+			tried[provider.Name] = true
+			provider = m.selectUntried(tier, sessionID, tried, optimizeMode)
+			retriedCurrentProvider = false
 			continue
 		}
 
@@ -394,10 +449,10 @@ func (m *DinAIMiddleware) attemptNonStreaming(
 	provider *AIProvider,
 	adapter libai.ProviderAdapter,
 	body []byte,
-) ([]byte, int, *AIProvider, error) {
+) ([]byte, int, http.Header, *AIProvider, error) {
 	transformedBody, extraHeaders, err := adapter.TransformRequest(body)
 	if err != nil {
-		return nil, 0, provider, fmt.Errorf("transform request: %w", err)
+		return nil, 0, nil, provider, fmt.Errorf("transform request: %w", err)
 	}
 
 	headers := make(map[string]string)
@@ -409,12 +464,50 @@ func (m *DinAIMiddleware) attemptNonStreaming(
 	}
 	headers["Content-Type"] = "application/json"
 
-	respBody, statusCode, _, err := m.client.Post(ctx, provider.HttpUrl, headers, transformedBody)
+	respBody, statusCode, respHeaders, err := m.client.Post(ctx, provider.HttpUrl, headers, transformedBody)
 	if err != nil {
-		return nil, 0, provider, fmt.Errorf("post: %w", err)
+		return nil, 0, nil, provider, fmt.Errorf("post: %w", err)
 	}
 
-	return respBody, statusCode, provider, nil
+	return respBody, statusCode, respHeaders, provider, nil
+}
+
+func isRetryableStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
+}
+
+func retryDelayFromHeaders(headers http.Header) (time.Duration, bool) {
+	if headers == nil {
+		return 0, false
+	}
+	retryAfterRaw := headers.Get("Retry-After")
+	if retryAfterRaw == "" {
+		return 0, false
+	}
+	delay, err := parseRetryAfter(retryAfterRaw, time.Now(), defaultRetryAfterCap)
+	if err != nil {
+		return 0, false
+	}
+	return delay, true
+}
+
+func shouldRetrySameProviderForStream(err error, alreadyRetried bool) bool {
+	if alreadyRetried {
+		return false
+	}
+	var streamErr *streamAttemptError
+	if !errors.As(err, &streamErr) {
+		return false
+	}
+	return isRetryableStatus(streamErr.statusCode)
+}
+
+func streamRetryAfter(err error) time.Duration {
+	var streamErr *streamAttemptError
+	if !errors.As(err, &streamErr) {
+		return 0
+	}
+	return streamErr.retryAfter
 }
 
 // setResponseHeaders sets the standard DIN AI response headers.

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -182,11 +182,15 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 			"request body exceeds 10MB limit", "invalid_request_error")
 	}
 
-	// Parse request to check stream flag.
-	var req libai.ChatCompletionRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	// Parse request once to check stream flag and prepare for model overwrite.
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &rawFields); err != nil {
 		return writeErrorResponse(w, http.StatusBadRequest,
 			"invalid JSON in request body", "invalid_request_error")
+	}
+	var isStream bool
+	if streamRaw, ok := rawFields["stream"]; ok {
+		_ = json.Unmarshal(streamRaw, &isStream)
 	}
 
 	// Resolve tier.
@@ -242,7 +246,7 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 		adapter := getAdapterForType(provider.AdapterType)
 
 		// Overwrite model in request body.
-		modifiedBody, err := overwriteModel(body, provider.ModelID)
+		modifiedBody, err := overwriteModel(rawFields, provider.ModelID)
 		if err != nil {
 			lastErr = err
 			attemptCount++
@@ -255,7 +259,7 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 			continue
 		}
 
-		if req.Stream {
+		if isStream {
 			result, err := attemptStream(r.Context(), provider, adapter, modifiedBody, m.client, m.logger)
 			if err != nil {
 				provider.MarkPingWarning()
@@ -531,18 +535,14 @@ func setResponseHeaders(w http.ResponseWriter, provider *AIProvider, tierName, s
 	}
 }
 
-// overwriteModel replaces the model field in the request body with the provider's model.
-func overwriteModel(body []byte, model string) ([]byte, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, err
-	}
+// overwriteModel replaces the model field in the pre-parsed request fields and re-marshals.
+func overwriteModel(rawFields map[string]json.RawMessage, model string) ([]byte, error) {
 	modelJSON, err := json.Marshal(model)
 	if err != nil {
 		return nil, err
 	}
-	raw["model"] = modelJSON
-	return json.Marshal(raw)
+	rawFields["model"] = modelJSON
+	return json.Marshal(rawFields)
 }
 
 // generateRequestID creates a unique request ID using crypto/rand.

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -409,7 +409,7 @@ func (m *DinAIMiddleware) attemptNonStreaming(
 	}
 	headers["Content-Type"] = "application/json"
 
-	respBody, statusCode, err := m.client.Post(ctx, provider.HttpUrl, headers, transformedBody)
+	respBody, statusCode, _, err := m.client.Post(ctx, provider.HttpUrl, headers, transformedBody)
 	if err != nil {
 		return nil, 0, provider, fmt.Errorf("post: %w", err)
 	}
@@ -738,14 +738,14 @@ func newHealthCheckClient() *defaultStreamingClient {
 	}
 }
 
-func (c *defaultStreamingClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+func (c *defaultStreamingClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 	resp, err := c.PostStream(ctx, url, headers, payload)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	return body, resp.StatusCode, err
+	return body, resp.StatusCode, resp.Header.Clone(), err
 }
 
 func (c *defaultStreamingClient) PostStream(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -850,7 +850,7 @@ func (c *defaultStreamingClient) Post(ctx context.Context, url string, headers m
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	return body, resp.StatusCode, resp.Header.Clone(), err
+	return body, resp.StatusCode, resp.Header, err
 }
 
 func (c *defaultStreamingClient) PostStream(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -388,6 +388,13 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 		if err != nil {
 			// Transform errors are our code's fault, not the provider's — no health update.
 			lastErr = err
+			attemptCount++
+			if attemptCount >= maxAttempts {
+				break
+			}
+			tried[provider.Name] = true
+			provider = m.selectUntried(tier, sessionID, tried, optimizeMode)
+			retriedCurrentProvider = false
 			continue
 		}
 

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -629,6 +629,9 @@ func (m *DinAIMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if val <= 0 {
 				return d.Errf("healthcheck_interval must be positive, got %d", val)
 			}
+			if d.NextArg() {
+				return d.Errf("too many arguments for healthcheck_interval")
+			}
 			m.HealthcheckInterval = val
 
 		case "healthcheck_threshold":
@@ -642,6 +645,9 @@ func (m *DinAIMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			if val <= 0 {
 				return d.Errf("healthcheck_threshold must be positive, got %d", val)
 			}
+			if d.NextArg() {
+				return d.Errf("too many arguments for healthcheck_threshold")
+			}
 			m.HealthcheckThreshold = val
 
 		case "request_attempt_count":
@@ -654,6 +660,9 @@ func (m *DinAIMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 			if val <= 0 {
 				return d.Errf("request_attempt_count must be positive, got %d", val)
+			}
+			if d.NextArg() {
+				return d.Errf("too many arguments for request_attempt_count")
 			}
 			m.RequestAttemptCount = val
 

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -273,11 +273,12 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 				if shouldRetrySameProviderForStream(err, retriedCurrentProvider) {
 					retriedCurrentProvider = true
 					retryAfter := streamRetryAfter(err)
-					if retryAfter > 0 {
-						if sleepErr := sleepWithContext(r.Context(), retryAfter); sleepErr != nil {
-							lastErr = sleepErr
-							break
-						}
+					if retryAfter <= 0 {
+						retryAfter = defaultRetryBackoff
+					}
+					if sleepErr := sleepWithContext(r.Context(), retryAfter); sleepErr != nil {
+						lastErr = sleepErr
+						break
 					}
 					continue
 				}
@@ -365,11 +366,13 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 
 			if isRetryableStatus(statusCode) && !retriedCurrentProvider {
 				retriedCurrentProvider = true
-				if retryAfter, ok := retryDelayFromHeaders(respHeaders); ok {
-					if sleepErr := sleepWithContext(r.Context(), retryAfter); sleepErr != nil {
-						lastErr = sleepErr
-						break
-					}
+				retryAfter := defaultRetryBackoff
+				if parsed, ok := retryDelayFromHeaders(respHeaders); ok {
+					retryAfter = parsed
+				}
+				if sleepErr := sleepWithContext(r.Context(), retryAfter); sleepErr != nil {
+					lastErr = sleepErr
+					break
 				}
 				continue
 			}

--- a/modules/ai/middleware.go
+++ b/modules/ai/middleware.go
@@ -415,7 +415,9 @@ func (m *DinAIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 		setResponseHeaders(w, provider, tierName, sessionID, requestID)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(transformed)
+		if _, err := w.Write(transformed); err != nil {
+			m.logger.Warn("failed to write response body", zap.Error(err))
+		}
 
 		RecordRequest(tierName, provider.Name, provider.ModelID, "200")
 		return nil

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -21,15 +21,15 @@ import (
 
 // mockClient implements IStreamingHTTPClient for middleware tests.
 type mockClient struct {
-	postHandler       func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error)
+	postHandler       func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error)
 	postStreamHandler func(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error)
 }
 
-func (m *mockClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+func (m *mockClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 	if m.postHandler != nil {
 		return m.postHandler(ctx, url, headers, payload)
 	}
-	return nil, 500, nil
+	return nil, 500, nil, nil
 }
 
 func (m *mockClient) PostStream(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {
@@ -49,8 +49,8 @@ func newTestMiddleware(t *testing.T) *DinAIMiddleware {
 	ensureMetricsRegistered(t)
 
 	client := &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
-			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`), 200, nil
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`), 200, nil, nil
 		},
 	}
 
@@ -196,8 +196,8 @@ func TestServeHTTP_AllProvidersFail_Returns502(t *testing.T) {
 
 	// Force all providers to return errors.
 	m.client = &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
-			return nil, 0, fmt.Errorf("connection refused")
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			return nil, 0, nil, fmt.Errorf("connection refused")
 		},
 	}
 
@@ -374,12 +374,12 @@ func TestServeHTTP_NonStreaming_Failover(t *testing.T) {
 
 	callCount := 0
 	m.client = &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 			callCount++
 			if callCount == 1 {
-				return []byte(`{"error":"server error"}`), 500, nil
+				return []byte(`{"error":"server error"}`), 500, nil, nil
 			}
-			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"deepseek-chat","choices":[{"index":0,"message":{"role":"assistant","content":"fallback"},"finish_reason":"stop"}]}`), 200, nil
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"deepseek-chat","choices":[{"index":0,"message":{"role":"assistant","content":"fallback"},"finish_reason":"stop"}]}`), 200, nil, nil
 		},
 	}
 
@@ -529,8 +529,8 @@ func TestServeHTTP_ConcurrentRequests(t *testing.T) {
 	sseData += "data: [DONE]\n\n"
 
 	m.client = &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
-			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`), 200, nil
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`), 200, nil, nil
 		},
 		postStreamHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {
 			return makeSSEResponse(200, sseData), nil
@@ -866,12 +866,12 @@ func TestServeHTTP_FailoverUpdatesHealth(t *testing.T) {
 
 	callCount := 0
 	m.client = &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 			callCount++
 			if callCount == 1 {
-				return nil, 0, fmt.Errorf("connection refused")
+				return nil, 0, nil, fmt.Errorf("connection refused")
 			}
-			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil, nil
 		},
 	}
 
@@ -904,12 +904,12 @@ func TestServeHTTP_SingleFailureStaysHealthy(t *testing.T) {
 	// Single 500 from one provider, but it gets retried to a second.
 	callCount := 0
 	m.client = &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 			callCount++
 			if callCount == 1 {
-				return []byte(`{"error":"server error"}`), 500, nil
+				return []byte(`{"error":"server error"}`), 500, nil, nil
 			}
-			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil, nil
 		},
 	}
 
@@ -930,12 +930,12 @@ func TestServeHTTP_429DoesNotMarkUnhealthy(t *testing.T) {
 
 	callCount := 0
 	m.client = &mockClient{
-		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 			callCount++
 			if callCount == 1 {
-				return []byte(`{"error":"rate limited"}`), 429, nil
+				return []byte(`{"error":"rate limited"}`), 429, nil, nil
 			}
-			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil, nil
 		},
 	}
 

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -950,6 +950,68 @@ func TestServeHTTP_429DoesNotMarkUnhealthy(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_NonStreaming_429RetrySameProviderThenFailover(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	m.Tiers[TierBalanced].Providers[0].HttpUrl = "https://provider-primary.example/v1/chat/completions"
+	m.Tiers[TierBalanced].Providers[1].HttpUrl = "https://provider-secondary.example/v1/chat/completions"
+
+	var primaryURL string
+	primaryCalls := 0
+	secondaryCalls := 0
+
+	m.client = &mockClient{
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			if primaryURL == "" {
+				primaryURL = url
+			}
+
+			if url == primaryURL {
+				primaryCalls++
+				if primaryCalls <= 2 {
+					return []byte(`{"error":"rate limited"}`), 429, http.Header{"Retry-After": []string{"0"}}, nil
+				}
+			} else {
+				secondaryCalls++
+			}
+
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"fallback","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil, nil
+		},
+	}
+
+	body := `{"model":"test","messages":[{"role":"user","content":"hi"}]}`
+	w, r := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	err := m.ServeHTTP(w, r, noopHandler)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 2, primaryCalls, "should retry same provider once after initial 429")
+	assert.Equal(t, 1, secondaryCalls, "should fail over after same-provider retry is exhausted")
+}
+
+func TestServeHTTP_NonStreaming_RetryAfterCancelledByContext(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	m.client = &mockClient{
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			return []byte(`{"error":"rate limited"}`), 429, http.Header{"Retry-After": []string{"5"}}, nil
+		},
+	}
+
+	body := `{"model":"test","messages":[{"role":"user","content":"hi"}]}`
+	w, req := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(ctx)
+
+	start := time.Now()
+	err := m.ServeHTTP(w, req, noopHandler)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Less(t, elapsed, 300*time.Millisecond, "cancelled context should interrupt Retry-After sleep")
+}
+
 func TestNewAIProvider_NoScheme(t *testing.T) {
 	_, err := NewAIProvider("test", "api.example.com/v1/chat")
 	assert.Error(t, err)

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -1126,6 +1126,46 @@ func TestServeHTTP_NonStreaming_TransformResponseError_NoInfiniteLoop(t *testing
 		"should return 502 when all attempts fail with transform errors")
 }
 
+func TestServeHTTP_NonStreaming_RetryAfterHTTPDate(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	m.Tiers[TierBalanced].Providers[0].HttpUrl = "https://provider-primary.example/v1/chat/completions"
+	m.Tiers[TierBalanced].Providers[1].HttpUrl = "https://provider-secondary.example/v1/chat/completions"
+
+	var primaryURL string
+	primaryCalls := 0
+	secondaryCalls := 0
+
+	m.client = &mockClient{
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			if primaryURL == "" {
+				primaryURL = url
+			}
+
+			if url == primaryURL {
+				primaryCalls++
+				if primaryCalls <= 2 {
+					// Use RFC1123 HTTP-date in the past so sleep is ~0.
+					pastDate := time.Now().Add(-1 * time.Second).UTC().Format(time.RFC1123)
+					return []byte(`{"error":"rate limited"}`), 429, http.Header{"Retry-After": []string{pastDate}}, nil
+				}
+			} else {
+				secondaryCalls++
+			}
+
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"fallback","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil, nil
+		},
+	}
+
+	body := `{"model":"test","messages":[{"role":"user","content":"hi"}]}`
+	w, r := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	err := m.ServeHTTP(w, r, noopHandler)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 2, primaryCalls, "should retry same provider once after initial 429 with HTTP-date")
+	assert.Equal(t, 1, secondaryCalls, "should fail over after same-provider retry is exhausted")
+}
+
 func TestServeHTTP_NonStreaming_503RetrySameProviderThenFailover(t *testing.T) {
 	m := newTestMiddleware(t)
 

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -1063,6 +1063,87 @@ func TestServeHTTP_NonStreaming_TransformResponseError_NoInfiniteLoop(t *testing
 		"should return 502 when all attempts fail with transform errors")
 }
 
+func TestServeHTTP_NonStreaming_503RetrySameProviderThenFailover(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	m.Tiers[TierBalanced].Providers[0].HttpUrl = "https://provider-primary.example/v1/chat/completions"
+	m.Tiers[TierBalanced].Providers[1].HttpUrl = "https://provider-secondary.example/v1/chat/completions"
+
+	var primaryURL string
+	primaryCalls := 0
+	secondaryCalls := 0
+
+	m.client = &mockClient{
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			if primaryURL == "" {
+				primaryURL = url
+			}
+
+			if url == primaryURL {
+				primaryCalls++
+				if primaryCalls <= 2 {
+					return []byte(`{"error":"service unavailable"}`), 503, http.Header{"Retry-After": []string{"0"}}, nil
+				}
+			} else {
+				secondaryCalls++
+			}
+
+			return []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"fallback","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`), 200, nil, nil
+		},
+	}
+
+	body := `{"model":"test","messages":[{"role":"user","content":"hi"}]}`
+	w, r := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	err := m.ServeHTTP(w, r, noopHandler)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 2, primaryCalls, "should retry same provider once after initial 503")
+	assert.Equal(t, 1, secondaryCalls, "should fail over after same-provider retry is exhausted")
+}
+
+func TestServeHTTP_Streaming_503RetrySameProviderThenFailover(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	m.Tiers[TierBalanced].Providers[0].HttpUrl = "https://provider-primary.example/v1/chat/completions"
+	m.Tiers[TierBalanced].Providers[1].HttpUrl = "https://provider-secondary.example/v1/chat/completions"
+
+	primaryURL := ""
+	primaryCalls := 0
+	secondaryCalls := 0
+
+	goodSSE := sseEvent("", `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"delta":{"role":"assistant"}}]}`)
+	goodSSE += sseEvent("", `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"delta":{"content":"fallback works"}}]}`)
+	goodSSE += "data: [DONE]\n\n"
+
+	m.client = &mockClient{
+		postStreamHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {
+			if primaryURL == "" {
+				primaryURL = url
+			}
+			if url == primaryURL {
+				primaryCalls++
+				if primaryCalls <= 2 {
+					resp := makeSSEResponse(http.StatusServiceUnavailable, "service unavailable")
+					resp.Header.Set("Retry-After", "0")
+					return resp, nil
+				}
+			} else {
+				secondaryCalls++
+			}
+			return makeSSEResponse(http.StatusOK, goodSSE), nil
+		},
+	}
+
+	body := `{"model":"test","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	w, r := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	err := m.ServeHTTP(w, r, noopHandler)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 2, primaryCalls, "should retry same provider once after initial 503")
+	assert.Equal(t, 1, secondaryCalls, "should fail over after same-provider retry is exhausted")
+	assert.Contains(t, w.Body.String(), "fallback works")
+}
+
 func TestServeHTTP_NonStreaming_RetryAfterCancelledByContext(t *testing.T) {
 	m := newTestMiddleware(t)
 

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -369,6 +369,50 @@ func TestServeHTTP_Streaming_FailoverOnFirstChunkError(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "[DONE]")
 }
 
+func TestServeHTTP_Streaming_429RetrySameProviderThenFailover(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	m.Tiers[TierBalanced].Providers[0].HttpUrl = "https://provider-primary.example/v1/chat/completions"
+	m.Tiers[TierBalanced].Providers[1].HttpUrl = "https://provider-secondary.example/v1/chat/completions"
+
+	primaryURL := ""
+	primaryCalls := 0
+	secondaryCalls := 0
+
+	goodSSE := sseEvent("", `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"delta":{"role":"assistant"}}]}`)
+	goodSSE += sseEvent("", `{"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"delta":{"content":"fallback works"}}]}`)
+	goodSSE += "data: [DONE]\n\n"
+
+	m.client = &mockClient{
+		postStreamHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {
+			if primaryURL == "" {
+				primaryURL = url
+			}
+			if url == primaryURL {
+				primaryCalls++
+				if primaryCalls <= 2 {
+					resp := makeSSEResponse(http.StatusTooManyRequests, "rate limited")
+					resp.Header.Set("Retry-After", "0")
+					return resp, nil
+				}
+			} else {
+				secondaryCalls++
+			}
+			return makeSSEResponse(http.StatusOK, goodSSE), nil
+		},
+	}
+
+	body := `{"model":"test","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	w, r := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	err := m.ServeHTTP(w, r, noopHandler)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 2, primaryCalls, "should retry same provider once after initial 429")
+	assert.Equal(t, 1, secondaryCalls, "should fail over after same-provider retry is exhausted")
+	assert.Contains(t, w.Body.String(), "fallback works")
+	assert.Contains(t, w.Body.String(), "[DONE]")
+}
+
 func TestServeHTTP_NonStreaming_Failover(t *testing.T) {
 	m := newTestMiddleware(t)
 

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -894,6 +894,56 @@ func TestUnmarshalCaddyfile_NegativeInterval(t *testing.T) {
 	assert.Contains(t, err.Error(), "must be positive")
 }
 
+func TestUnmarshalCaddyfile_ExcessArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+		errMsg    string
+	}{
+		{
+			name:      "healthcheck_interval excess",
+			directive: "healthcheck_interval 30 extra",
+			errMsg:    "too many arguments for healthcheck_interval",
+		},
+		{
+			name:      "healthcheck_threshold excess",
+			directive: "healthcheck_threshold 3 extra",
+			errMsg:    "too many arguments for healthcheck_threshold",
+		},
+		{
+			name:      "request_attempt_count excess",
+			directive: "request_attempt_count 5 extra",
+			errMsg:    "too many arguments for request_attempt_count",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(`din_ai {
+		%s
+		tiers {
+			fast {
+				providers {
+					p1 https://api.example.com {
+						model test-model
+						cost {
+							input_per_1m 1.00
+							output_per_1m 2.00
+						}
+					}
+				}
+			}
+		}
+	}`, tt.directive)
+			m := &DinAIMiddleware{}
+			d := caddyfile.NewTestDispenser(input)
+			err := m.UnmarshalCaddyfile(d)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
 func TestUnmarshalCaddyfile_UnknownAdapterType(t *testing.T) {
 	input := `din_ai {
 		tiers {

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -1056,6 +1056,32 @@ func TestServeHTTP_NonStreaming_RetryAfterCancelledByContext(t *testing.T) {
 	assert.Less(t, elapsed, 300*time.Millisecond, "cancelled context should interrupt Retry-After sleep")
 }
 
+func TestServeHTTP_Streaming_RetryAfterCancelledByContext(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	m.client = &mockClient{
+		postStreamHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {
+			resp := makeSSEResponse(http.StatusTooManyRequests, "rate limited")
+			resp.Header.Set("Retry-After", "5")
+			return resp, nil
+		},
+	}
+
+	body := `{"model":"test","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	w, req := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(ctx)
+
+	start := time.Now()
+	err := m.ServeHTTP(w, req, noopHandler)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Less(t, elapsed, 300*time.Millisecond, "cancelled context should interrupt streaming Retry-After sleep")
+}
+
 func TestNewAIProvider_NoScheme(t *testing.T) {
 	_, err := NewAIProvider("test", "api.example.com/v1/chat")
 	assert.Error(t, err)

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -1032,6 +1032,37 @@ func TestServeHTTP_NonStreaming_429RetrySameProviderThenFailover(t *testing.T) {
 	assert.Equal(t, 1, secondaryCalls, "should fail over after same-provider retry is exhausted")
 }
 
+func TestServeHTTP_NonStreaming_TransformResponseError_NoInfiniteLoop(t *testing.T) {
+	m := newTestMiddleware(t)
+
+	// Use Anthropic adapter so TransformResponse actually parses the body.
+	m.Tiers[TierBalanced].Providers[0].AdapterType = AdapterAnthropic
+	m.Tiers[TierBalanced].Providers[0].HttpUrl = "https://provider-primary.example/v1/messages"
+	m.Tiers[TierBalanced].Providers[1].AdapterType = AdapterAnthropic
+	m.Tiers[TierBalanced].Providers[1].HttpUrl = "https://provider-secondary.example/v1/messages"
+
+	callCount := 0
+	m.client = &mockClient{
+		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
+			callCount++
+			// Return HTTP 200 with body that Anthropic adapter cannot parse,
+			// triggering a TransformResponse error.
+			return []byte(`not valid json`), 200, nil, nil
+		},
+	}
+
+	body := `{"model":"claude-3","messages":[{"role":"user","content":"hi"}]}`
+	w, r := makeRequest(t, "POST", "/v1/chat/completions", "application/json", body, nil)
+	err := m.ServeHTTP(w, r, noopHandler)
+
+	assert.NoError(t, err)
+	// Should NOT loop forever — must terminate after maxAttempts (default 3).
+	assert.LessOrEqual(t, callCount, m.RequestAttemptCount,
+		"should terminate after maxAttempts, not loop infinitely on TransformResponse errors")
+	assert.Equal(t, http.StatusBadGateway, w.Code,
+		"should return 502 when all attempts fail with transform errors")
+}
+
 func TestServeHTTP_NonStreaming_RetryAfterCancelledByContext(t *testing.T) {
 	m := newTestMiddleware(t)
 

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -448,8 +448,10 @@ func TestServeHTTP_DefaultTier(t *testing.T) {
 }
 
 func TestOverwriteModel(t *testing.T) {
-	body := []byte(`{"model":"original","messages":[],"stream":false}`)
-	result, err := overwriteModel(body, "new-model")
+	var rawFields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(`{"model":"original","messages":[],"stream":false}`), &rawFields))
+
+	result, err := overwriteModel(rawFields, "new-model")
 	require.NoError(t, err)
 
 	var parsed map[string]json.RawMessage
@@ -461,6 +463,17 @@ func TestOverwriteModel(t *testing.T) {
 
 	// Messages should be preserved.
 	assert.Contains(t, string(result), "messages")
+
+	// Calling again with a different model should work (retry scenario).
+	result2, err := overwriteModel(rawFields, "another-model")
+	require.NoError(t, err)
+
+	var parsed2 map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result2, &parsed2))
+
+	var model2 string
+	require.NoError(t, json.Unmarshal(parsed2["model"], &model2))
+	assert.Equal(t, "another-model", model2)
 }
 
 func TestGenerateRequestID(t *testing.T) {

--- a/modules/ai/middleware_test.go
+++ b/modules/ai/middleware_test.go
@@ -46,7 +46,6 @@ var noopHandler = caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Requ
 
 func newTestMiddleware(t *testing.T) *DinAIMiddleware {
 	t.Helper()
-	ensureMetricsRegistered(t)
 
 	client := &mockClient{
 		postHandler: func(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
@@ -537,8 +536,6 @@ func TestServeHTTP_PrefixedPathDoesNotMatch(t *testing.T) {
 }
 
 func TestCleanup_StopsHealthChecks(t *testing.T) {
-	ensureMetricsRegistered(t)
-
 	m := &DinAIMiddleware{
 		Tiers: map[string]*Tier{
 			TierFast: {

--- a/modules/ai/provider_test.go
+++ b/modules/ai/provider_test.go
@@ -198,6 +198,41 @@ func TestProviderConcurrentAccess(t *testing.T) {
 	// If we get here without a race detector panic, the mutex is working
 }
 
+func TestProviderHealthThresholdBoundary(t *testing.T) {
+	t.Run("exactly threshold failures stays healthy, threshold+1 transitions to unhealthy", func(t *testing.T) {
+		p := mustProvider(t)
+		assert.Equal(t, Healthy, p.HealthStatus())
+
+		// DefaultHCThreshold (3) failures: condition is `failures > hcThreshold`,
+		// so exactly 3 should NOT transition.
+		for i := 0; i < DefaultHCThreshold; i++ {
+			p.MarkPingFailure()
+		}
+		assert.Equal(t, Healthy, p.HealthStatus(), "exactly %d failures should remain Healthy", DefaultHCThreshold)
+
+		// The (threshold+1)th failure crosses the boundary.
+		p.MarkPingFailure()
+		assert.Equal(t, Unhealthy, p.HealthStatus(), "%d failures should transition to Unhealthy", DefaultHCThreshold+1)
+	})
+
+	t.Run("exactly threshold successes stays unhealthy, threshold+1 transitions to healthy", func(t *testing.T) {
+		p := mustProvider(t)
+		setProviderHealth(p, Unhealthy)
+		assert.Equal(t, Unhealthy, p.HealthStatus())
+
+		// DefaultHCThreshold (3) successes: condition is `successes > hcThreshold`,
+		// so exactly 3 should NOT recover.
+		for i := 0; i < DefaultHCThreshold; i++ {
+			p.MarkPingSuccess()
+		}
+		assert.Equal(t, Unhealthy, p.HealthStatus(), "exactly %d successes should remain Unhealthy", DefaultHCThreshold)
+
+		// The (threshold+1)th success crosses the boundary.
+		p.MarkPingSuccess()
+		assert.Equal(t, Healthy, p.HealthStatus(), "%d successes should transition to Healthy", DefaultHCThreshold+1)
+	})
+}
+
 func mustProvider(t *testing.T) *AIProvider {
 	t.Helper()
 	p, err := NewAIProvider("test-provider", "https://api.example.com/v1/chat/completions")

--- a/modules/ai/retry_after.go
+++ b/modules/ai/retry_after.go
@@ -1,0 +1,71 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultRetryAfterCap = 5 * time.Second
+
+func parseRetryAfter(headerValue string, now time.Time, capDuration time.Duration) (time.Duration, error) {
+	if capDuration <= 0 {
+		capDuration = defaultRetryAfterCap
+	}
+
+	value := strings.TrimSpace(headerValue)
+	if value == "" {
+		return 0, fmt.Errorf("retry-after is empty")
+	}
+
+	// Retry-After can be delta-seconds.
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0, fmt.Errorf("retry-after cannot be negative")
+		}
+		delay := time.Duration(seconds) * time.Second
+		if delay > capDuration {
+			return capDuration, nil
+		}
+		return delay, nil
+	}
+
+	// Retry-After can be an HTTP-date.
+	retryAt, err := httpDateParse(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid retry-after: %w", err)
+	}
+	delay := retryAt.Sub(now)
+	if delay < 0 {
+		return 0, nil
+	}
+	if delay > capDuration {
+		return capDuration, nil
+	}
+	return delay, nil
+}
+
+func httpDateParse(v string) (time.Time, error) {
+	if ts, err := time.Parse(time.RFC1123, v); err == nil {
+		return ts, nil
+	}
+	return time.Parse(time.RFC1123Z, v)
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/modules/ai/retry_after.go
+++ b/modules/ai/retry_after.go
@@ -8,7 +8,12 @@ import (
 	"time"
 )
 
-const defaultRetryAfterCap = 5 * time.Second
+const (
+	// defaultRetryAfterCap limits provider Retry-After values so requests don't stall for long periods.
+	defaultRetryAfterCap = 5 * time.Second
+	// defaultRetryBackoff is used when a retryable status is returned without a usable Retry-After header.
+	defaultRetryBackoff = 500 * time.Millisecond
+)
 
 func parseRetryAfter(headerValue string, now time.Time, capDuration time.Duration) (time.Duration, error) {
 	if capDuration <= 0 {
@@ -51,7 +56,10 @@ func httpDateParse(v string) (time.Time, error) {
 	if ts, err := time.Parse(time.RFC1123, v); err == nil {
 		return ts, nil
 	}
-	return time.Parse(time.RFC1123Z, v)
+	if ts, err := time.Parse(time.RFC1123Z, v); err == nil {
+		return ts, nil
+	}
+	return time.Parse(time.RFC850, v)
 }
 
 func sleepWithContext(ctx context.Context, d time.Duration) error {

--- a/modules/ai/retry_after_test.go
+++ b/modules/ai/retry_after_test.go
@@ -53,6 +53,12 @@ func TestParseRetryAfter_CapApplied(t *testing.T) {
 	assert.Equal(t, 1*time.Second, d)
 }
 
+func TestParseRetryAfter_NegativeSeconds(t *testing.T) {
+	_, err := parseRetryAfter("-5", time.Now(), 10*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "negative")
+}
+
 func TestSleepWithContext_Cancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/modules/ai/retry_after_test.go
+++ b/modules/ai/retry_after_test.go
@@ -1,0 +1,46 @@
+package ai
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRetryAfter_Seconds(t *testing.T) {
+	d, err := parseRetryAfter("2", time.Now(), 10*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Second, d)
+}
+
+func TestParseRetryAfter_HTTPDate(t *testing.T) {
+	now := time.Date(2026, 2, 23, 10, 0, 0, 0, time.UTC)
+	target := now.Add(3 * time.Second).Format(time.RFC1123)
+
+	d, err := parseRetryAfter(target, now, 10*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 3*time.Second, d)
+}
+
+func TestParseRetryAfter_Invalid(t *testing.T) {
+	_, err := parseRetryAfter("not-a-date", time.Now(), 10*time.Second)
+	require.Error(t, err)
+}
+
+func TestParseRetryAfter_CapApplied(t *testing.T) {
+	d, err := parseRetryAfter("60", time.Now(), 1*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 1*time.Second, d)
+}
+
+func TestSleepWithContext_Cancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := sleepWithContext(ctx, 5*time.Second)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 200*time.Millisecond)
+}

--- a/modules/ai/retry_after_test.go
+++ b/modules/ai/retry_after_test.go
@@ -24,6 +24,24 @@ func TestParseRetryAfter_HTTPDate(t *testing.T) {
 	assert.Equal(t, 3*time.Second, d)
 }
 
+func TestParseRetryAfter_HTTPDateRFC850(t *testing.T) {
+	now := time.Date(2026, 2, 23, 10, 0, 0, 0, time.UTC)
+	target := now.Add(2 * time.Second).Format(time.RFC850)
+
+	d, err := parseRetryAfter(target, now, 10*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Second, d)
+}
+
+func TestParseRetryAfter_HTTPDateInPast(t *testing.T) {
+	now := time.Date(2026, 2, 23, 10, 0, 0, 0, time.UTC)
+	target := now.Add(-2 * time.Second).Format(time.RFC1123)
+
+	d, err := parseRetryAfter(target, now, 10*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), d)
+}
+
 func TestParseRetryAfter_Invalid(t *testing.T) {
 	_, err := parseRetryAfter("not-a-date", time.Now(), 10*time.Second)
 	require.Error(t, err)

--- a/modules/ai/streaming.go
+++ b/modules/ai/streaming.go
@@ -31,6 +31,23 @@ type streamResult struct {
 	adapter libai.ProviderAdapter
 }
 
+type streamAttemptError struct {
+	statusCode int
+	retryAfter time.Duration
+	err        error
+}
+
+func (e *streamAttemptError) Error() string {
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return fmt.Sprintf("stream attempt failed with HTTP %d", e.statusCode)
+}
+
+func (e *streamAttemptError) Unwrap() error {
+	return e.err
+}
+
 // attemptStream tries to open a streaming connection to a provider and validate the first chunk.
 // Returns a streamResult on success, or an error if the provider fails.
 func attemptStream(
@@ -67,8 +84,18 @@ func attemptStream(
 
 	// Check HTTP status before reading the body.
 	if resp.StatusCode != http.StatusOK {
+		retryAfter := time.Duration(0)
+		if isRetryableStatus(resp.StatusCode) {
+			if d, parseErr := parseRetryAfter(resp.Header.Get("Retry-After"), time.Now(), defaultRetryAfterCap); parseErr == nil {
+				retryAfter = d
+			}
+		}
 		resp.Body.Close()
-		return nil, fmt.Errorf("provider returned HTTP %d", resp.StatusCode)
+		return nil, &streamAttemptError{
+			statusCode: resp.StatusCode,
+			retryAfter: retryAfter,
+			err:        fmt.Errorf("provider returned HTTP %d", resp.StatusCode),
+		}
 	}
 
 	// Create a single buffered reader that persists across reads.

--- a/modules/ai/streaming_test.go
+++ b/modules/ai/streaming_test.go
@@ -22,14 +22,14 @@ type mockStreamingClient struct {
 	handler func(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error)
 }
 
-func (m *mockStreamingClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, error) {
+func (m *mockStreamingClient) Post(ctx context.Context, url string, headers map[string]string, payload []byte) ([]byte, int, http.Header, error) {
 	resp, err := m.PostStream(ctx, url, headers, payload)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
-	return body, resp.StatusCode, err
+	return body, resp.StatusCode, resp.Header.Clone(), err
 }
 
 func (m *mockStreamingClient) PostStream(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {

--- a/modules/ai/streaming_test.go
+++ b/modules/ai/streaming_test.go
@@ -177,6 +177,31 @@ func TestAttemptStream_NonOKStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP 429")
 }
 
+func TestAttemptStream_NonOKStatusIncludesRetryAfter(t *testing.T) {
+	adapter := libai.NewOpenAIAdapter()
+	logger := zap.NewNop()
+
+	client := &mockStreamingClient{
+		handler: func(ctx context.Context, url string, headers map[string]string, payload []byte) (*http.Response, error) {
+			resp := makeSSEResponse(429, "rate limited")
+			resp.Header.Set("Retry-After", "2")
+			return resp, nil
+		},
+	}
+
+	provider := newTestProvider("test-openai", Healthy)
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+
+	result, err := attemptStream(context.Background(), provider, adapter, body, client, logger)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	var streamErr *streamAttemptError
+	require.ErrorAs(t, err, &streamErr)
+	assert.Equal(t, http.StatusTooManyRequests, streamErr.statusCode)
+	assert.Equal(t, 2*time.Second, streamErr.retryAfter)
+}
+
 func TestAttemptStream_ErrorInFirstChunk(t *testing.T) {
 	adapter := libai.NewOpenAIAdapter()
 	logger := zap.NewNop()

--- a/modules/ai/streaming_test.go
+++ b/modules/ai/streaming_test.go
@@ -303,6 +303,33 @@ func TestStreamToClient_Anthropic(t *testing.T) {
 	assert.Nil(t, usage)
 }
 
+func TestStreamToClient_AnthropicToolCallDeltas(t *testing.T) {
+	adapter := libai.NewAnthropicAdapter()
+	logger := zap.NewNop()
+
+	events := sseEvent("message_start", `{"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-20250514","role":"assistant"}}`)
+	events += sseEvent("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup_weather"}}`)
+	events += sseEvent("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"SF\"}"}}`)
+	events += sseEvent("message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`)
+	events += sseEvent("message_stop", `{"type":"message_stop"}`)
+
+	reader := strings.NewReader(events)
+	body := io.NopCloser(reader)
+	bufReader := bufio.NewReader(reader)
+	recorder := httptest.NewRecorder()
+
+	usage, err := streamToClient(context.Background(), recorder, body, bufReader, adapter, logger)
+	require.NoError(t, err)
+	assert.Nil(t, usage)
+
+	result := recorder.Body.String()
+	assert.Contains(t, result, `"tool_calls"`)
+	assert.Contains(t, result, `"lookup_weather"`)
+	assert.Contains(t, result, `{\"city\":\"SF\"}`)
+	assert.Contains(t, result, `"finish_reason":"tool_calls"`)
+	assert.Contains(t, result, "[DONE]")
+}
+
 func TestStreamToClient_WithUsage(t *testing.T) {
 	adapter := libai.NewOpenAIAdapter()
 	logger := zap.NewNop()

--- a/modules/ai/tier.go
+++ b/modules/ai/tier.go
@@ -11,8 +11,8 @@ import (
 
 // Tier represents a quality tier (fast, balanced, premium) containing multiple AI providers.
 type Tier struct {
-	Name      string
-	Providers []*AIProvider
+	Name      string        `json:"name"`
+	Providers []*AIProvider `json:"providers"`
 }
 
 // GetAvailableProviders returns providers that can serve requests, prioritizing healthy over warning.


### PR DESCRIPTION
## Summary
- Add Retry-After-aware retry behavior: retry the same provider once on `429/503` with capped backoff, then fail over.
- Add multimodal request support for Anthropic translation (`content` string or content-part arrays with `text` and `image_url`, including base64 data URLs).
- Add Anthropic tool-call translation across request mapping, non-streaming responses, and streaming tool-call deltas.

## Code Quality & Bug Fixes (25 commits)

### Bug Fixes
- **R6**: Prevent infinite loop on `TransformResponse` error in retry loop (`cd06caf`)
- **R7**: Omit id/type/name from tool call continuation deltas per OpenAI streaming protocol (`127e78f`)
- **R8**: Allow `tool_use` responses with unknown content block types (`fc5ce10`)
- **O14**: Reject excess arguments in Caddyfile directives (`5b0dbf8`)
- **O15**: Map `tool_choice: "none"` correctly — omit tools for Anthropic (`0f27a3d`)
- **O16**: Pass through unrecognized `tool_choice` shapes instead of dropping (`566eb59`)
- **O10**: Log write errors on non-streaming response (`d05b761`)

### Performance
- **O3**: Eliminate double JSON parse of request body (`654928a`)
- **O17**: Remove unnecessary `Header.Clone()` in non-streaming client (`a63ce53`)

### Refactoring
- **O1**: Make `Record*` metrics functions nil-safe, removing 28 `ensureMetricsRegistered` calls (`3b2771b`)
- **O2**: Extract `newSingleProviderMiddleware` integration test helper, removing 189 lines of boilerplate (`b54c349`)
- **O5**: Add JSON tags to `Tier` struct (`1994c3f`)
- **O18**: Clarify `Content` vs `Text` fields in `AnthropicRequestContentBlock` (`417e92c`)

### Test Coverage (12 new test functions)
- **T8**: Health threshold boundary off-by-one (`5e82033`)
- **T9**: `TransformResponse` infinite loop regression test
- **T10**: Multi-turn tool conversation request translation (`c27da23`)
- **T11**: Streaming with concurrent tool calls (`c27da23`)
- **T12**: Non-streaming 503 retry behavior (`344f979`)
- **T13**: `tool_choice` string mappings — auto, required, none, unknown (`beb8bf5`)
- **T14**: `mapAnthropicStopReason("tool_use")` mapping (`c27da23`)
- **T15**: Streaming 503 retry (`344f979`)
- **T16**: `content_block_start` text type handling (`c27da23`)
- **T17**: Retry-After HTTP-date in middleware (`cb04dc2`)
- **T18**: `parseBase64DataURL` edge cases (`7fc5d18`)
- **T19**: `extractSystemText` with array content parts (`7fc5d18`)
- **T20**: `parseRetryAfter` negative seconds (`864216c`)

## Validation
- `go test ./modules/ai/... ./lib/ai/... -count=1 -short` — all passing
- `go vet ./...` — clean
- Code review sub-agent: no blocking issues found