### PR TITLE
feat: add "all mutations" configuration for Gremlins

### DIFF
--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -1,0 +1,40 @@
+---
+silent: false
+unleash:
+  integration: false
+  dry-run: false
+  tags: ""
+  output: ""
+  diff: ""
+  output-statuses: ""
+  workers: 0
+  test-cpu: 0
+  timeout-coefficient: 30 # default 0
+  threshold:
+    efficacy: 99.99999999999999 # default 0
+    mutant-coverage: 0
+  exclude-files: []
+
+mutants:
+  arithmetic-base:
+    enabled: true
+  conditionals-boundary:
+    enabled: true
+  conditionals-negation:
+    enabled: true
+  increment-decrement:
+    enabled: true
+  invert-assignments:
+    enabled: true # default false
+  invert-bitwise:
+    enabled: true # default false
+  invert-bwassign:
+    enabled: true # default false
+  invert-negatives:
+    enabled: true
+  invert-logical:
+    enabled: true # default false
+  invert-loopctrl:
+    enabled: true # default false
+  remove-self-assignments:
+    enabled: true # default false

--- a/modules/network_block_lag_test.go
+++ b/modules/network_block_lag_test.go
@@ -245,7 +245,10 @@ func TestCalculateDynamicBlockLagLimitConcurrency(t *testing.T) {
 
 // TestDynamicBlockLagWithNoProviders tests behavior when no providers are available
 func TestDynamicBlockLagWithNoProviders(t *testing.T) {
-	n, err := NewNetwork("test-network", EVMHandler, utils.EnvTest, "8080")
+	n, err := NewNetwork("test-network", EVMHandler, utils.EnvTest, LoopbackConfig{
+		Port:   "8080",
+		ApiKey: DefaultLoopbackApiKey,
+	})
 	require.NoError(t, err)
 
 	n.logger = logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
@@ -268,7 +271,10 @@ func TestDynamicBlockLagWithNoProviders(t *testing.T) {
 
 // TestDynamicBlockLagWithUnsupportedHandler tests behavior with handlers that don't support dynamic block lag
 func TestDynamicBlockLagWithUnsupportedHandler(t *testing.T) {
-	n, err := NewNetwork("test-network", BeaconHandler, utils.EnvTest, "8080")
+	n, err := NewNetwork("test-network", BeaconHandler, utils.EnvTest, LoopbackConfig{
+		Port:   "8080",
+		ApiKey: DefaultLoopbackApiKey,
+	})
 	require.NoError(t, err)
 
 	n.logger = logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
@@ -408,7 +414,10 @@ func createMockTimestampServer(sim blockTimestampSimulator) *httptest.Server {
 }
 
 func createTestNetworkWithTimestampProvider(t *testing.T, serverURL string, sim blockTimestampSimulator) *network {
-	n, err := NewNetwork("test-network", EVMHandler, utils.EnvTest, "8080")
+	n, err := NewNetwork("test-network", EVMHandler, utils.EnvTest, LoopbackConfig{
+		Port:   "8080",
+		ApiKey: DefaultLoopbackApiKey,
+	})
 	require.NoError(t, err)
 
 	// Initialize network dependencies

--- a/modules/network_test.go
+++ b/modules/network_test.go
@@ -497,15 +497,15 @@ func TestPerformArchiveCheck_TraceBlockByNumber(t *testing.T) {
 	defer ctrl.Finish()
 
 	tests := []struct {
-		name                      string
-		archiveEnabled            bool
-		traceEnabled              bool
-		archiveResponse           []byte
-		archiveStatusCode         int
-		traceResponse             []byte
-		traceStatusCode           int
-		expectError               bool
-		expectedErrMsg            string
+		name              string
+		archiveEnabled    bool
+		traceEnabled      bool
+		archiveResponse   []byte
+		archiveStatusCode int
+		traceResponse     []byte
+		traceStatusCode   int
+		expectError       bool
+		expectedErrMsg    string
 	}{
 		{
 			name:              "trace_disabled_only_archive_check_runs",
@@ -584,7 +584,10 @@ func TestPerformArchiveCheck_TraceBlockByNumber(t *testing.T) {
 			}
 
 			// Create network
-			n, err := NewNetwork("ethereum", EVMHandler, utils.Environment("test"), "8000")
+			n, err := NewNetwork("ethereum", EVMHandler, utils.Environment("test"), LoopbackConfig{
+				Port:   "8080",
+				ApiKey: DefaultLoopbackApiKey,
+			})
 			require.NoError(t, err)
 			n.HttpClient = mockHTTPClient
 			n.RequestAttemptCount = 1
@@ -887,7 +890,7 @@ func TestGetLatestBlockNumber(t *testing.T) {
 			mockLogger := logger.NewLoggerClient(zap.NewNop(), utils.EnvTest)
 
 			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), LoopbackConfig{
-				Port: tt.caddyPort,
+				Port:   tt.caddyPort,
 				ApiKey: DefaultLoopbackApiKey,
 			})
 			assert.NoError(t, err)
@@ -1175,7 +1178,7 @@ func TestCheckSelfLoopbackHealth(t *testing.T) {
 			}
 
 			n, err := NewNetwork(tt.networkName, EVMHandler, utils.Environment("test"), LoopbackConfig{
-				Port: tt.caddyPort,
+				Port:   tt.caddyPort,
 				ApiKey: DefaultLoopbackApiKey,
 			})
 			assert.NoError(t, err)


### PR DESCRIPTION
  Introduces .gremlins.yaml to configure the Gremlins mutation testing tool.                                                                                                     
  Enables all mutant types (including non-default ones: invert-assignments,
  invert-bitwise, invert-bwassign, invert-logical, invert-loopctrl,
  remove-self-assignments) and sets a near-100% efficacy threshold to enforce
  comprehensive mutation test coverage.